### PR TITLE
fix: 修复 bkmonitorbeat 在 windows 下无法获取到 IoTime 导致的 io使用率一直为0的情况 

### DIFF
--- a/pkg/bkmonitorbeat/tasks/basereport/collector/disk.go
+++ b/pkg/bkmonitorbeat/tasks/basereport/collector/disk.go
@@ -53,29 +53,6 @@ type DiskStats struct {
 	Svctm            float64 `json:"svctm"`
 }
 
-func ToDiskStats(stats disk.IOCountersStat) DiskStats {
-	return DiskStats{
-		ReadCount:        stats.ReadCount,
-		MergedReadCount:  stats.MergedReadCount,
-		WriteCount:       stats.WriteCount,
-		MergedWriteCount: stats.MergedWriteCount,
-		ReadBytes:        stats.ReadBytes,
-		WriteBytes:       stats.WriteBytes,
-		ReadTime:         stats.ReadTime,
-		WriteTime:        stats.WriteTime,
-		IopsInProgress:   stats.IopsInProgress,
-		IoTime:           stats.IoTime,
-		WeightedIO:       stats.WeightedIO,
-		Name:             stats.Name,
-		SerialNumber:     stats.SerialNumber,
-		Label:            stats.Label,
-		MajorNum:         stats.Major,
-		MinorNum:         stats.Minor,
-		ReadSectors:      stats.ReadBytes / SectorSize,
-		WriteSectors:     stats.WriteBytes / SectorSize,
-	}
-}
-
 func IOCounters(names ...string) (map[string]DiskStats, error) {
 	stats, err := disk.IOCountersWithContext(context.Background(), names...)
 	if err != nil {

--- a/pkg/bkmonitorbeat/tasks/basereport/collector/disk_unix.go
+++ b/pkg/bkmonitorbeat/tasks/basereport/collector/disk_unix.go
@@ -58,6 +58,29 @@ func isPartition(diskStat DiskStats) bool {
 	return partitionRegex.MatchString(diskStat.Name)
 }
 
+func ToDiskStats(stats disk.IOCountersStat) DiskStats {
+	return DiskStats{
+		ReadCount:        stats.ReadCount,
+		MergedReadCount:  stats.MergedReadCount,
+		WriteCount:       stats.WriteCount,
+		MergedWriteCount: stats.MergedWriteCount,
+		ReadBytes:        stats.ReadBytes,
+		WriteBytes:       stats.WriteBytes,
+		ReadTime:         stats.ReadTime,
+		WriteTime:        stats.WriteTime,
+		IopsInProgress:   stats.IopsInProgress,
+		IoTime:           stats.IoTime,
+		WeightedIO:       stats.WeightedIO,
+		Name:             stats.Name,
+		SerialNumber:     stats.SerialNumber,
+		Label:            stats.Label,
+		MajorNum:         stats.Major,
+		MinorNum:         stats.Minor,
+		ReadSectors:      stats.ReadBytes / SectorSize,
+		WriteSectors:     stats.WriteBytes / SectorSize,
+	}
+}
+
 // FilterDiskIoStats 过滤磁盘io信息
 func FilterDiskIoStats(diskStats map[string]DiskStats, config configs.DiskConfig) map[string]DiskStats {
 	resultDiskStats := make(map[string]DiskStats)

--- a/pkg/bkmonitorbeat/tasks/basereport/collector/disk_windows.go
+++ b/pkg/bkmonitorbeat/tasks/basereport/collector/disk_windows.go
@@ -20,6 +20,29 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
+func ToDiskStats(stats disk.IOCountersStat) DiskStats {
+	return DiskStats{
+		ReadCount:        stats.ReadCount,
+		MergedReadCount:  stats.MergedReadCount,
+		WriteCount:       stats.WriteCount,
+		MergedWriteCount: stats.MergedWriteCount,
+		ReadBytes:        stats.ReadBytes,
+		WriteBytes:       stats.WriteBytes,
+		ReadTime:         stats.ReadTime,
+		WriteTime:        stats.WriteTime,
+		IopsInProgress:   stats.IopsInProgress,
+		IoTime:           stats.ReadTime + stats.WriteTime,
+		WeightedIO:       stats.WeightedIO,
+		Name:             stats.Name,
+		SerialNumber:     stats.SerialNumber,
+		Label:            stats.Label,
+		MajorNum:         stats.Major,
+		MinorNum:         stats.Minor,
+		ReadSectors:      stats.ReadBytes / SectorSize,
+		WriteSectors:     stats.WriteBytes / SectorSize,
+	}
+}
+
 // FilterDiskIoStats 过滤磁盘io信息
 func FilterDiskIoStats(diskStats map[string]DiskStats, config configs.DiskConfig) map[string]DiskStats {
 	resultDiskStats := make(map[string]DiskStats)


### PR DESCRIPTION
1. 修复 bkmonitorbeat 在 windows 下无法获取到 ioTime的问题 （使用ReadTime + writeTime 来近似表示）

参考：
linux /proc/diskstats  linux中对于 iotime 是有直接的数据可以支持解析出 ioTime
macos  对于macos中查看 gopsutil 代码， gopsutil 主要是使用的 readTime + writeTime 来近似的代表 IO的时间（实际上应该还包含IO等待的时间）
