### PR TITLE
fix: 修改skywalking collector 首字母大写逻辑

### DIFF
--- a/pkg/collector/internal/utils/utils.go
+++ b/pkg/collector/internal/utils/utils.go
@@ -46,10 +46,12 @@ func IsValidUint64(u uint64) bool {
 	return !(u == uint64(math.NaN()) || u == uint64(math.Inf(0)))
 }
 
+// FirstUpper 仅首字母大写，过滤掉驼峰的情况
 func FirstUpper(s, defaultVal string) string {
 	if s == "" {
 		return defaultVal
 	}
+	s = strings.ToLower(s)
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 

--- a/pkg/collector/receiver/skywalking/encoder.go
+++ b/pkg/collector/receiver/skywalking/encoder.go
@@ -271,8 +271,11 @@ func swTagsToAttributesByRule(dest pcommon.Map, span *agentv3.SpanObject) {
 
 		if urlObj != nil {
 			// attributes.http.scheme
-			if _, ok := dest.Get(semconv.AttributeHTTPScheme); !ok {
-				dest.InsertString(semconv.AttributeHTTPScheme, urlObj.Scheme)
+			httpScheme, ok := dest.Get(semconv.AttributeHTTPScheme)
+			if !ok {
+				dest.InsertString(semconv.AttributeHTTPScheme, utils.FirstUpper(urlObj.Scheme, unknownVal))
+			} else {
+				dest.UpsertString(semconv.AttributeHTTPScheme, utils.FirstUpper(httpScheme.StringVal(), unknownVal))
 			}
 			// attribute.http.target / attribute.http.host
 			if spanType == agentv3.SpanType_Exit {


### PR DESCRIPTION
1.修改skywalking collector 首字母大写逻辑，排除驼峰的情况。
变更为 **仅首字母大写**
2.变更skywalking attributes.http.scheme 的字段内容，也套用首字母大写的逻辑