### PR TITLE
fix(bkmonitorbeat): 兼容低版本节点管理资源限制渲染并补回开关逻辑

### DIFF
--- a/pkg/bkmonitorbeat/script/generate_support_files/write_root_conf_tpl.sh
+++ b/pkg/bkmonitorbeat/script/generate_support_files/write_root_conf_tpl.sh
@@ -51,9 +51,11 @@ EOF
 # ============================= Resource ==================================
 EOF
     cat <<EOF >> "$path"
-{% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
 resource_limit:
+{%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
+  enabled: false
+{%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
+{%- set resource_limit = resource_limit | default({}) -%}
   enabled: true
   cpu: {{
     [
@@ -73,7 +75,11 @@ resource_limit:
         resource_limit.get('mem', {}).get('max', 1000)
     ] | min | int
   }}
-{% endif %}
+{%- else %}
+  enabled: true
+  cpu: 1
+  mem: -1
+{%- endif %}
 
 EOF
   fi

--- a/pkg/bkmonitorbeat/support-files/templates/freebsd/x86_64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/freebsd/x86_64/etc/bkmonitorbeat.conf.tpl
@@ -28,9 +28,11 @@ logging.backups: 5
 
 
 # ============================= Resource ==================================
-{% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
 resource_limit:
+{%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
+  enabled: false
+{%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
+{%- set resource_limit = resource_limit | default({}) -%}
   enabled: true
   cpu: {{
     [
@@ -50,7 +52,11 @@ resource_limit:
         resource_limit.get('mem', {}).get('max', 1000)
     ] | min | int
   }}
-{% endif %}
+{%- else %}
+  enabled: true
+  cpu: 1
+  mem: -1
+{%- endif %}
 
 # ================================= Tasks =======================================
 bkmonitorbeat:

--- a/pkg/bkmonitorbeat/support-files/templates/linux/aarch64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/linux/aarch64/etc/bkmonitorbeat.conf.tpl
@@ -28,9 +28,11 @@ logging.backups: 5
 
 
 # ============================= Resource ==================================
-{% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
 resource_limit:
+{%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
+  enabled: false
+{%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
+{%- set resource_limit = resource_limit | default({}) -%}
   enabled: true
   cpu: {{
     [
@@ -50,7 +52,11 @@ resource_limit:
         resource_limit.get('mem', {}).get('max', 1000)
     ] | min | int
   }}
-{% endif %}
+{%- else %}
+  enabled: true
+  cpu: 1
+  mem: -1
+{%- endif %}
 
 # ================================= Tasks =======================================
 bkmonitorbeat:

--- a/pkg/bkmonitorbeat/support-files/templates/linux/x86/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/linux/x86/etc/bkmonitorbeat.conf.tpl
@@ -28,9 +28,11 @@ logging.backups: 5
 
 
 # ============================= Resource ==================================
-{% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
 resource_limit:
+{%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
+  enabled: false
+{%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
+{%- set resource_limit = resource_limit | default({}) -%}
   enabled: true
   cpu: {{
     [
@@ -50,7 +52,11 @@ resource_limit:
         resource_limit.get('mem', {}).get('max', 1000)
     ] | min | int
   }}
-{% endif %}
+{%- else %}
+  enabled: true
+  cpu: 1
+  mem: -1
+{%- endif %}
 
 # ================================= Tasks =======================================
 bkmonitorbeat:

--- a/pkg/bkmonitorbeat/support-files/templates/linux/x86_64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/linux/x86_64/etc/bkmonitorbeat.conf.tpl
@@ -28,9 +28,11 @@ logging.backups: 5
 
 
 # ============================= Resource ==================================
-{% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
 resource_limit:
+{%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
+  enabled: false
+{%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
+{%- set resource_limit = resource_limit | default({}) -%}
   enabled: true
   cpu: {{
     [
@@ -50,7 +52,11 @@ resource_limit:
         resource_limit.get('mem', {}).get('max', 1000)
     ] | min | int
   }}
-{% endif %}
+{%- else %}
+  enabled: true
+  cpu: 1
+  mem: -1
+{%- endif %}
 
 # ================================= Tasks =======================================
 bkmonitorbeat:

--- a/pkg/bkmonitorbeat/support-files/templates/windows/x86/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/windows/x86/etc/bkmonitorbeat.conf.tpl
@@ -28,9 +28,11 @@ logging.backups: 5
 
 
 # ============================= Resource ==================================
-{% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
 resource_limit:
+{%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
+  enabled: false
+{%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
+{%- set resource_limit = resource_limit | default({}) -%}
   enabled: true
   cpu: {{
     [
@@ -50,7 +52,11 @@ resource_limit:
         resource_limit.get('mem', {}).get('max', 1000)
     ] | min | int
   }}
-{% endif %}
+{%- else %}
+  enabled: true
+  cpu: 1
+  mem: -1
+{%- endif %}
 
 # ================================= Tasks =======================================
 bkmonitorbeat:

--- a/pkg/bkmonitorbeat/support-files/templates/windows/x86_64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/windows/x86_64/etc/bkmonitorbeat.conf.tpl
@@ -28,9 +28,11 @@ logging.backups: 5
 
 
 # ============================= Resource ==================================
-{% if cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
 resource_limit:
+{%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
+  enabled: false
+{%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
+{%- set resource_limit = resource_limit | default({}) -%}
   enabled: true
   cpu: {{
     [
@@ -50,7 +52,11 @@ resource_limit:
         resource_limit.get('mem', {}).get('max', 1000)
     ] | min | int
   }}
-{% endif %}
+{%- else %}
+  enabled: true
+  cpu: 1
+  mem: -1
+{%- endif %}
 
 # ================================= Tasks =======================================
 bkmonitorbeat:


### PR DESCRIPTION
1、低版本节点管理的cmdb_instance中没有bk_cpu与bk_mem字段，加个默认resource_limit兜底
2、将之前的资源限制开关补回来