### PR TITLE
feat: KubeEventConfig.Clean() 未调用 InitIdent() 导致 kubeevent 任务配置热更新失效 --story=132613570

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bkcodeai.json
 .codebuddy
 
 .claude
+.cursor

--- a/pkg/bkmonitorbeat/configs/kubeevent.go
+++ b/pkg/bkmonitorbeat/configs/kubeevent.go
@@ -47,7 +47,7 @@ func (c *KubeEventConfig) GetType() string {
 }
 
 func (c *KubeEventConfig) Clean() error {
-	return nil
+	return c.InitIdent()
 }
 
 func NewKubeEventConfig(root *Config) *KubeEventConfig {


### PR DESCRIPTION
close #1010158081132613570