### PR TITLE
fix:修复极端情况下拨测任务释放信号量失败panic的问题

### DIFF
--- a/pkg/bkmonitorbeat/tasks/udp/gather.go
+++ b/pkg/bkmonitorbeat/tasks/udp/gather.go
@@ -180,20 +180,26 @@ func (g *Gather) Run(ctx context.Context, e chan<- define.Event) {
 		// 循环列表检测
 		for _, targetHost := range result {
 			// 获取并发限制信号量
-			err := g.GetSemaphore().Acquire(ctx, 1)
+			s := g.GetSemaphore()
+			err := s.Acquire(ctx, 1)
 			if err != nil {
 				logger.Errorf("Semaphore Acquire failed for task udp task id: %d", g.TaskConfig.GetTaskID())
 				return
 			}
 			wg.Add(1)
-			go func(tHost, host string) {
+			go func(tHost, host string, s tasks.Semaphore) {
+				defer func() {
+					if err := recover(); err != nil {
+						logger.Errorf("udp task something happend, error is %s\n", err)
+					}
+				}()
 				// 初始化事件
 				event := NewEvent(g, start, tHost)
 				event.ResolvedIP = host
 
 				defer func() {
 					wg.Done()
-					g.GetSemaphore().Release(1)
+					s.Release(1)
 					e <- event
 				}()
 				// 检查单个目标
@@ -208,7 +214,7 @@ func (g *Gather) Run(ctx context.Context, e chan<- define.Event) {
 				if !end.IsZero() {
 					event.EndAt = end
 				}
-			}(taskHost, targetHost)
+			}(taskHost, targetHost, s)
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
极端场景：
当客户有很多拨测任务的时候，可能存在上一个 Gather 的任务还没执行完毕，下一个Gather任务就重新进来的情况。
这可能会导致 Gather 对象的 Semaphore 变更， 从而在对 Semaphore 信号量进行释放的时候 panic 导致程序异常退出。

添加recover逻辑预防 Semaphore.Release(1) panic 的情况。
修改 Semaphore 信号量传入 goroutine 的方式