### PR TITLE
fix: 修复过往PR中出错的项

### DIFF
--- a/pkg/transfer/template/etl/basereport/disk.go
+++ b/pkg/transfer/template/etl/basereport/disk.go
@@ -87,10 +87,6 @@ func NewPerformanceDiskProcessor(ctx context.Context, name string) *PerformanceD
 				etl.ExtractByJMESPath("usage.device"), etl.TransformNilString,
 			),
 			etl.NewSimpleField(
-				"mountpoint",
-				etl.ExtractByJMESPath("usage.mountpoint"), etl.TransformNilString,
-			),
-			etl.NewSimpleField(
 				"device_type",
 				etl.ExtractByJMESPath("usage.fstype"), etl.TransformNilString,
 			),

--- a/pkg/unify-query/influxdb/influxdb_router.go
+++ b/pkg/unify-query/influxdb/influxdb_router.go
@@ -155,6 +155,12 @@ func (r *Router) Ping(ctx context.Context, timeout time.Duration, pingCount int)
 				log.Warnf(ctx, "do ping failed, error: %s", err)
 				continue
 			}
+			// 对于配置了账号密码的情况
+			// 此处用于兼容 influxdb 的 basic auth 认证
+			if v.Username != "" && v.Password != "" {
+				req.SetBasicAuth(v.Username, v.Password)
+			}
+
 			// 状态码 204 变更 read 跳出循环
 			// 否则持续走完 PingCount 结束
 			if resp.StatusCode == http.StatusNoContent {


### PR DESCRIPTION
1. 移除 transfer 3.8.x disk 指标中重复的 mountpoint 内容
2. unify-query 3.8.x 兼容 influxdb ping 开启认证的策略