### PR TITLE
fix:修复unify-query 兼容influxdb Ping认证的场景

### DIFF
--- a/pkg/unify-query/influxdb/influxdb_router.go
+++ b/pkg/unify-query/influxdb/influxdb_router.go
@@ -137,6 +137,12 @@ func (r *Router) Ping(ctx context.Context, timeout time.Duration, pingCount int)
 			if err != nil {
 				continue
 			}
+			// 对于配置了账号密码的情况
+			// 此处用于兼容 influxdb 的 basic auth 认证
+			if v.Username != "" && v.Password != "" {
+				req.SetBasicAuth(v.Username, v.Password)
+			}
+
 			resp, err := clint.Do(req)
 			if err != nil {
 				continue


### PR DESCRIPTION
修复unify-query 兼容influxdb Ping认证的场景