### PR TITLE
fix(es): 正确处理同一组中的嵌套和非嵌套查询

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -744,20 +744,28 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 	bootQueries := make([]elastic.Query, 0)
 	orQuery := make([]elastic.Query, 0, len(allConditions))
 
-	nestedFields := make(map[string]struct{})
 	for _, conditions := range allConditions {
-		andQuery := make([]elastic.Query, 0, len(conditions))
+		// Track nested fields separately for each condition group
+		nestedFields := make(map[string]struct{})
+		nestedQueries := make(map[string][]elastic.Query)
+		nonNestedQueries := make([]elastic.Query, 0)
+
+		// First pass: process all conditions and separate nested from non-nested
 		for _, con := range conditions {
 			key := con.DimensionName
 			if f.decode != nil {
 				key = f.decode(key)
 			}
 
+			// Check if this dimension is in a nested field
+			nf := f.NestedField(con.DimensionName)
+
+			var q elastic.Query
 			switch con.Operator {
 			case structured.ConditionExisted:
-				andQuery = append(andQuery, elastic.NewExistsQuery(key))
+				q = elastic.NewExistsQuery(key)
 			case structured.ConditionNotExisted:
-				andQuery = append(andQuery, f.getQuery(MustNot, elastic.NewExistsQuery(key)))
+				q = f.getQuery(MustNot, elastic.NewExistsQuery(key))
 			default:
 				// 根据字段类型，判断是否使用 isExistsQuery 方法判断非空
 				fieldType, ok := f.mapping[key]
@@ -823,7 +831,6 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 				}
 
 				// 非空才进行验证
-				var q elastic.Query
 				switch con.Operator {
 				case structured.ConditionEqual, structured.ConditionContains, structured.ConditionRegEqual:
 					q = f.getQuery(Should, queries...)
@@ -834,21 +841,38 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 				default:
 					return nil, fmt.Errorf("operator is not support, %+v", con)
 				}
+			}
 
-				nf := f.NestedField(con.DimensionName)
-				if nf != "" {
-					nestedFields[nf] = struct{}{}
-				}
-
-				if q != nil {
-					andQuery = append(andQuery, q)
-				}
+			// Add to the appropriate query collection
+			if nf != "" {
+				nestedFields[nf] = struct{}{}
+				nestedQueries[nf] = append(nestedQueries[nf], q)
+			} else if q != nil {
+				nonNestedQueries = append(nonNestedQueries, q)
 			}
 		}
 
-		aq := f.getQuery(Must, andQuery...)
-		if aq != nil {
-			orQuery = append(orQuery, aq)
+		// Combine nested queries by field
+		nestedFieldQueries := make([]elastic.Query, 0)
+		for field, queries := range nestedQueries {
+			if len(queries) > 0 {
+				// Create a nested query for this field
+				nestedQuery := elastic.NewNestedQuery(field, f.getQuery(Must, queries...))
+				nestedFieldQueries = append(nestedFieldQueries, nestedQuery)
+			}
+		}
+
+		// Combine all queries (nested and non-nested)
+		var allQueries []elastic.Query
+		allQueries = append(allQueries, nonNestedQueries...)
+		allQueries = append(allQueries, nestedFieldQueries...)
+
+		// Add to OR query
+		if len(allQueries) > 0 {
+			aq := f.getQuery(Must, allQueries...)
+			if aq != nil {
+				orQuery = append(orQuery, aq)
+			}
 		}
 	}
 
@@ -862,13 +886,6 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 		resQuery = elastic.NewBoolQuery().Must(bootQueries...)
 	} else if len(bootQueries) == 1 {
 		resQuery = bootQueries[0]
-	}
-
-	// 拼接 nested query
-	if len(nestedFields) > 0 {
-		for k := range nestedFields {
-			resQuery = elastic.NewNestedQuery(k, resQuery)
-		}
 	}
 
 	return resQuery, nil

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -119,22 +119,22 @@ func TestFormatFactory_Query(t *testing.T) {
 			conditions: metadata.AllConditions{
 				{
 					{
-						DimensionName: "nested.key",
+						DimensionName: "nested1.key",
 						Value:         []string{"val-1", "val-2"},
 						Operator:      structured.ConditionContains,
 					},
 					{
-						DimensionName: "nested.key",
+						DimensionName: "nested1.key",
 						Value:         []string{"val-3"},
 						Operator:      structured.ConditionEqual,
 					},
 					{
-						DimensionName: "nested.key",
+						DimensionName: "nested1.key",
 						Operator:      structured.ConditionExisted,
 					},
 				},
 			},
-			expected: `{"query":{"nested":{"path":"nested","query":{"bool":{"must":[{"bool":{"should":[{"wildcard":{"nested.key":{"value":"val-1"}}},{"wildcard":{"nested.key":{"value":"val-2"}}}]}},{"match_phrase":{"nested.key":{"query":"val-3"}}},{"exists":{"field":"nested.key"}}]}}}}}`,
+			expected: `{"query":{"nested":{"query":{"bool":{"must":[{"bool":{"should":[{"wildcard":{"nested1.key":{"value":"*val-1*"}}},{"wildcard":{"nested1.key":{"value":"*val-2*"}}}]}},{"match_phrase":{"nested1.key":{"query":"val-3"}}},{"exists":{"field":"nested1.key"}}]}},"path":"nested1"}}}`,
 		},
 		"keyword and text check wildcard": {
 			conditions: metadata.AllConditions{
@@ -191,7 +191,7 @@ func TestFormatFactory_Query(t *testing.T) {
 						Operator:      structured.ConditionEqual,
 					},
 					{
-						DimensionName: "nested.key",
+						DimensionName: "nested1.key",
 						Value:         []string{"val-1"},
 						Operator:      structured.ConditionEqual,
 					},
@@ -204,7 +204,105 @@ func TestFormatFactory_Query(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"query":{"bool":{"should":[{"bool":{"must":[{"match_phrase":{"keyword":{"query":"test"}}},{"nested":{"query":{"match_phrase":{"nested.key":{"query":"val-1"}}},"path":"nested"}}]}},{"match_phrase":{"text":{"query":"test"}}}]}}}`,
+			expected: `{"query":{"bool":{"should":[{"bool":{"must":[{"match_phrase":{"keyword":{"query":"test"}}},{"nested":{"query":{"match_phrase":{"nested1.key":{"query":"val-1"}}},"path":"nested1"}}]}},{"match_phrase":{"text":{"query":"test"}}}]}}}`,
+		},
+		"multiple nested fields in same condition group": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "nested1.name",
+						Value:         []string{"test-user"},
+						Operator:      structured.ConditionEqual,
+					},
+					{
+						DimensionName: "nested2.city",
+						Value:         []string{"Shanghai"},
+						Operator:      structured.ConditionEqual,
+					},
+					{
+						DimensionName: "keyword",
+						Value:         []string{"normal-field"},
+						Operator:      structured.ConditionEqual,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"must":[{"match_phrase":{"keyword":{"query":"normal-field"}}},{"nested":{"path":"nested1","query":{"match_phrase":{"nested1.name":{"query":"test-user"}}}}},{"nested":{"path":"nested2","query":{"match_phrase":{"nested2.city":{"query":"Shanghai"}}}}}]}}}`,
+		},
+		"nested fields in different condition groups": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "nested1.name",
+						Value:         []string{"test-user"},
+						Operator:      structured.ConditionEqual,
+					},
+					{
+						DimensionName: "keyword",
+						Value:         []string{"group1"},
+						Operator:      structured.ConditionEqual,
+					},
+				},
+				{
+					{
+						DimensionName: "nested2.city",
+						Value:         []string{"Shanghai"},
+						Operator:      structured.ConditionEqual,
+					},
+					{
+						DimensionName: "text",
+						Value:         []string{"group2"},
+						Operator:      structured.ConditionContains,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"should":[{"bool":{"must":[{"match_phrase":{"keyword":{"query":"group1"}}},{"nested":{"path":"nested1","query":{"match_phrase":{"nested1.name":{"query":"test-user"}}}}}]}},{"bool":{"must":[{"match_phrase":{"text":{"query":"group2"}}},{"nested":{"path":"nested2","query":{"match_phrase":{"nested2.city":{"query":"Shanghai"}}}}}]}}]}}}`,
+		},
+		"nested fields with different levels": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "nested3.nestedChild.key",
+						Value:         []string{"value"},
+						Operator:      structured.ConditionEqual,
+					},
+					{
+						DimensionName: "nested3.annotations",
+						Operator:      structured.ConditionExisted,
+					},
+					{
+						DimensionName: "keyword",
+						Value:         []string{"test"},
+						Operator:      structured.ConditionEqual,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"must":[{"match_phrase":{"keyword":{"query":"test"}}},{"nested":{"query":{"match_phrase":{"nested3.nestedChild.key":{"query":"value"}}},"path":"nested3.nestedChild"}},{"nested":{"path":"nested3","query":{"exists":{"field":"nested3.annotations"}}}}]}}}`,
+		},
+		"mixed nested and normal queries with different operators": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "nested1.age",
+						Value:         []string{"18"},
+						Operator:      structured.ConditionGte,
+					},
+					{
+						DimensionName: "nested1.active",
+						Operator:      structured.ConditionExisted,
+					},
+					{
+						DimensionName: "keyword",
+						Value:         []string{"value1", "value2"},
+						Operator:      structured.ConditionNotEqual,
+					},
+					{
+						DimensionName: "text",
+						Value:         []string{"partial"},
+						Operator:      structured.ConditionContains,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"must":[{"bool":{"must_not":[{"match_phrase":{"keyword":{"query":"value1"}}},{"match_phrase":{"keyword":{"query":"value2"}}}]}},{"match_phrase":{"text":{"query":"partial"}}},{"nested":{"path":"nested1","query":{"bool":{"must":[{"range":{"nested1.age":{"from":"18","include_lower":true,"include_upper":true,"to":null}}},{"exists":{"field":"nested1.active"}}]}}}}]}}}`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -212,8 +310,49 @@ func TestFormatFactory_Query(t *testing.T) {
 			mappings := []map[string]any{
 				{
 					"properties": map[string]any{
-						"nested": map[string]any{
+						"nested1": map[string]any{
 							"type": "nested",
+							"properties": map[string]any{
+								"key": map[string]any{
+									"type": "keyword",
+								},
+								"name": map[string]any{
+									"type": "keyword",
+								},
+								"age": map[string]any{
+									"type": "long",
+								},
+								"active": map[string]any{
+									"type": "boolean",
+								},
+							},
+						},
+						"nested2": map[string]any{
+							"type": "nested",
+							"properties": map[string]any{
+								"city": map[string]any{
+									"type": "keyword",
+								},
+								"street": map[string]any{
+									"type": "keyword",
+								},
+							},
+						},
+						"nested3": map[string]any{
+							"type": "nested",
+							"properties": map[string]any{
+								"annotations": map[string]any{
+									"type": "keyword",
+								},
+								"nestedChild": map[string]any{
+									"type": "nested",
+									"properties": map[string]any{
+										"key": map[string]any{
+											"type": "keyword",
+										},
+									},
+								},
+							},
 						},
 						"keyword": map[string]any{
 							"type": "keyword",

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -182,6 +182,30 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"bool":{"must":[{"bool":{"must_not":{"exists":{"field":"key-1"}}}},{"exists":{"field":"key-2"}}]}}}`,
 		},
+		"combine nested and normal query in one group": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"test"},
+						Operator:      structured.ConditionEqual,
+					},
+					{
+						DimensionName: "nested.key",
+						Value:         []string{"val-1"},
+						Operator:      structured.ConditionEqual,
+					},
+				},
+				{
+					{
+						DimensionName: "text",
+						Value:         []string{"test"},
+						Operator:      structured.ConditionContains,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"should":[{"bool":{"must":[{"match_phrase":{"keyword":{"query":"test"}}},{"nested":{"query":{"match_phrase":{"nested.key":{"query":"val-1"}}},"path":"nested"}}]}},{"match_phrase":{"text":{"query":"test"}}}]}}}`,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := metadata.InitHashID(context.Background())


### PR DESCRIPTION
1. 为每个条件组单独跟踪嵌套字段和非嵌套字段的查询条件
2. 对于嵌套字段路径，将相关条件分别收集到对应路径的查询列表中
3. 对于非嵌套字段，将其条件收集到非嵌套查询列表中
4. 针对每个嵌套字段路径，创建单独的嵌套查询
5. 最后将所有非嵌套查询和嵌套查询组合在一起，保持正确的查询结构层次