### PR TITLE
fix:修改collector配置发现错误返回策略

### DIFF
--- a/pkg/collector/receiver/skywalking/grpc_test.go
+++ b/pkg/collector/receiver/skywalking/grpc_test.go
@@ -215,7 +215,7 @@ func TestFetchConfigurationsNilSn(t *testing.T) {
 	svc := &ConfigurationDiscoveryService{}
 
 	cmds, err := svc.FetchConfigurations(ctx, req)
-	assert.Error(t, err)
+	assert.Nil(t, err)
 	assert.Len(t, cmds.GetCommands(), 0)
 }
 


### PR DESCRIPTION
bk-collector 配置发现功能取消将 error信息返回给到探针侧。
更改为bk-collector日志记录一条错误信息的方式