### PR TITLE
fixbug: 控制指标上报字段填写错误

### DIFF
--- a/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/metrics_processor.go
+++ b/pkg/bk-monitor-worker/internal/apm/pre_calculate/window/metrics_processor.go
@@ -828,7 +828,7 @@ func newMetricProcessor(ctx context.Context, dataId string, processorOpts Proces
 		bkBizId:                           baseInfo.BkBizId,
 		appName:                           baseInfo.AppName,
 		appId:                             baseInfo.AppId,
-		enabledLayer4Report:               processorOpts.enabledInfoCache,
+		enabledLayer4Report:               processorOpts.metricLayer4ReportEnabled,
 		podInstanceErrorFlowReportEnabled: processorOpts.podInstanceErrorFlowReportEnabled,
 		podApmErrorFlowReportEnabled:      processorOpts.podApmErrorFlowReportEnabled,
 		podSystemErrorFlowReportEnabled:   processorOpts.podSystemErrorFlowReportEnabled,


### PR DESCRIPTION
enabledLayer4Report应当对应procssorOptions的metricLayer4ReportEnabled