### PR TITLE
feat: 常驻任务框架Bug 修复与 APM 预计算逻辑调整

### DIFF
--- a/pkg/bk-monitor-worker/bmw.yaml.tpl
+++ b/pkg/bk-monitor-worker/bmw.yaml.tpl
@@ -106,7 +106,7 @@ worker:
     duration: 5s
   daemonTask:
     maintainer:
-      interval: 1s
+      interval: 5s
       tolerateCount: 60
       tolerateInterval: 10s
       intolerantFactor: 2
@@ -156,7 +156,6 @@ taskConfig:
       distributive:
         subSize: 10
         watchExpireInterval: 100ms
-        concurrentCount: 1000
         concurrentExpirationMaximum: 100000
     processor:
       enabledTraceInfoCache: 0

--- a/pkg/bk-monitor-worker/bmw.yaml.tpl
+++ b/pkg/bk-monitor-worker/bmw.yaml.tpl
@@ -177,6 +177,7 @@ taskConfig:
           layers: 10
           divisor: 2
     metrics:
+      semaphoreReportInterval: 5s
       profile:
         enabled: false
         host: http://127.0.0.1:14040

--- a/pkg/bk-monitor-worker/cmd/controller.go
+++ b/pkg/bk-monitor-worker/cmd/controller.go
@@ -11,6 +11,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -55,7 +56,7 @@ func startController(cmd *cobra.Command, args []string) {
 	logger.Infof("Starting HTTP server at %s:%d", config.ControllerListenHost, config.ControllerListenPort)
 
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Fatalf("listen addr error, %v", err)
 		}
 	}()

--- a/pkg/bk-monitor-worker/cmd/task.go
+++ b/pkg/bk-monitor-worker/cmd/task.go
@@ -10,6 +10,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -52,7 +53,7 @@ func startTask(cmd *cobra.Command, args []string) {
 	logger.Infof("Starting HTTP server at %s:%d", config.TaskListenHost, config.TaskListenPort)
 
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Fatalf("listen addr error, %v", err)
 		}
 	}()

--- a/pkg/bk-monitor-worker/config/apm_config.go
+++ b/pkg/bk-monitor-worker/config/apm_config.go
@@ -40,11 +40,6 @@ var (
 	// If value is too small, the concurrent performance may be affected
 	DistributiveWindowWatchExpireInterval time.Duration
 
-	// DistributiveWindowConcurrentCount The maximum concurrency.
-	// For example, concurrentProcessCount is set to 10 and subWindowSize is set to 5,
-	// then each sub-window can have a maximum of 10 traces running at the same time,
-	// and a total of 5 * 10 can be processed at the same time.
-	DistributiveWindowConcurrentCount int
 	// DistributiveWindowConcurrentExpirationMaximum Maximum number of concurrent expirations
 	DistributiveWindowConcurrentExpirationMaximum int
 	// EnabledTraceInfoCache Whether to enable Storing the latest trace data into cache.
@@ -105,7 +100,6 @@ func initApmVariables() {
 
 	DistributiveWindowSubSize = GetValue("taskConfig.apmPreCalculate.window.distributive.subSize", 10)
 	DistributiveWindowWatchExpireInterval = GetValue("taskConfig.apmPreCalculate.window.distributive.watchExpireInterval", 100*time.Millisecond, viper.GetDuration)
-	DistributiveWindowConcurrentCount = GetValue("taskConfig.apmPreCalculate.window.distributive.concurrentCount", 1000)
 	DistributiveWindowConcurrentExpirationMaximum = GetValue("taskConfig.apmPreCalculate.window.distributive.concurrentExpirationMaximum", 100000)
 
 	EnabledTraceInfoCache = GetValue("taskConfig.apmPreCalculate.processor.enabledTraceInfoCache", 0)

--- a/pkg/bk-monitor-worker/config/apm_config.go
+++ b/pkg/bk-monitor-worker/config/apm_config.go
@@ -87,6 +87,8 @@ var (
 	ProfileHost string
 	// ProfileAppIdx app name of profile
 	ProfileAppIdx string
+	// SemaphoreReportInterval time interval for reporting chan amount at the current time
+	SemaphoreReportInterval time.Duration
 )
 
 func initApmVariables() {
@@ -123,4 +125,5 @@ func initApmVariables() {
 	ProfileEnabled = GetValue("taskConfig.apmPreCalculate.metrics.profile.enabled", false)
 	ProfileHost = GetValue("taskConfig.apmPreCalculate.metrics.profile.host", "")
 	ProfileAppIdx = GetValue("taskConfig.apmPreCalculate.metrics.profile.appIdx", "")
+	SemaphoreReportInterval = GetValue("taskConfig.apmPreCalculate.metrics.semaphoreReportInterval", 5*time.Second, viper.GetDuration)
 }

--- a/pkg/bk-monitor-worker/config/config.go
+++ b/pkg/bk-monitor-worker/config/config.go
@@ -319,7 +319,7 @@ func initVariables() {
 	WorkerHealthCheckInfoDuration = GetValue("worker.healthCheck.duration", 5*time.Second, viper.GetDuration)
 	// WorkerDaemonTaskMaintainerInterval worker常驻任务检测任务是否正常运行的间隔
 	WorkerDaemonTaskMaintainerInterval = GetValue(
-		"worker.daemonTask.maintainer.interval", 1*time.Second, viper.GetDuration,
+		"worker.daemonTask.maintainer.interval", 5*time.Second, viper.GetDuration,
 	)
 	// WorkerDaemonTaskRetryTolerateCount worker常驻任务配置，当任务重试超过指定数量仍然失败时，下次重试间隔就不断动态增长
 	WorkerDaemonTaskRetryTolerateCount = GetValue("worker.daemonTask.maintainer.tolerateCount", 60)

--- a/pkg/bk-monitor-worker/go.mod
+++ b/pkg/bk-monitor-worker/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c
 	github.com/jinzhu/gorm v1.9.16
 	github.com/josephburnett/jd v1.7.1
-	github.com/json-iterator/go v1.1.12
 	github.com/minio/highwayhash v1.0.2
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -107,6 +106,7 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/metrics.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/metrics.go
@@ -12,6 +12,7 @@ package pre_calculate
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/pyroscope-go"
 
@@ -30,6 +31,8 @@ type MetricOptions struct {
 	enabledProfile bool
 	profileAddress string
 	profileAppIdx  string
+
+	reportInterval time.Duration
 }
 
 // EnabledProfileReport Whether to enable indicator reporting.
@@ -59,6 +62,12 @@ func ProfileAppIdx(h string) MetricOption {
 		defaultV := "apm_precalculate"
 		logger.Infof("profile appIdx is not specified, %s is used as the default", defaultV)
 		options.profileAppIdx = defaultV
+	}
+}
+
+func MetricReportInterval(t time.Duration) MetricOption {
+	return func(options *MetricOptions) {
+		options.reportInterval = t
 	}
 }
 

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/pre_calculate.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/pre_calculate.go
@@ -38,7 +38,7 @@ func Initial(parentCtx context.Context) (PreCalculateProcessor, error) {
 		WithDistributiveWindowConfig(
 			window.DistributiveWindowSubSize(config.DistributiveWindowSubSize),
 			window.DistributiveWindowWatchExpiredInterval(config.DistributiveWindowWatchExpireInterval),
-			window.ConcurrentProcessCount(config.DistributiveWindowConcurrentCount),
+			window.ConcurrentProcessCount(),
 			window.ConcurrentExpirationMaximum(config.DistributiveWindowConcurrentExpirationMaximum),
 		).
 		WithProcessorConfig(

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/pre_calculate.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/pre_calculate.go
@@ -82,6 +82,7 @@ func Initial(parentCtx context.Context) (PreCalculateProcessor, error) {
 			EnabledProfileReport(config.ProfileEnabled),
 			ProfileAddress(config.ProfileHost),
 			ProfileAppIdx(config.ProfileAppIdx),
+			MetricReportInterval(config.SemaphoreReportInterval),
 		).
 		Build(), nil
 }

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/pre_calculate_test.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/pre_calculate_test.go
@@ -28,10 +28,10 @@ func TestApmPreCalculateViaFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	errChan := make(chan bool, 1)
+	errChan := make(chan error, 1)
 	go op.Run(errChan)
-	runSuccess := <-errChan
-	if !runSuccess {
+	runErr := <-errChan
+	if runErr != nil {
 		logger.Fatal("failed to run")
 	}
 	close(errChan)

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/storage/cache.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/storage/cache.go
@@ -147,8 +147,7 @@ func RedisCacheReadTimeout(readTimeout time.Duration) RedisCacheOption {
 }
 
 type RedisCache struct {
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx context.Context
 
 	client goRedis.UniversalClient
 }
@@ -181,8 +180,7 @@ func (r *RedisCache) Query(key string) ([]byte, error) {
 	return res.Bytes()
 }
 
-func newRedisCache(options RedisCacheOptions) (*RedisCache, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+func newRedisCache(ctx context.Context, options RedisCacheOptions) (*RedisCache, error) {
 	client, err := redisUtils.NewRedisClient(
 		context.Background(),
 		&redisUtils.Option{
@@ -199,12 +197,11 @@ func newRedisCache(options RedisCacheOptions) (*RedisCache, error) {
 		},
 	)
 	if err != nil {
-		cancel()
 		return nil, fmt.Errorf("failed to create redis client. %+v. error: %s", options, err)
 	}
 
 	logger.Infof("create Redis Client successfully")
-	return &RedisCache{client: client, ctx: ctx, cancel: cancel}, nil
+	return &RedisCache{client: client, ctx: ctx}, nil
 }
 
 type MemoryCache struct {

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/storage/es.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/storage/es.go
@@ -19,7 +19,8 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
-	jsoniter "github.com/json-iterator/go"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 )
 
 const (
@@ -31,7 +32,7 @@ type Converter func(io.ReadCloser) (any, error)
 var (
 	BytesConverter Converter = func(body io.ReadCloser) (any, error) {
 		var resInstance EsQueryResult
-		if err := jsoniter.NewDecoder(body).Decode(&resInstance); err != nil {
+		if err := jsonx.Decode(body, &resInstance); err != nil {
 			return nil, err
 		}
 
@@ -42,12 +43,12 @@ var (
 		if resMap == nil {
 			return nil, nil
 		}
-		return jsoniter.Marshal(resMap)
+		return jsonx.Marshal(resMap)
 	}
 
 	AggsCountConvert Converter = func(body io.ReadCloser) (any, error) {
 		var resInstance EsQueryResult
-		if err := jsoniter.NewDecoder(body).Decode(&resInstance); err != nil {
+		if err := jsonx.Decode(body, &resInstance); err != nil {
 			return nil, err
 		}
 
@@ -188,7 +189,7 @@ func (e *esStorage) Query(data any) (any, error) {
 	body := data.(EsQueryData)
 	var buf bytes.Buffer
 
-	if err := jsoniter.NewEncoder(&buf).Encode(body.Body); err != nil {
+	if err := jsonx.Encode(&buf, body.Body); err != nil {
 		return nil, err
 	}
 

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/storage/storage.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/storage/storage.go
@@ -154,6 +154,8 @@ func SaveReqBufferSize(s int) ProxyOption {
 
 // Proxy storage backend proxy.
 type Proxy struct {
+	dataId string
+
 	config ProxyOptions
 
 	traceEs     *esStorage
@@ -189,37 +191,43 @@ loop:
 			switch r.Target {
 			case SaveEs:
 				item := r.Data.(EsStorageData)
-				metrics.DecreaseApmSaveRequestCount(item.DataId, string(SaveEs))
 
 				esSaveData = append(esSaveData, item)
 				if len(esSaveData) >= p.config.saveHoldMaxCount {
 					// todo 是否需要满时动态调整
 					err := p.saveEs.SaveBatch(esSaveData)
+					metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageSaveEs, metrics.OperateSave)
+					metrics.RecordApmPreCalcSaveStorageTotal(p.dataId, metrics.StorageSaveEs, len(esSaveData))
 					if err != nil {
 						logger.Errorf("[MAX TRIGGER] Failed to save %d pieces of data to ES, cause: %s", len(esSaveData), err)
+						metrics.RecordApmPreCalcOperateStorageFailedTotal(p.dataId, metrics.SaveEsFailed)
 					}
 					esSaveData = make([]EsStorageData, 0, p.config.saveHoldMaxCount)
 				}
 			case Cache:
 				item := r.Data.(CacheStorageData)
-				metrics.DecreaseApmSaveRequestCount(item.DataId, string(Cache))
+				metrics.RecordApmPreCalcOperateStorageCount(item.DataId, metrics.StorageCache, metrics.OperateSave)
 
 				cacheSaveData = append(cacheSaveData, item)
 				if len(cacheSaveData) >= p.config.saveHoldMaxCount {
 					err := p.cache.SaveBatch(cacheSaveData)
+					metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageCache, metrics.OperateSave)
+					metrics.RecordApmPreCalcSaveStorageTotal(p.dataId, metrics.StorageCache, len(cacheSaveData))
 					if err != nil {
 						logger.Errorf("[MAX TRIGGER] Failed to save %d pieces of data to CACHE, cause: %s", len(cacheSaveData), err)
+						metrics.RecordApmPreCalcOperateStorageFailedTotal(p.dataId, metrics.SaveCacheFailed)
 					}
 					cacheSaveData = make([]CacheStorageData, 0, p.config.saveHoldMaxCount)
 				}
 			case BloomFilter:
 				// Bloom-filter needs to be added immediately,
 				// otherwise it may not be added and cause an error in judgment.
-				data := r.Data.(BloomStorageData)
-				metrics.DecreaseApmSaveRequestCount(data.DataId, string(BloomFilter))
-
-				if err := p.bloomFilter.Add(data); err != nil {
-					logger.Errorf("Bloom Filter add key: %s failed, error: %s", data.Key, err)
+				item := r.Data.(BloomStorageData)
+				metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageBloomFilter, metrics.OperateSave)
+				metrics.RecordApmPreCalcSaveStorageTotal(p.dataId, metrics.StorageBloomFilter, 1)
+				if err := p.bloomFilter.Add(item); err != nil {
+					logger.Errorf("Bloom Filter add key: %s failed, error: %s", item.Key, err)
+					metrics.RecordApmPreCalcOperateStorageFailedTotal(p.dataId, metrics.SaveBloomFilterFailed)
 				}
 			default:
 				logger.Warnf("An invalid storage SAVE request was received: %s", r.Target)
@@ -227,15 +235,21 @@ loop:
 		case <-ticker.C:
 			if len(esSaveData) != 0 {
 				err := p.saveEs.SaveBatch(esSaveData)
+				metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageSaveEs, metrics.OperateSave)
+				metrics.RecordApmPreCalcSaveStorageTotal(p.dataId, metrics.StorageSaveEs, len(esSaveData))
 				if err != nil {
 					logger.Errorf("[TICKER TRIGGER] Failed to save %d pieces of data to ES, cause: %s", len(esSaveData), err)
+					metrics.RecordApmPreCalcOperateStorageFailedTotal(p.dataId, metrics.SaveEsFailed)
 				}
 				esSaveData = make([]EsStorageData, 0, p.config.saveHoldMaxCount)
 			}
 			if len(cacheSaveData) != 0 {
 				err := p.cache.SaveBatch(cacheSaveData)
+				metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageCache, metrics.OperateSave)
+				metrics.RecordApmPreCalcSaveStorageTotal(p.dataId, metrics.StorageCache, len(cacheSaveData))
 				if err != nil {
 					logger.Errorf("[TICKER TRIGGER] Failed to save %d pieces of data to CACHE, cause: %s", len(cacheSaveData), err)
+					metrics.RecordApmPreCalcOperateStorageFailedTotal(p.dataId, metrics.SaveCacheFailed)
 				}
 				cacheSaveData = make([]CacheStorageData, 0, p.config.saveHoldMaxCount)
 			}
@@ -251,10 +265,13 @@ loop:
 func (p *Proxy) Query(queryRequest QueryRequest) (any, error) {
 	switch queryRequest.Target {
 	case TraceEs:
+		metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageTraceEs, metrics.OperateQuery)
 		return p.traceEs.Query(queryRequest.Data)
 	case SaveEs:
+		metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageSaveEs, metrics.OperateQuery)
 		return p.saveEs.Query(queryRequest.Data)
 	case Cache:
+		metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageCache, metrics.OperateQuery)
 		return p.cache.Query(queryRequest.Data.(string))
 	default:
 		info := fmt.Sprintf("An invalid storage QUERY request was received: %s", queryRequest.Target)
@@ -266,6 +283,7 @@ func (p *Proxy) Query(queryRequest QueryRequest) (any, error) {
 func (p *Proxy) Exist(req ExistRequest) (bool, error) {
 	switch req.Target {
 	case BloomFilter:
+		metrics.RecordApmPreCalcOperateStorageCount(p.dataId, metrics.StorageBloomFilter, metrics.OperateQuery)
 		return p.bloomFilter.Exist(req.Key)
 	default:
 		logger.Warnf("Exist method does not support type: %s, it will return false", req.Target)
@@ -273,7 +291,7 @@ func (p *Proxy) Exist(req ExistRequest) (bool, error) {
 	}
 }
 
-func NewProxyInstance(ctx context.Context, options ...ProxyOption) (*Proxy, error) {
+func NewProxyInstance(dataId string, ctx context.Context, options ...ProxyOption) (*Proxy, error) {
 	opt := ProxyOptions{}
 	for _, setter := range options {
 		setter(&opt)
@@ -307,6 +325,7 @@ func NewProxyInstance(ctx context.Context, options ...ProxyOption) (*Proxy, erro
 	}
 
 	return &Proxy{
+		dataId:          dataId,
 		config:          opt,
 		traceEs:         traceEsInstance,
 		saveEs:          saveEsInstance,

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/distributive.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/distributive.go
@@ -11,6 +11,7 @@ package window
 
 import (
 	"context"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -55,9 +56,9 @@ func DistributiveWindowWatchExpiredInterval(interval time.Duration) Distributive
 // For example, concurrentProcessCount is set to 10 and subWindowSize is set to 5,
 // then each sub-window can have a maximum of 10 traces running at the same time,
 // and a total of 5 * 10 can be processed at the same time.
-func ConcurrentProcessCount(c int) DistributiveWindowOption {
+func ConcurrentProcessCount() DistributiveWindowOption {
 	return func(options *DistributiveWindowOptions) {
-		options.concurrentProcessCount = c
+		options.concurrentProcessCount = runtime.NumCPU() * 2
 	}
 }
 

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/processor.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/processor.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ahmetb/go-linq/v3"
 	mapset "github.com/deckarep/golang-set/v2"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/valyala/fastjson"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
@@ -24,6 +23,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/apm/pre_calculate/core"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/apm/pre_calculate/storage"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/metrics"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	monitorLogger "github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -104,7 +104,7 @@ func (p *Processor) listSpanFromStorage(event Event) []*StandardSpan {
 		infoKey := storage.CacheTraceInfoKey.Format(p.dataIdBaseInfo.BkBizId, p.dataIdBaseInfo.AppName, event.TraceId)
 		data, err := p.proxy.Query(storage.QueryRequest{Target: storage.Cache, Data: infoKey})
 		if err == nil && data != nil {
-			parseErr := jsoniter.Unmarshal(data.([]byte), &spans)
+			parseErr := jsonx.Unmarshal(data.([]byte), &spans)
 			if parseErr != nil {
 				p.logger.Infof(
 					"Cache spans whose traceId is %s was found in traceInfo(key: %s), "+
@@ -298,7 +298,7 @@ func (p *Processor) Process(receiver chan<- storage.SaveRequest, event Event) {
 
 func (p *Processor) sendStorageRequests(receiver chan<- storage.SaveRequest, result ProcessResult, event Event) {
 	if p.config.enabledInfoCache {
-		spanBytes, _ := jsoniter.Marshal(event.Spans)
+		spanBytes, _ := jsonx.Marshal(event.Spans)
 		receiver <- storage.SaveRequest{
 			Target: storage.Cache,
 			Action: storage.SaveTraceCache,
@@ -319,7 +319,7 @@ func (p *Processor) sendStorageRequests(receiver chan<- storage.SaveRequest, res
 		},
 	}
 
-	resultBytes, _ := jsoniter.Marshal(result)
+	resultBytes, _ := jsonx.Marshal(result)
 	receiver <- storage.SaveRequest{
 		Target: storage.SaveEs,
 		Action: storage.SavePrecalculateResult,

--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/window.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/window.go
@@ -134,17 +134,11 @@ type Handler interface {
 	add(StandardSpan)
 }
 
-type OperatorMetricKey string
-
-var (
-	TraceCount OperatorMetricKey = "traceCount"
-	SpanCount  OperatorMetricKey = "spanCount"
-)
-
 // Operator Window processing strategy
 type Operator interface {
 	Start(spanChan <-chan []StandardSpan, errorReceiveChan chan<- error, runtimeOpt ...RuntimeConfigOption)
-	ReportMetric() map[OperatorMetricKey]int
+	GetWindowsLength() int
+	RecordTraceAndSpanCountMetric()
 }
 
 type Operation struct {

--- a/pkg/bk-monitor-worker/metrics/apm_metrics.go
+++ b/pkg/bk-monitor-worker/metrics/apm_metrics.go
@@ -125,6 +125,26 @@ var (
 		},
 		[]string{"data_id"},
 	)
+
+	// **** APM 父子窗口实现指标
+	// apmPreCalcWindowTraceTotal trace count of distributive windows
+	apmPreCalcWindowTraceTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "window_trace_count",
+			Help:      "window trace count",
+		},
+		[]string{"data_id", "sub_window_id"},
+	)
+	// apmPreCalcWindowSpanTotal apm预计算任务窗口span数量
+	apmPreCalcWindowSpanTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "window_span_count",
+			Help:      "window span count",
+		},
+		[]string{"data_id", "sub_window_id"},
+	)
 )
 
 func RecordApmPreCalcLocateSpanDuration(dataId string, t time.Time) {
@@ -164,6 +184,14 @@ func AddApmNotifierReceiveMessageCount(dataId, topic string) {
 	apmPreCalcNotifierReceiveMessageCount.WithLabelValues(dataId, topic).Inc()
 }
 
+func RecordApmPreCalcWindowTraceTotal(dataId string, subWindowId int, n int) {
+	apmPreCalcWindowTraceTotal.WithLabelValues(dataId, strconv.Itoa(subWindowId)).Set(float64(n))
+}
+
+func RecordApmPreCalcWindowSpanTotal(dataId string, subWindowId int, n int) {
+	apmPreCalcWindowSpanTotal.WithLabelValues(dataId, strconv.Itoa(subWindowId)).Set(float64(n))
+}
+
 func init() {
 	// register the metrics
 	Registry.MustRegister(
@@ -176,5 +204,7 @@ func init() {
 		apmPreCalcSaveStorageTotal,
 		apmPreCalcExpiredKeyTotal,
 		apmPreCalcLocateSpanDuration,
+		apmPreCalcWindowTraceTotal,
+		apmPreCalcWindowSpanTotal,
 	)
 }

--- a/pkg/bk-monitor-worker/metrics/apm_metrics.go
+++ b/pkg/bk-monitor-worker/metrics/apm_metrics.go
@@ -1,0 +1,180 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ApmNamespace      = "bmw_apm_pre_calc"
+	defDurationBucket = []float64{
+		0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300, 600, 1000, 1500, 2000, 3000, 5000,
+	}
+
+	// apmPreCalcNotifierReceiveMessageCount apm预计算任务接收数量
+	apmPreCalcNotifierReceiveMessageCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "notifier_receive_message_count",
+			Help:      "notifier receive message count",
+		},
+		[]string{"data_id", "topic"},
+	)
+	apmPreCalcParseSpanDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: ApmNamespace,
+			Name:      "notifier_parse_span_duration",
+			Help:      "notifier parse span duration",
+			Buckets:   defDurationBucket,
+		},
+		[]string{"data_id", "topic"},
+	)
+
+	TaskProcessChan          = "task_process_chan"
+	WindowProcessEventChan   = "window_process_event_chan"
+	SaveRequestChan          = "save_request_chan"
+	apmPreCalcSemaphoreTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "semaphore_total",
+			Help:      "semaphore total",
+		},
+		[]string{"data_id", "scene"},
+	)
+
+	apmPreCalcProcessEventDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: ApmNamespace,
+			Name:      "process_event_duration",
+			Help:      "process event duration",
+			Buckets:   defDurationBucket,
+		},
+		[]string{"data_id", "sub_window_id"},
+	)
+
+	QueryBloomFilterFailed = "query_bloom_filter_failed"
+	QueryEsFailed          = "query_es_failed"
+	QueryEsReturnEmpty     = "query_es_return_empty"
+	QueryESResponseInvalid = "query_es_response_invalid"
+	SaveEsFailed           = "save_es_failed"
+	SaveCacheFailed        = "save_cache_failed"
+	SaveBloomFilterFailed  = "save_bloom_filter_failed"
+	// apmPreCalcOperateStorageFailedTotal apm预计算对 trace 进行预计算时发生存储层失败计数指标
+	apmPreCalcOperateStorageFailedTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "operate_storage_failed",
+			Help:      "operate event storage failed",
+		},
+		[]string{"data_id", "error"},
+	)
+
+	StorageSaveEs      = "save_es"
+	StorageTraceEs     = "trace_es"
+	StorageCache       = "cache"
+	StorageBloomFilter = "bloom_filter"
+	OperateSave        = "save"
+	OperateQuery       = "query"
+	// apmPreCalcOperateStorageCount APM 预计算查询存储层的保存次数
+	apmPreCalcOperateStorageCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "operate_storage_count",
+			Help:      "operate storage count",
+		},
+		[]string{"data_id", "storage", "operate"},
+	)
+	// apmPreCalcSaveStorageTotal APM 预计算保存存储层的保存数量
+	apmPreCalcSaveStorageTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "save_storage_total",
+			Help:      "save storage total",
+		},
+		[]string{"data_id", "storage"},
+	)
+
+	// apmPreCalcExpiredKeyTotal APM 预计算过期 traceId 数量
+	apmPreCalcExpiredKeyTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ApmNamespace,
+			Name:      "expired_key_total",
+			Help:      "expired key total",
+		},
+		[]string{"data_id", "sub_window_id"},
+	)
+
+	// apmPreCalcLocateSpanDuration apm 预计算分配 span 到窗口的耗时
+	apmPreCalcLocateSpanDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: ApmNamespace,
+			Name:      "locate_span_duration",
+			Help:      "locate span duration",
+			Buckets:   defDurationBucket,
+		},
+		[]string{"data_id"},
+	)
+)
+
+func RecordApmPreCalcLocateSpanDuration(dataId string, t time.Time) {
+	apmPreCalcLocateSpanDuration.WithLabelValues(dataId).Observe(time.Since(t).Seconds())
+}
+
+func RecordApmPreCalcExpiredKeyTotal(dataId string, subWindowId int, n int) {
+	apmPreCalcExpiredKeyTotal.WithLabelValues(dataId, strconv.Itoa(subWindowId)).Add(float64(n))
+}
+
+func RecordApmPreCalcSaveStorageTotal(dataId, storage string, n int) {
+	apmPreCalcSaveStorageTotal.WithLabelValues(dataId, storage).Add(float64(n))
+}
+
+func RecordApmPreCalcOperateStorageCount(dataId, storage, operate string) {
+	apmPreCalcOperateStorageCount.WithLabelValues(dataId, storage, operate).Add(1)
+}
+
+func RecordApmPreCalcOperateStorageFailedTotal(dataId, error string) {
+	apmPreCalcOperateStorageFailedTotal.WithLabelValues(dataId, error).Add(1)
+}
+
+func RecordApmPreCalcProcessEventDuration(dataId string, subWindowId int, t time.Time) {
+	apmPreCalcProcessEventDuration.WithLabelValues(dataId, strconv.Itoa(subWindowId)).Observe(time.Since(t).Seconds())
+}
+
+func RecordNotifierParseSpanDuration(dataId, topic string, t time.Time) {
+	apmPreCalcParseSpanDuration.WithLabelValues(dataId, topic).Observe(time.Since(t).Seconds())
+}
+
+func RecordApmPreCalcSemaphoreTotal(dataId, scene string, n int) {
+	apmPreCalcSemaphoreTotal.WithLabelValues(dataId, scene).Set(float64(n))
+}
+
+// AddApmNotifierReceiveMessageCount apm预计算任务接收数量指标 + 1
+func AddApmNotifierReceiveMessageCount(dataId, topic string) {
+	apmPreCalcNotifierReceiveMessageCount.WithLabelValues(dataId, topic).Inc()
+}
+
+func init() {
+	// register the metrics
+	Registry.MustRegister(
+		apmPreCalcNotifierReceiveMessageCount,
+		apmPreCalcParseSpanDuration,
+		apmPreCalcSemaphoreTotal,
+		apmPreCalcProcessEventDuration,
+		apmPreCalcOperateStorageFailedTotal,
+		apmPreCalcOperateStorageCount,
+		apmPreCalcSaveStorageTotal,
+		apmPreCalcExpiredKeyTotal,
+		apmPreCalcLocateSpanDuration,
+	)
+}

--- a/pkg/bk-monitor-worker/metrics/metrics.go
+++ b/pkg/bk-monitor-worker/metrics/metrics.go
@@ -51,48 +51,6 @@ var (
 		},
 		[]string{"name"},
 	)
-
-	// APM task metric
-	// apmPreCalcFilterEsQueryCount apm预计算任务过滤器返回true然后查询ES的次数
-	apmPreCalcFilterEsQueryCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "bmw_apm_pre_calc_filter_es_query_count",
-			Help: "apm pre calc filter es query count",
-		},
-		[]string{"data_id", "status"},
-	)
-	// apmPreCalcSaveRequestCount apm预计算任务存储需求次数
-	apmPreCalcSaveRequestCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "bmw_apm_pre_calc_save_request_count",
-			Help: "apm pre calc save request count",
-		},
-		[]string{"data_id", "storage_type"},
-	)
-	// apmPreCalcMessageCount apm预计算任务消息接收数量
-	apmPreCalcMessageCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "bmw_apm_pre_calc_message_count",
-			Help: "apm pre calc message count",
-		},
-		[]string{"data_id"},
-	)
-	// apmPreCalcWindowTraceCount apm预计算任务窗口trace数量
-	apmPreCalcWindowTraceCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "bmw_apm_pre_calc_window_trace_count",
-			Help: "apm pre calc window trace count",
-		},
-		[]string{"data_id", "distributive_window_id"},
-	)
-	// apmPreCalcWindowTraceCount apm预计算任务窗口span数量
-	apmPreCalcWindowSpanCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "bmw_apm_pre_calc_window_span_count",
-			Help: "apm pre calc window span count",
-		},
-		[]string{"data_id", "distributive_window_id"},
-	)
 )
 
 // RequestApiCount request api count metric
@@ -185,98 +143,6 @@ func RunTaskCostTime(taskName string, startTime time.Time) error {
 	return nil
 }
 
-// RunApmPreCalcFilterEsQuery APM预计算ES查询次数指标 + 1
-func RunApmPreCalcFilterEsQuery(dataId, status string) error {
-	metric, err := apmPreCalcFilterEsQueryCount.GetMetricWithLabelValues(dataId, status)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return err
-	}
-
-	metric.Inc()
-	return nil
-}
-
-// IncreaseApmSaveRequestCount APM预计算ES存储请求指标 + 1
-func IncreaseApmSaveRequestCount(dataId, storageType string) {
-	metric, err := apmPreCalcSaveRequestCount.GetMetricWithLabelValues(dataId, storageType)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Inc()
-}
-
-// DecreaseApmSaveRequestCount APM预计算ES存储请求指标 - 1
-func DecreaseApmSaveRequestCount(dataId, storageType string) {
-	metric, err := apmPreCalcSaveRequestCount.GetMetricWithLabelValues(dataId, storageType)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Dec()
-}
-
-// IncreaseApmMessageChanCount APM预计算ES存储请求指标 + 1
-func IncreaseApmMessageChanCount(dataId string) {
-	metric, err := apmPreCalcMessageCount.GetMetricWithLabelValues(dataId)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Inc()
-}
-
-// DecreaseApmMessageChanCount APM预计算ES存储请求指标 - 1
-func DecreaseApmMessageChanCount(dataId string) {
-	metric, err := apmPreCalcMessageCount.GetMetricWithLabelValues(dataId)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Dec()
-}
-
-// IncreaseApmWindowsTraceCount APM预计算窗口Trace数量指标 + 1
-func IncreaseApmWindowsTraceCount(dataId, id string) {
-	metric, err := apmPreCalcWindowTraceCount.GetMetricWithLabelValues(dataId, id)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Inc()
-}
-
-// DecreaseApmWindowsTraceCount APM预计算窗口Trace数量指标 - 1
-func DecreaseApmWindowsTraceCount(dataId, id string) {
-	metric, err := apmPreCalcWindowTraceCount.GetMetricWithLabelValues(dataId, id)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Dec()
-}
-
-// IncreaseApmWindowsSpanCount APM预计算窗口Span数量指标 + 1
-func IncreaseApmWindowsSpanCount(dataId, id string) {
-	metric, err := apmPreCalcWindowSpanCount.GetMetricWithLabelValues(dataId, id)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Inc()
-}
-
-// DecreaseApmWindowsSpanCount APM预计算窗口Span数量指标 - n
-func DecreaseApmWindowsSpanCount(dataId, id string, n int) {
-	metric, err := apmPreCalcWindowSpanCount.GetMetricWithLabelValues(dataId, id)
-	if err != nil {
-		logger.Errorf("prom get apm pre calc filter es query count metric failed: %s", err)
-		return
-	}
-	metric.Sub(float64(n))
-}
-
 // 设置 api 请求的耗时
 func SetApiRequestCostTime(method, apiPath string) func() {
 	start := time.Now()
@@ -338,6 +204,24 @@ var (
 			Help: "mysql change count",
 		},
 		[]string{"table", "operation"},
+	)
+
+	// 常驻任务正在运行的任务统计
+	daemonRunningTaskCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "daemon_running_task_count",
+			Help: "daemon running task count",
+		},
+		[]string{"task_dimension"},
+	)
+
+	// 常驻任务任务重试次数
+	daemonTaskRetryCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "daemon_task_retry_count",
+			Help: "daemon task retry count",
+		},
+		[]string{"task_dimension"},
 	)
 )
 
@@ -407,25 +291,39 @@ func MysqlCount(tableName, operation string, count float64) error {
 	return nil
 }
 
-var Registry *prometheus.Registry
+func RecordDaemonTask(dimension string) {
+	metric, err := daemonRunningTaskCount.GetMetricWithLabelValues(dimension)
+	if err != nil {
+		logger.Errorf("prom get [daemonRunningTaskCount] metric failed: %s", err)
+		return
+	}
+	metric.Set(1)
+}
+
+func RecordDaemonTaskRetryCount(dimension string) {
+	metric, err := daemonTaskRetryCount.GetMetricWithLabelValues(dimension)
+	if err != nil {
+		logger.Errorf("prom get [daemonTaskRetryCount] metric failed: %s", err)
+		return
+	}
+	metric.Add(1)
+}
+
+var Registry = prometheus.NewRegistry()
 
 func init() {
 	// register the metrics
-	Registry = prometheus.NewRegistry()
 	Registry.MustRegister(
 		apiRequestCount,
 		apiRequestCost,
 		taskCount,
 		taskCostTime,
-		apmPreCalcFilterEsQueryCount,
-		apmPreCalcSaveRequestCount,
-		apmPreCalcMessageCount,
-		apmPreCalcWindowTraceCount,
-		apmPreCalcWindowSpanCount,
 		consulCount,
 		gseCount,
 		esCount,
 		redisCount,
 		mysqlCount,
+		daemonRunningTaskCount,
+		daemonTaskRetryCount,
 	)
 }

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/binding.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/binding.go
@@ -105,6 +105,9 @@ func (b *Binding) deleteBinding(taskUniId string) error {
 	ctx := context.Background()
 
 	workerInfoStr, err := b.getWorkerByTask(ctx, taskUniId)
+	if err != nil {
+		return err
+	}
 	var workerBinding WorkerBinding
 	if err = jsoniter.Unmarshal([]byte(workerInfoStr), &workerBinding); err != nil {
 		return fmt.Errorf(
@@ -113,9 +116,6 @@ func (b *Binding) deleteBinding(taskUniId string) error {
 		)
 	}
 
-	if err != nil {
-		return fmt.Errorf("failed to check field: %s of hash: %s, error: %s", taskUniId, common.DaemonBindingTask(), err)
-	}
 	if workerBinding.WorkerId == "" {
 		return fmt.Errorf(
 			"failed to delete binding from task binding because the binding(%s <----> ?) does not exist",
@@ -137,7 +137,8 @@ func (b *Binding) deleteBinding(taskUniId string) error {
 		)
 	}
 
-	return err
+	logger.Infof("[BINDING DELETE] delete binding (%s <----> %s)", taskUniId, workerBinding.WorkerId)
+	return nil
 }
 
 func (b *Binding) deleteWorkerBinding(workerId string) error {

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/binding.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/binding.go
@@ -15,12 +15,12 @@ import (
 	"sync"
 
 	redis "github.com/go-redis/redis/v8"
-	jsoniter "github.com/json-iterator/go"
 
 	rdb "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/broker/redis"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/common"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/task"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -85,12 +85,12 @@ func (b *Binding) addBinding(taskBinding TaskBinding, workerBinding WorkerBindin
 		return nil
 	}
 
-	workerBindingBytes, _ := jsoniter.Marshal(workerBinding)
+	workerBindingBytes, _ := jsonx.Marshal(workerBinding)
 	if err = b.redisClient.HSet(ctx, common.DaemonBindingTask(), taskBinding.UniId, workerBindingBytes).Err(); err != nil {
 		return fmt.Errorf("failed to add a task binding, error: %s", err)
 	}
 
-	taskBindingBytes, _ := jsoniter.Marshal(taskBinding)
+	taskBindingBytes, _ := jsonx.Marshal(taskBinding)
 	if err = b.redisClient.HSet(
 		ctx, common.DaemonBindingWorker(workerBinding.WorkerId),
 		taskBinding.UniId, taskBindingBytes,
@@ -109,7 +109,7 @@ func (b *Binding) deleteBinding(taskUniId string) error {
 		return err
 	}
 	var workerBinding WorkerBinding
-	if err = jsoniter.Unmarshal([]byte(workerInfoStr), &workerBinding); err != nil {
+	if err = jsonx.Unmarshal([]byte(workerInfoStr), &workerBinding); err != nil {
 		return fmt.Errorf(
 			"failed to parse value to WokerInfo on taskUniId Binding: %s, value: %s. error: %s",
 			taskUniId, workerInfoStr, err,
@@ -182,7 +182,7 @@ func (b *Binding) deleteWorkerBinding(workerId string) error {
 
 func (b *Binding) toWorkerBinding(workerStr string) (*WorkerBinding, error) {
 	var res WorkerBinding
-	if err := jsoniter.Unmarshal([]byte(workerStr), &res); err != nil {
+	if err := jsonx.Unmarshal([]byte(workerStr), &res); err != nil {
 		return nil, err
 	}
 	return &res, nil
@@ -190,7 +190,7 @@ func (b *Binding) toWorkerBinding(workerStr string) (*WorkerBinding, error) {
 
 func (b *Binding) toTaskBinding(taskStr string) (*TaskBinding, error) {
 	var res TaskBinding
-	if err := jsoniter.Unmarshal([]byte(taskStr), &res); err != nil {
+	if err := jsonx.Unmarshal([]byte(taskStr), &res); err != nil {
 		return nil, err
 	}
 

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/daemon.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/daemon.go
@@ -45,7 +45,7 @@ type Numerator interface {
 }
 
 type Operator interface {
-	Start(stopParentContext context.Context, errorReceiveChan chan<- error, payload []byte)
+	Start(runInstanceCtx context.Context, errorReceiveChan chan<- error, payload []byte)
 }
 
 type OperatorDefine struct {
@@ -59,12 +59,12 @@ var taskDefine = map[string]OperatorDefine{
 		if err != nil {
 			return nil, err
 		}
-		runSuccessChan := make(chan bool, 1)
+		runSuccessChan := make(chan error, 1)
 		go op.Run(runSuccessChan)
-		runSuccess := <-runSuccessChan
+		runErr := <-runSuccessChan
 		close(runSuccessChan)
-		if !runSuccess {
-			return nil, errors.New("apm.pre_calculate failed to run")
+		if runErr != nil {
+			return nil, errors.New(fmt.Sprintf("apm.pre_calculate failed to initial, error: %s", runErr))
 		}
 		return op, err
 	}},

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/daemon.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/daemon.go
@@ -16,13 +16,12 @@ import (
 	"fmt"
 	"math/rand"
 
-	jsoniter "github.com/json-iterator/go"
-
 	rdb "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/broker/redis"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/common"
 	apmTasks "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/apm/pre_calculate"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/task"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -133,7 +132,7 @@ func computeWorker(t task.SerializerTask) (service.WorkerInfo, error) {
 
 	// TODO 从worker列表中选择worker进行调度 待补充更多的调度规则 目前暂时使用随机选择
 	data, _ := redisClient.Get(ctx, keys[rand.Intn(len(keys))]).Bytes()
-	if err = jsoniter.Unmarshal(data, &res); err != nil {
+	if err = jsonx.Unmarshal(data, &res); err != nil {
 		return res, fmt.Errorf("parse workerInfo failed. error: %s", err)
 	}
 	return res, nil

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/daemon.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/daemon.go
@@ -46,6 +46,9 @@ type Numerator interface {
 
 type Operator interface {
 	Start(runInstanceCtx context.Context, errorReceiveChan chan<- error, payload []byte)
+	// GetTaskDimension get the metric dimension of the daemon task,
+	// and the maintainer will report the metric regularly.
+	GetTaskDimension(payload []byte) string
 }
 
 type OperatorDefine struct {

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/maintainer.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/maintainer.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	jsoniter "github.com/json-iterator/go"
 
 	rdb "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/broker/redis"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/common"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/config"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/metrics"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -81,7 +81,7 @@ loop:
 
 			for taskUniId, taskStr := range taskHash {
 				var taskBinding TaskBinding
-				if err = jsoniter.Unmarshal([]byte(taskStr), &taskBinding); err != nil {
+				if err = jsonx.Unmarshal([]byte(taskStr), &taskBinding); err != nil {
 					logger.Errorf(
 						"failed to parse value to TaskBinding on key: %s field: %s. "+
 							"error: %s", r.listenTaskKey, taskUniId, err,
@@ -146,7 +146,7 @@ func (r *RunMaintainer) listenRunningState(
 ) {
 	retryTicker := &time.Ticker{}
 	errorChan := errorReceiveChan
-	runningTicker := time.NewTicker(5 * time.Second)
+	runningTicker := time.NewTicker(30 * time.Second)
 
 	for {
 		select {

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/numerator.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/numerator.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ahmetb/go-linq/v3"
 	"github.com/go-redis/redis/v8"
-	jsoniter "github.com/json-iterator/go"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/config"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/task"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -164,7 +164,7 @@ func (d *DefaultNumerator) listWorker() ([]service.WorkerInfo, error) {
 	for _, key := range workers {
 		bytesData, _ := d.redisClient.Get(d.ctx, key).Bytes()
 		var workerInfo service.WorkerInfo
-		if err = jsoniter.Unmarshal(bytesData, &workerInfo); err != nil {
+		if err = jsonx.Unmarshal(bytesData, &workerInfo); err != nil {
 			return res, fmt.Errorf(
 				"failed to unmarshal value to WorkerInfo with key: %s(value: %s). error: %s",
 				key, bytesData, err,
@@ -186,7 +186,7 @@ func (d *DefaultNumerator) listTask() (map[string]task.SerializerTask, error) {
 
 	for _, item := range tasks {
 		var instance task.SerializerTask
-		if err = jsoniter.Unmarshal([]byte(item), &instance); err != nil {
+		if err = jsonx.Unmarshal([]byte(item), &instance); err != nil {
 			return res, fmt.Errorf("failed to unmarshal value(%s) to Task on %s. error: %s", item, common.DaemonTaskKey(), err)
 		}
 		res[ComputeTaskUniId(instance)] = instance

--- a/pkg/bk-monitor-worker/service/scheduler/daemon/watcher.go
+++ b/pkg/bk-monitor-worker/service/scheduler/daemon/watcher.go
@@ -15,13 +15,13 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	jsoniter "github.com/json-iterator/go"
 
 	rdb "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/broker/redis"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/common"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/config"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/task"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -105,7 +105,7 @@ func (d *DefaultWatcher) toWorkerInfo(workerKey string) (service.WorkerInfo, err
 		return res, err
 	}
 
-	if err = jsoniter.Unmarshal(bytesData, &res); err != nil {
+	if err = jsonx.Unmarshal(bytesData, &res); err != nil {
 		return res, err
 	}
 
@@ -180,7 +180,7 @@ func (d *DefaultWatcher) watchTask() {
 
 func (d *DefaultWatcher) toTask(taskStr string) (task.SerializerTask, error) {
 	var res task.SerializerTask
-	if err := jsoniter.Unmarshal([]byte(taskStr), &res); err != nil {
+	if err := jsonx.Unmarshal([]byte(taskStr), &res); err != nil {
 		return res, err
 	}
 	return res, nil

--- a/pkg/bk-monitor-worker/service/worker_service.go
+++ b/pkg/bk-monitor-worker/service/worker_service.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	jsoniter "github.com/json-iterator/go"
 
 	rdb "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/broker/redis"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/common"
@@ -22,6 +21,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service/scheduler"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service/scheduler/periodic"
 	commonUtils "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/common"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/worker"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
@@ -101,7 +101,7 @@ func (w *WorkerHealthMaintainer) Start() {
 	for {
 		select {
 		case <-ticker.C:
-			data, _ := jsoniter.Marshal(fixInfo)
+			data, _ := jsonx.Marshal(fixInfo)
 			for _, queueName := range w.queues {
 				workerKey := common.WorkerKey(queueName, w.id)
 				w.redisClient.Set(w.ctx, workerKey, data, w.config.infoTtl)

--- a/pkg/bk-monitor-worker/utils/jsonx/compare_test.go
+++ b/pkg/bk-monitor-worker/utils/jsonx/compare_test.go
@@ -9,7 +9,9 @@
 
 package jsonx
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestCompareObjects(t *testing.T) {
 	type args struct {

--- a/pkg/bk-monitor-worker/utils/jsonx/sonic.go
+++ b/pkg/bk-monitor-worker/utils/jsonx/sonic.go
@@ -10,6 +10,8 @@
 package jsonx
 
 import (
+	"io"
+
 	"github.com/bytedance/sonic"
 )
 
@@ -37,4 +39,12 @@ func UnmarshalString(data string, v interface{}) error {
 
 func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
 	return sonicAPI.MarshalIndent(v, prefix, indent)
+}
+
+func Decode(body io.Reader, v interface{}) error {
+	return sonicAPI.NewDecoder(body).Decode(v)
+}
+
+func Encode(buf io.Writer, v interface{}) error {
+	return sonicAPI.NewEncoder(buf).Encode(v)
 }

--- a/pkg/bk-monitor-worker/utils/runtimex/runtime.go
+++ b/pkg/bk-monitor-worker/utils/runtimex/runtime.go
@@ -64,6 +64,7 @@ func HandleCrashToChan(errorReceiveChan chan<- error) {
 			case errorReceiveChan <- err:
 				logger.Infof("send error to receiveChan")
 			case <-time.After(5 * time.Second):
+				// avoid errorReceiveChan blocking caused by multi-exceptions
 				logger.Infof("send error to receiveChan timeout, this error(%s) will not be received", err)
 			}
 


### PR DESCRIPTION
**bug 修复：**
1. APM 预计算更改
   1. 父子窗口并发数量改为根据 cpu 核数确定，去除配置
   2. Kafka 消费者增加监听 context 退出信号
   3. cache、es 存储类初始化时添加parentContext 参数
   4. defer 全局异常捕获增加发送超时逻辑
2. 常驻任务
   1. 检查任务是否正常时间间隔默认值从 1 秒改为 5 秒一次
   2. 修复常驻任务和具体gourotine，使用 context 不一致导致关闭不了问题
  **新增指标**

1️⃣常驻任务侧：
1. daemon_running_task_count 运行中的常驻任务心跳
   1. 维度
      1. task_dimension
         1. 预计算认为为 data_id
2. daemon_task_retry_count 常驻任务重试次数
   1. 维度
      1. task_dimension
         1. 预计算认为为 data_id

2️⃣APM 预计算侧：
1. notifier_receive_message_count kafka 接收消息数量
   1. 维度
      1. data_id
      2. topic
2. notifier_parse_span_duration span json解析耗时
   1. 维度
      1. data_id
      2. topic
3. semaphore_total channel 占用量
   1. 维度
      1. data_id
      2. scene
         1. task_process_chan
         2. window_process_event_chan
         3. save_request_chan
4. process_event_duration trace 执行预计算逻辑耗时
   1. 维度
      1. data_id
      2. sub_window_id
5. operate_storage_failed 存储层处理失败数量
   1. 维度
      1. data_id
      2. error
         1. query_bloom_filter_failed
         2. query_es_failed
         3. query_es_return_empty
         4. query_es_response_invalid
         5. save_es_failed
         6. save_cache_failed
         7. save_bloom_filter_failed
6. operate_storage_count 存储层处理次数
   1. 维度
      1. data_id
      2. storage
         1. save_es
         2. trace_es
         3. cache
         4. bloom_filter
      3. operate
         1. save
         2. query
7. save_storage_total 存储层保存数据的数量
   1. 维度
      1. data_id
      2. storage
         1. save_es
         2. trace_es
         3. cache
         4. bloom_filter
8. expired_key_total traceid 过期速率
   1. 维度
      1. data_id
      2. sub_window_id
9. locate_span_duration 分配 span 到具体窗口的耗时
   1. 维度
      1. data_id
10. window_trace_count 窗口 trace 数量
    1. 维度
       1. data_id
       2. sub_window_id
11. window_span_count 窗口 span 数量
    1. 维度
       1. data_id
       2. sub_window_id