### PR TITLE
feat(es): 实现基于TTL的映射缓存机制

### DIFF
--- a/pkg/unify-query/metadata/struct.go
+++ b/pkg/unify-query/metadata/struct.go
@@ -130,6 +130,42 @@ type Query struct {
 	NeedAddTime bool
 }
 
+func (q *Query) FieldsUniqueKey() string {
+	if q.TableID == "" {
+		return ""
+	}
+
+	s := set.New[string]()
+
+	if q.Field != "" {
+		s.Add(q.Field)
+	}
+
+	for _, condGroup := range q.AllConditions {
+		for _, cond := range condGroup {
+			if cond.DimensionName != "" {
+				s.Add(cond.DimensionName)
+			}
+		}
+	}
+
+	for _, agg := range q.Aggregates {
+		for _, dim := range agg.Dimensions {
+			if dim != "" {
+				s.Add(dim)
+			}
+		}
+	}
+
+	for _, order := range q.Orders {
+		if order.Name != "" {
+			s.Add(order.Name)
+		}
+	}
+
+	return fmt.Sprintf("%s|%s", q.TableID, s.ToArray())
+}
+
 type HighLight struct {
 	MaxAnalyzedOffset int  `json:"max_analyzed_offset,omitempty"`
 	Enable            bool `json:"enable,omitempty"`

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -37,6 +37,10 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/tsdb"
 )
 
+const (
+	MappingCacheTTL = 5 * time.Minute
+)
+
 var _ tsdb.Instance = (*Instance)(nil)
 
 type Instance struct {
@@ -53,6 +57,10 @@ type Instance struct {
 
 	timeout time.Duration
 	maxSize int
+
+	mappingCache     MappingCache
+	mappingCacheLock sync.RWMutex
+	mappingTTL       time.Duration
 }
 
 type Connects []Connect
@@ -85,6 +93,7 @@ type InstanceOption struct {
 	Timeout     time.Duration
 	Headers     map[string]string
 	HealthCheck bool
+	MappingTTL  time.Duration
 }
 
 type queryOption struct {
@@ -106,6 +115,11 @@ var TimeSeriesResultPool = sync.Pool{
 }
 
 func NewInstance(ctx context.Context, opt *InstanceOption) (*Instance, error) {
+	mappingTTL := opt.MappingTTL
+	if mappingTTL <= 0 {
+		mappingTTL = MappingCacheTTL
+	}
+
 	ins := &Instance{
 		ctx:      ctx,
 		maxSize:  opt.MaxSize,
@@ -114,6 +128,9 @@ func NewInstance(ctx context.Context, opt *InstanceOption) (*Instance, error) {
 		headers:     opt.Headers,
 		healthCheck: opt.HealthCheck,
 		timeout:     opt.Timeout,
+
+		mappingCache: make(MappingCache),
+		mappingTTL:   mappingTTL,
 	}
 
 	if len(ins.connects) == 0 {
@@ -512,11 +529,17 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 				errChan <- err
 				wg.Done()
 			}()
-
-			mappings, mappingErr := i.getMappings(ctx, conn, aliases)
-			if mappingErr != nil {
-				err = mappingErr
-				return
+			mappings, exist := i.checkIsMappingCached(query.FieldsUniqueKey())
+			if exist {
+				span.Set("mapping-exist", true)
+			} else {
+				span.Set("mapping-exist", false)
+				var mappingErr error
+				mappings, mappingErr = i.getMappings(ctx, conn, aliases)
+				if mappingErr != nil {
+					err = mappingErr
+					return
+				}
 			}
 			if len(mappings) == 0 {
 				err = fmt.Errorf("index is empty with %v，url: %s", aliases, conn.Address)
@@ -713,11 +736,20 @@ func (i *Instance) QuerySeriesSet(
 					conn:    conn,
 				}
 
-				mappings, err1 := i.getMappings(ctx, qo.conn, qo.indexes)
-				// index 不存在，mappings 获取异常直接返回空
-				if len(mappings) == 0 {
-					log.Warnf(ctx, "index is empty with %v", qo.indexes)
-					return
+				mappings, exist := i.checkIsMappingCached(query.FieldsUniqueKey())
+				span.Set("mapping-exist", exist)
+				if !exist {
+					var mappingErr error
+					mappings, mappingErr = i.getMappings(ctx, conn, aliases)
+					if mappingErr != nil {
+						err = mappingErr
+						return
+					}
+					if len(mappings) == 0 {
+						log.Warnf(ctx, "index is empty with %v", qo.indexes)
+						err = fmt.Errorf("index is empty with %v，url: %s", aliases, conn.Address)
+						return
+					}
 				}
 
 				if err1 != nil {

--- a/pkg/unify-query/tsdb/elasticsearch/mapping_cache.go
+++ b/pkg/unify-query/tsdb/elasticsearch/mapping_cache.go
@@ -1,0 +1,153 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package elasticsearch
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MappingEntry 保存缓存映射数据和最后更新时间
+type MappingEntry struct {
+	mappings    []map[string]any
+	lastUpdated time.Time
+}
+
+func (m MappingEntry) IsExpired(ttl time.Duration) bool {
+	return time.Now().After(m.lastUpdated.Add(ttl))
+}
+
+// MappingCache 保存缓存映射
+// 结构: map[tableID]map[fieldsStr]MappingEntry
+type MappingCache map[string]map[string]MappingEntry
+
+// Put 添加映射到缓存
+func (m *MappingCache) Put(tableID string, fieldsStr string, mappings []map[string]any) {
+	if m == nil {
+		return
+	}
+
+	if *m == nil {
+		*m = make(MappingCache)
+	}
+
+	if _, ok := (*m)[tableID]; !ok {
+		(*m)[tableID] = make(map[string]MappingEntry)
+	}
+
+	(*m)[tableID][fieldsStr] = MappingEntry{
+		mappings:    mappings,
+		lastUpdated: time.Now(),
+	}
+}
+
+// Get 从缓存获取映射条目，自动处理过期条目
+func (m *MappingCache) Get(tableID string, fieldsStr string, ttl time.Duration) (MappingEntry, bool) {
+	if m == nil || *m == nil {
+		return MappingEntry{}, false
+	}
+
+	tableMap, ok := (*m)[tableID]
+	if !ok {
+		return MappingEntry{}, false
+	}
+
+	entry, ok := tableMap[fieldsStr]
+	if !ok {
+		return MappingEntry{}, false
+	}
+
+	if entry.IsExpired(ttl) {
+		delete(tableMap, fieldsStr)
+		if len(tableMap) == 0 {
+			delete(*m, tableID)
+		}
+		return MappingEntry{}, false
+	}
+
+	return entry, true
+}
+
+// Delete 从缓存删除映射
+func (m *MappingCache) Delete(tableID string, fieldsStr string) {
+	if m == nil || *m == nil {
+		return
+	}
+
+	tableMap, ok := (*m)[tableID]
+	if !ok {
+		return
+	}
+
+	if fieldsStr == "" {
+		delete(*m, tableID)
+	} else {
+		delete(tableMap, fieldsStr)
+		if len(tableMap) == 0 {
+			delete(*m, tableID)
+		}
+	}
+}
+
+// Clear 清空缓存
+func (m *MappingCache) Clear() {
+	if m != nil {
+		*m = make(MappingCache)
+	}
+}
+
+// checkIsMappingCached 检查映射是否已缓存
+func (i *Instance) checkIsMappingCached(queryIdentifier string) ([]map[string]any, bool) {
+	parts := strings.Split(queryIdentifier, "|")
+	if len(parts) < 1 {
+		return nil, false
+	}
+
+	tableID := parts[0]
+	fieldsStr := ""
+	if len(parts) > 1 {
+		fieldsStr = strings.Join(parts[1:], "|")
+	}
+
+	i.mappingCacheLock.RLock()
+	defer i.mappingCacheLock.RUnlock()
+
+	entry, exist := i.mappingCache.Get(tableID, fieldsStr, i.mappingTTL)
+	if !exist {
+		return nil, false
+	}
+
+	return entry.mappings, true
+}
+
+// writeMappings 写入映射到缓存
+func (i *Instance) writeMappings(mappings []map[string]any, queryIdentifier string) error {
+	if len(mappings) == 0 {
+		return fmt.Errorf("cannot cache empty mappings")
+	}
+
+	parts := strings.Split(queryIdentifier, "|")
+	if len(parts) < 1 {
+		return fmt.Errorf("invalid query identifier format: %s", queryIdentifier)
+	}
+
+	tableID := parts[0]
+	fieldsStr := ""
+	if len(parts) > 1 {
+		fieldsStr = strings.Join(parts[1:], "|")
+	}
+
+	i.mappingCacheLock.Lock()
+	defer i.mappingCacheLock.Unlock()
+
+	i.mappingCache.Put(tableID, fieldsStr, mappings)
+	return nil
+}


### PR DESCRIPTION
- 在Query结构体中添加FieldsUniqueKey方法用于生成缓存键
- 实现MappingCache类型，支持Put、Get、Delete和Clear操作
- 在Instance结构体中添加mappingCache字段，使用RWMutex保证线程安全
- 设置默认MappingCacheTTL常量为5分钟
- 在InstanceOption中添加MappingTTL选项支持自定义TTL配置
- 在QueryRawData和QuerySeriesSet方法中集成缓存机制
- 添加完整的TestInstance_mappingCache测试用例验证缓存功能