### PR TITLE
feature: influxdb support https

### DIFF
--- a/pkg/influxdb-proxy/backend/manager.go
+++ b/pkg/influxdb-proxy/backend/manager.go
@@ -112,6 +112,7 @@ var Refresh = func() error {
 			Port:            info.Port,
 			Disabled:        info.Disabled,
 			BackupRateLimit: info.BackupRateLimit,
+			Protocol:        info.Protocol,
 		}
 	}
 	err = BackendManager.Refresh(hostInfoMap)

--- a/pkg/influxdb-proxy/backend/struct.go
+++ b/pkg/influxdb-proxy/backend/struct.go
@@ -21,6 +21,7 @@ type BasicConfig struct {
 	Port     int
 	Username string
 	Password string
+	Protocol string
 
 	Disabled        bool
 	BackupRateLimit float64
@@ -40,6 +41,7 @@ func MakeBasicConfig(name string, host *Info, forceBackup bool, ignoreKafka bool
 		Port:            host.Port,
 		Username:        host.Username,
 		Password:        host.Password,
+		Protocol:        host.Protocol,
 		Disabled:        host.Disabled,
 		BackupRateLimit: host.BackupRateLimit,
 		ForceBackup:     forceBackup,
@@ -112,6 +114,7 @@ type Info struct {
 	Port       int    `json:"port"`
 	Username   string `json:"username"`
 	Password   string `json:"password"`
+	Protocol   string `json:"protocol"`
 	// 兼容默认值为 false 需要保持开启，所以用反状态
 	Disabled        bool    `json:"status,omitempty"`
 	BackupRateLimit float64 `json:"backup_rate_limit,omitempty"`

--- a/pkg/influxdb-proxy/consul/struct.go
+++ b/pkg/influxdb-proxy/consul/struct.go
@@ -34,6 +34,8 @@ type HostInfo struct {
 	Port       int    `json:"port"`
 	Username   string `json:"username"`
 	Password   string `json:"password"`
+	// support https and http
+	Protocol string `json:"protocol"`
 	// 兼容默认值为 false 需要保持开启，所以用反状态
 	Disabled        bool    `json:"status,omitempty"`
 	BackupRateLimit float64 `json:"backup_rate_limit,omitempty"`

--- a/pkg/influxdb-proxy/transport/influxdb.go
+++ b/pkg/influxdb-proxy/transport/influxdb.go
@@ -24,9 +24,10 @@ import (
 // GetClient 根据参数获取influxdb实例
 func GetClient(address, username, password string) (client.Client, error) {
 	clientItem, err := client.NewHTTPClient(client.HTTPConfig{
-		Addr:     address,
-		Username: username,
-		Password: password,
+		Addr:               address,
+		Username:           username,
+		Password:           password,
+		InsecureSkipVerify: true,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/influxdb-proxy/transport/transport.go
+++ b/pkg/influxdb-proxy/transport/transport.go
@@ -47,6 +47,9 @@ func NewTransport(ctx context.Context, queryDuration string, maxQueryLines int, 
 // 获取backend实例
 func (t *Transport) getClientInstance(ctx context.Context, name string, hostInfo *consul.HostInfo) (client.Client, error) {
 	address := fmt.Sprintf("http://%s:%d", hostInfo.DomainName, hostInfo.Port)
+	if hostInfo.Protocol == "https" {
+		address = fmt.Sprintf("https://%s:%d", hostInfo.DomainName, hostInfo.Port)
+	}
 	cli, err := GetClient(address, hostInfo.Username, hostInfo.Password)
 	return cli, err
 }

--- a/pkg/unify-query/curl/curl.go
+++ b/pkg/unify-query/curl/curl.go
@@ -12,6 +12,7 @@ package curl
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
@@ -56,10 +57,11 @@ func (c *HttpCurl) Request(ctx context.Context, method string, opt Options) (*ht
 		defer span.End()
 	}
 
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	client := http.Client{
-		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Transport: otelhttp.NewTransport(transport),
 	}
-
 	c.Log.Ctx(ctx).Info(fmt.Sprintf("[%s] %s", method, opt.UrlPath))
 
 	req, err := http.NewRequestWithContext(ctx, method, opt.UrlPath, bytes.NewBuffer(opt.Body))

--- a/pkg/unify-query/influxdb/client/client.go
+++ b/pkg/unify-query/influxdb/client/client.go
@@ -11,6 +11,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -79,7 +80,9 @@ func (c *BasicClient) Query(
 	trace.InsertStringIntoSpan("query-params", values.Encode(), span)
 	trace.InsertStringIntoSpan("http-url", urlPath, span)
 
-	client := http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	client := &http.Client{Transport: otelhttp.NewTransport(transport)}
 	req, err := http.NewRequestWithContext(ctx, "GET", urlPath, nil)
 	if err != nil {
 		log.Errorf(ctx, "client new request error:%s", err)

--- a/pkg/unify-query/influxdb/endpoint.go
+++ b/pkg/unify-query/influxdb/endpoint.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	GRPC = "grpc"
-	HTTP = "http"
+	GRPC  = "grpc"
+	HTTP  = "http"
+	HTTPS = "https"
 )
 
 type BackendRef struct {

--- a/pkg/unify-query/influxdb/influxdb_router.go
+++ b/pkg/unify-query/influxdb/influxdb_router.go
@@ -12,6 +12,7 @@ package influxdb
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -131,7 +132,14 @@ func (r *Router) Ping(ctx context.Context, timeout time.Duration, pingCount int)
 	}
 
 	// 开始进行 Ping influxdb
-	clint := &http.Client{Timeout: timeout}
+	clint := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
 	for _, v := range r.hostInfo {
 		// 重试 pingCount 次数
 		var read bool

--- a/pkg/unify-query/tsdb/influxdb/instance.go
+++ b/pkg/unify-query/tsdb/influxdb/instance.go
@@ -152,7 +152,7 @@ func (i *Instance) QueryExemplar(ctx context.Context, fields []string, query *me
 
 	urlPath := fmt.Sprintf(
 		"%s://%s:%d/%s?%s",
-		"http", i.host, i.port, "query", values.Encode(),
+		i.protocol, i.host, i.port, "query", values.Encode(),
 	)
 
 	trace.InsertStringIntoSpan("query-params", values.Encode(), span)
@@ -452,7 +452,7 @@ func (i *Instance) query(
 
 	urlPath := fmt.Sprintf(
 		"%s://%s:%d/%s?%s",
-		"http", i.host, i.port, "query", values.Encode(),
+		i.protocol, i.host, i.port, "query", values.Encode(),
 	)
 
 	trace.InsertStringIntoSpan("query-params", values.Encode(), span)
@@ -771,7 +771,7 @@ func (i *Instance) LabelNames(ctx context.Context, query *metadata.Query, start,
 
 		urlPath := fmt.Sprintf(
 			"%s://%s:%d/%s?%s",
-			"http", i.host, i.port, "query", values.Encode(),
+			i.protocol, i.host, i.port, "query", values.Encode(),
 		)
 
 		trace.InsertStringIntoSpan("query-params", values.Encode(), span)
@@ -893,7 +893,7 @@ func (i *Instance) metrics(ctx context.Context, query *metadata.Query) ([]string
 
 	urlPath := fmt.Sprintf(
 		"%s://%s:%d/%s?%s",
-		"http", i.host, i.port, "query", values.Encode(),
+		i.protocol, i.host, i.port, "query", values.Encode(),
 	)
 
 	trace.InsertStringIntoSpan("query-params", values.Encode(), span)
@@ -1041,7 +1041,7 @@ func (i *Instance) LabelValues(ctx context.Context, query *metadata.Query, name 
 
 		urlPath := fmt.Sprintf(
 			"%s://%s:%d/%s?%s",
-			"http", i.host, i.port, "query", values.Encode(),
+			i.protocol, i.host, i.port, "query", values.Encode(),
 		)
 
 		trace.InsertStringIntoSpan("query-params", values.Encode(), span)


### PR DESCRIPTION
3.8.x unifyquery + influxdbProxy  支持 influxdb 实例表中的 `Protocol=https` 字段内容做为开启 ssl 标识，并做对应的适配