### PR TITLE
fix: hash_consul写入数据前将中文转化为unicode

### DIFF
--- a/pkg/bk-monitor-worker/utils/hashconsul/consul.go
+++ b/pkg/bk-monitor-worker/utils/hashconsul/consul.go
@@ -28,6 +28,7 @@ func Put(c *consul.Instance, key, val string) error {
 			unicodeVal += string(runeValue)
 		}
 	}
+	val = unicodeVal
 
 	oldValueBytes, err := c.Get(key)
 	if err != nil {


### PR DESCRIPTION
fix: hash_consul写入数据前将中文转化为unicode