### PR TITLE
feat(unify-query): v1beta1 configData Redis化改造 - SchemaProvider 动态配置加载 #1193

### DIFF
--- a/pkg/unify-query/cmd/root.go
+++ b/pkg/unify-query/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/define"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/service/cmdb"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/service/consul"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/service/featureFlag"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/service/http"
@@ -56,6 +57,7 @@ var rootCmd = &cobra.Command{
 		serviceList = []define.Service{
 			&consul.Service{},
 			&redis.Service{},
+			&cmdb.Service{},
 			&trace.Service{},
 			&influxdb.Service{},
 			&tsdb.Service{},

--- a/pkg/unify-query/cmdb/cmdb.go
+++ b/pkg/unify-query/cmdb/cmdb.go
@@ -14,9 +14,15 @@ import (
 )
 
 type CMDB interface {
-	// QueryResourceMatcher 获取目标的关键维度和值（instant 查询）
+	// QueryResourceMatcher 获取目标的关键维度和值（instant 查询），返回 []string 路径
 	QueryResourceMatcher(ctx context.Context, lookBackDelta, spaceUid string, ts string, target, source Resource, indexesMatcher, expandMatcher Matcher, expandShow bool, pathResource []Resource) (Resource, Matcher, []string, Resource, Matchers, error)
 
-	// QueryResourceMatcherRange 获取目标的关键维度和值（query_range 查询）
+	// QueryResourceMatcherRange 获取目标的关键维度和值（query_range 查询），返回 []string 路径
 	QueryResourceMatcherRange(ctx context.Context, lookBackDelta, spaceUid string, step string, startTs, endTs string, target, source Resource, indexesMatcher, expandMatcher Matcher, expandShow bool, pathResource []Resource) (Resource, Matcher, []string, Resource, []MatchersWithTimestamp, error)
+
+	// QueryDynamicPaths 获取目标的关键维度和值（instant 查询），返回 []PathV2 完整路径信息
+	QueryDynamicPaths(ctx context.Context, lookBackDelta, spaceUid string, ts string, target, source Resource, indexesMatcher, expandMatcher Matcher, expandShow bool, pathResource []Resource) (Resource, Matcher, []PathV2, Resource, Matchers, error)
+
+	// QueryDynamicPathsRange 获取目标的关键维度和值（query_range 查询），返回 []PathV2 完整路径信息
+	QueryDynamicPathsRange(ctx context.Context, lookBackDelta, spaceUid string, step string, startTs, endTs string, target, source Resource, indexesMatcher, expandMatcher Matcher, expandShow bool, pathResource []Resource) (Resource, Matcher, []PathV2, Resource, []MatchersWithTimestamp, error)
 }

--- a/pkg/unify-query/cmdb/schema_provider.go
+++ b/pkg/unify-query/cmdb/schema_provider.go
@@ -1,0 +1,85 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package cmdb
+
+import (
+	"errors"
+)
+
+// SchemaProvider 资源和关联定义的抽象接口
+// 用于从不同来源(静态配置、Redis等)获取资源类型定义和关联关系定义
+// 该接口定义在 cmdb 根包中，供 v1beta1 和 v1beta3 共同使用
+type SchemaProvider interface {
+	// GetResourceDefinition 获取单个资源定义
+	GetResourceDefinition(namespace, name string) (*ResourceDefinition, error)
+	// ListResourceDefinitions 列出指定命名空间下的所有资源定义
+	// 如果 namespace 为空字符串,返回全局资源定义
+	ListResourceDefinitions(namespace string) ([]*ResourceDefinition, error)
+	// GetRelationDefinition 获取单个关联定义
+	GetRelationDefinition(namespace, name string) (*RelationDefinition, error)
+	// ListRelationDefinitions 列出指定命名空间下的所有关联定义
+	// 如果 namespace 为空字符串,返回全局关联定义
+	ListRelationDefinitions(namespace string) ([]*RelationDefinition, error)
+}
+
+// ResourceDefinition 资源类型定义
+// 数据格式与 metadata (bk-monitor) 写入 Redis 的格式一致
+type ResourceDefinition struct {
+	Namespace string                 `json:"namespace"` // 命名空间(空字符串表示全局)
+	Name      string                 `json:"name"`      // 资源类型名称
+	Fields    []FieldDefinition      `json:"fields"`    // 字段定义列表
+	Labels    map[string]string      `json:"labels"`    // 标签
+	Spec      map[string]interface{} `json:"spec"`      // 原始 spec 数据
+}
+
+// FieldDefinition 字段定义
+type FieldDefinition struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+}
+
+// GetPrimaryKeys 获取主键字段列表(必填字段)
+func (rd *ResourceDefinition) GetPrimaryKeys() []string {
+	keys := make([]string, 0)
+	for _, field := range rd.Fields {
+		if field.Required {
+			keys = append(keys, field.Name)
+		}
+	}
+	return keys
+}
+
+// GetInfoFields 获取信息字段列表(非必填字段)
+func (rd *ResourceDefinition) GetInfoFields() []string {
+	fields := make([]string, 0)
+	for _, field := range rd.Fields {
+		if !field.Required {
+			fields = append(fields, field.Name)
+		}
+	}
+	return fields
+}
+
+// RelationDefinition 关联关系定义
+type RelationDefinition struct {
+	Namespace    string                 `json:"namespace"`     // 命名空间
+	Name         string                 `json:"name"`          // 关联名称
+	FromResource string                 `json:"from_resource"` // 源资源类型
+	ToResource   string                 `json:"to_resource"`   // 目标资源类型
+	Category     string                 `json:"category"`      // 关联类别: static/dynamic
+	IsBelongsTo  bool                   `json:"is_belongs_to"` // 是否为从属关系
+	Labels       map[string]string      `json:"labels"`        // 标签
+	Spec         map[string]interface{} `json:"spec"`          // 原始 spec 数据
+}
+
+var (
+	ErrResourceDefinitionNotFound = errors.New("resource definition not found")
+	ErrRelationDefinitionNotFound = errors.New("relation definition not found")
+)

--- a/pkg/unify-query/cmdb/schema_provider_test.go
+++ b/pkg/unify-query/cmdb/schema_provider_test.go
@@ -1,0 +1,42 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package cmdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceDefinition_GetPrimaryKeys(t *testing.T) {
+	rd := &ResourceDefinition{
+		Fields: []FieldDefinition{
+			{Name: "a", Required: true},
+			{Name: "b", Required: false},
+			{Name: "c", Required: true},
+		},
+	}
+
+	keys := rd.GetPrimaryKeys()
+	assert.Equal(t, []string{"a", "c"}, keys)
+}
+
+func TestResourceDefinition_GetInfoFields(t *testing.T) {
+	rd := &ResourceDefinition{
+		Fields: []FieldDefinition{
+			{Name: "a", Required: true},
+			{Name: "b", Required: false},
+			{Name: "c", Required: false},
+		},
+	}
+
+	fields := rd.GetInfoFields()
+	assert.Equal(t, []string{"b", "c"}, fields)
+}

--- a/pkg/unify-query/cmdb/struct.go
+++ b/pkg/unify-query/cmdb/struct.go
@@ -32,11 +32,58 @@ type Relation struct {
 	V []Resource
 }
 
-// Path 关联路径
+// Path 关联路径 (v1)
 type Path []Relation
 
 // Paths 多组关联路径
 type Paths []Path
+
+// ========================================
+// V2 路径类型定义
+// ========================================
+
+// PathStepV2 路径中的一步 (v2)
+type PathStepV2 struct {
+	ResourceType string `json:"resource_type"`           // 资源类型
+	RelationType string `json:"relation_type,omitempty"` // 到达该资源的关系类型（第一步为空）
+	Category     string `json:"category,omitempty"`      // 关系类别
+	Direction    string `json:"direction,omitempty"`     // 遍历方向
+}
+
+// PathV2 一条完整的路径 (v2)
+type PathV2 struct {
+	Steps []PathStepV2 `json:"steps"`
+}
+
+// String 返回路径的字符串表示
+func (p *PathV2) String() string {
+	if len(p.Steps) == 0 {
+		return ""
+	}
+	result := p.Steps[0].ResourceType
+	for i := 1; i < len(p.Steps); i++ {
+		result += " -> " + p.Steps[i].ResourceType
+	}
+	return result
+}
+
+// ToResourceTypes 返回路径中的资源类型列表
+func (p *PathV2) ToResourceTypes() []string {
+	types := make([]string, len(p.Steps))
+	for i, step := range p.Steps {
+		types[i] = step.ResourceType
+	}
+	return types
+}
+
+// ToStringSlice 返回路径的字符串切片表示
+func (p *PathV2) ToStringSlice() []string {
+	result := make([]string, len(p.Steps))
+	for i, step := range p.Steps {
+		result[i] = step.ResourceType
+	}
+	return result
+}
 
 // RelationMultiResourceRequest 请求参数
 type RelationMultiResourceRequest struct {
@@ -110,4 +157,38 @@ type RelationMultiResourceRangeResponseData struct {
 type RelationMultiResourceRangeResponse struct {
 	TraceID string                                   `json:"trace_id"`
 	Data    []RelationMultiResourceRangeResponseData `json:"data"`
+}
+
+type RelationMultiResourceResponseDataV2 struct {
+	Code int `json:"code"`
+
+	SourceType Resource `json:"source_type"`
+	SourceInfo Matcher  `json:"source_info"`
+	TargetType Resource `json:"target_type"`
+
+	TargetList Matchers `json:"target_list"`
+	Path       []PathV2 `json:"path"`
+	Message    string   `json:"message"`
+}
+
+type RelationMultiResourceResponseV2 struct {
+	TraceID string                                `json:"trace_id"`
+	Data    []RelationMultiResourceResponseDataV2 `json:"data"`
+}
+
+type RelationMultiResourceRangeResponseDataV2 struct {
+	Code int `json:"code"`
+
+	SourceType Resource `json:"source_type"`
+	SourceInfo Matcher  `json:"source_info"`
+	TargetType Resource `json:"target_type"`
+
+	TargetList []MatchersWithTimestamp `json:"target_list"`
+	Path       []PathV2                `json:"path"`
+	Message    string                  `json:"message"`
+}
+
+type RelationMultiResourceRangeResponseV2 struct {
+	TraceID string                                     `json:"trace_id"`
+	Data    []RelationMultiResourceRangeResponseDataV2 `json:"data"`
 }

--- a/pkg/unify-query/cmdb/v1beta1/config.go
+++ b/pkg/unify-query/cmdb/v1beta1/config.go
@@ -9,7 +9,11 @@
 
 package v1beta1
 
-import "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+import (
+	"sync"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
 
 var configData = &Config{
 	Resource: []ResourceConf{
@@ -344,6 +348,7 @@ var configData = &Config{
 }
 
 var resourceConfig = make(map[cmdb.Resource]ResourceConf)
+var resourceConfigMu sync.RWMutex
 
 func init() {
 	for _, c := range configData.Resource {
@@ -351,7 +356,20 @@ func init() {
 	}
 }
 
+// updateResourceConfig 更新资源配置映射（当配置来自 SchemaProvider 时使用）
+func updateResourceConfig(cfg *Config) {
+	resourceConfigMu.Lock()
+	defer resourceConfigMu.Unlock()
+	newConfig := make(map[cmdb.Resource]ResourceConf, len(cfg.Resource))
+	for _, c := range cfg.Resource {
+		newConfig[c.Name] = c
+	}
+	resourceConfig = newConfig
+}
+
 func ResourcesIndex(resources ...cmdb.Resource) cmdb.Index {
+	resourceConfigMu.RLock()
+	defer resourceConfigMu.RUnlock()
 	var index cmdb.Index
 	for _, r := range resources {
 		index = append(index, resourceConfig[r].Index...)
@@ -360,6 +378,8 @@ func ResourcesIndex(resources ...cmdb.Resource) cmdb.Index {
 }
 
 func ResourcesInfo(resources ...cmdb.Resource) cmdb.Index {
+	resourceConfigMu.RLock()
+	defer resourceConfigMu.RUnlock()
 	var index []string
 	for _, r := range resources {
 		index = append(index, resourceConfig[r].Info...)
@@ -368,5 +388,7 @@ func ResourcesInfo(resources ...cmdb.Resource) cmdb.Index {
 }
 
 func AllResources() map[cmdb.Resource]ResourceConf {
+	resourceConfigMu.RLock()
+	defer resourceConfigMu.RUnlock()
 	return resourceConfig
 }

--- a/pkg/unify-query/cmdb/v1beta1/config_adapter.go
+++ b/pkg/unify-query/cmdb/v1beta1/config_adapter.go
@@ -1,0 +1,136 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
+)
+
+// ConfigAdapter 将 SchemaProvider 的数据转换为 v1beta1 Config 格式
+type ConfigAdapter struct {
+	provider cmdb.SchemaProvider
+}
+
+// NewConfigAdapter 创建 ConfigAdapter
+func NewConfigAdapter(provider cmdb.SchemaProvider) *ConfigAdapter {
+	return &ConfigAdapter{
+		provider: provider,
+	}
+}
+
+// GetConfig 从 SchemaProvider 获取数据并转换为 v1beta1 Config
+// namespace 为空字符串时获取全局配置
+//
+// 注意：v1beta1 没有 namespace 概念，因此会按资源/关联 Name 去重，
+// 跨 namespace 出现相同 Name 时只保留第一个。
+func (ca *ConfigAdapter) GetConfig(ctx context.Context, namespace string) (*Config, error) {
+	resources, err := ca.provider.ListResourceDefinitions(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("list resource definitions error: %w", err)
+	}
+
+	relations, err := ca.provider.ListRelationDefinitions(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("list relation definitions error: %w", err)
+	}
+
+	if len(resources) == 0 && len(relations) == 0 {
+		return nil, fmt.Errorf("no resource or relation definitions found for namespace %q", namespace)
+	}
+
+	cfg := &Config{
+		Resource: make([]ResourceConf, 0, len(resources)),
+		Relation: make([]RelationConf, 0, len(relations)),
+	}
+
+	// v1beta1 没有 namespace 概念，按 Name 去重（跨 namespace 相同资源只保留第一个）
+	seenResource := make(map[string]bool, len(resources))
+	for _, rd := range resources {
+		if seenResource[rd.Name] {
+			log.Debugf(ctx, "skip duplicate resource %q (namespace=%s), already seen", rd.Name, rd.Namespace)
+			continue
+		}
+		seenResource[rd.Name] = true
+		cfg.Resource = append(cfg.Resource, convertResourceDefinition(rd))
+	}
+
+	// 关联也按边去重，避免跨 namespace 重复的边
+	// v1beta1 使用无向图，所以 "pod->node" 和 "node->pod" 是同一条边
+	seenRelation := make(map[string]bool, len(relations))
+	for _, rd := range relations {
+		relConf, convertErr := convertRelationDefinition(rd)
+		if convertErr != nil {
+			log.Warnf(ctx, "skip relation %s: %v", rd.Name, convertErr)
+			continue
+		}
+		edgeKey := undirectedEdgeKey(rd.FromResource, rd.ToResource)
+		if seenRelation[edgeKey] {
+			log.Debugf(ctx, "skip duplicate relation %q (namespace=%s), edge %s already seen", rd.Name, rd.Namespace, edgeKey)
+			continue
+		}
+		seenRelation[edgeKey] = true
+		cfg.Relation = append(cfg.Relation, relConf)
+	}
+
+	return cfg, nil
+}
+
+// convertResourceDefinition 将 cmdb.ResourceDefinition 转换为 v1beta1 ResourceConf
+// 映射规则:
+//   - FieldDefinition.Required=true  → Index（主键/索引字段）
+//   - FieldDefinition.Required=false → Info（信息字段）
+func convertResourceDefinition(rd *cmdb.ResourceDefinition) ResourceConf {
+	var index cmdb.Index
+	var info cmdb.Index
+
+	for _, field := range rd.Fields {
+		if field.Required {
+			index = append(index, field.Name)
+		} else {
+			info = append(info, field.Name)
+		}
+	}
+
+	return ResourceConf{
+		Name:  cmdb.Resource(rd.Name),
+		Index: index,
+		Info:  info,
+	}
+}
+
+// convertRelationDefinition 将 cmdb.RelationDefinition 转换为 v1beta1 RelationConf
+// 映射规则:
+//   - FromResource → Resources[0]
+//   - ToResource   → Resources[1]
+func convertRelationDefinition(rd *cmdb.RelationDefinition) (RelationConf, error) {
+	if rd.FromResource == "" || rd.ToResource == "" {
+		return RelationConf{}, fmt.Errorf("from_resource or to_resource is empty")
+	}
+
+	return RelationConf{
+		Resources: []cmdb.Resource{
+			cmdb.Resource(rd.FromResource),
+			cmdb.Resource(rd.ToResource),
+		},
+	}, nil
+}
+
+// undirectedEdgeKey 生成无向边的去重 key
+// v1beta1 graph 是无向图，"a->b" 和 "b->a" 是同一条边
+func undirectedEdgeKey(a, b string) string {
+	if a > b {
+		a, b = b, a
+	}
+	return a + "<>" + b
+}

--- a/pkg/unify-query/cmdb/v1beta1/config_adapter_test.go
+++ b/pkg/unify-query/cmdb/v1beta1/config_adapter_test.go
@@ -1,0 +1,312 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+// mockSchemaProvider 简单 mock 实现 cmdb.SchemaProvider
+type mockSchemaProvider struct {
+	resources []*cmdb.ResourceDefinition
+	relations []*cmdb.RelationDefinition
+}
+
+func (m *mockSchemaProvider) GetResourceDefinition(namespace, name string) (*cmdb.ResourceDefinition, error) {
+	for _, r := range m.resources {
+		if r.Namespace == namespace && r.Name == name {
+			return r, nil
+		}
+	}
+	return nil, cmdb.ErrResourceDefinitionNotFound
+}
+
+func (m *mockSchemaProvider) ListResourceDefinitions(namespace string) ([]*cmdb.ResourceDefinition, error) {
+	result := make([]*cmdb.ResourceDefinition, 0)
+	for _, r := range m.resources {
+		if r.Namespace == namespace || namespace == "" {
+			result = append(result, r)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockSchemaProvider) GetRelationDefinition(namespace, name string) (*cmdb.RelationDefinition, error) {
+	for _, r := range m.relations {
+		if r.Namespace == namespace && r.Name == name {
+			return r, nil
+		}
+	}
+	return nil, cmdb.ErrRelationDefinitionNotFound
+}
+
+func (m *mockSchemaProvider) ListRelationDefinitions(namespace string) ([]*cmdb.RelationDefinition, error) {
+	result := make([]*cmdb.RelationDefinition, 0)
+	for _, r := range m.relations {
+		if r.Namespace == namespace || namespace == "" {
+			result = append(result, r)
+		}
+	}
+	return result, nil
+}
+
+func TestConfigAdapter_GetConfig(t *testing.T) {
+	provider := &mockSchemaProvider{
+		resources: []*cmdb.ResourceDefinition{
+			{
+				Namespace: "",
+				Name:      "pod",
+				Fields: []cmdb.FieldDefinition{
+					{Name: "bcs_cluster_id", Required: true},
+					{Name: "namespace", Required: true},
+					{Name: "pod", Required: true},
+				},
+			},
+			{
+				Namespace: "",
+				Name:      "node",
+				Fields: []cmdb.FieldDefinition{
+					{Name: "bcs_cluster_id", Required: true},
+					{Name: "node", Required: true},
+				},
+			},
+			{
+				Namespace: "",
+				Name:      "host",
+				Fields: []cmdb.FieldDefinition{
+					{Name: "bk_host_id", Required: true},
+					{Name: "version", Required: false},
+					{Name: "env_name", Required: false},
+				},
+			},
+		},
+		relations: []*cmdb.RelationDefinition{
+			{
+				Namespace:    "",
+				Name:         "node_with_pod",
+				FromResource: "node",
+				ToResource:   "pod",
+				Category:     "static",
+			},
+			{
+				Namespace:    "",
+				Name:         "host_with_system",
+				FromResource: "host",
+				ToResource:   "system",
+				Category:     "static",
+			},
+		},
+	}
+
+	adapter := NewConfigAdapter(provider)
+	cfg, err := adapter.GetConfig(context.Background(), "")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// 验证资源数量
+	assert.Len(t, cfg.Resource, 3)
+
+	// 验证资源转换
+	resourceMap := make(map[cmdb.Resource]ResourceConf)
+	for _, r := range cfg.Resource {
+		resourceMap[r.Name] = r
+	}
+
+	// pod: 3 个 required 字段 → 3 个 Index, 0 个 Info
+	podConf := resourceMap["pod"]
+	assert.Equal(t, cmdb.Resource("pod"), podConf.Name)
+	assert.Equal(t, cmdb.Index{"bcs_cluster_id", "namespace", "pod"}, podConf.Index)
+	assert.Nil(t, podConf.Info)
+
+	// node: 2 个 required 字段
+	nodeConf := resourceMap["node"]
+	assert.Equal(t, cmdb.Resource("node"), nodeConf.Name)
+	assert.Equal(t, cmdb.Index{"bcs_cluster_id", "node"}, nodeConf.Index)
+	assert.Nil(t, nodeConf.Info)
+
+	// host: 1 个 required + 2 个 optional → Index + Info
+	hostConf := resourceMap["host"]
+	assert.Equal(t, cmdb.Resource("host"), hostConf.Name)
+	assert.Equal(t, cmdb.Index{"bk_host_id"}, hostConf.Index)
+	assert.Equal(t, cmdb.Index{"version", "env_name"}, hostConf.Info)
+
+	// 验证关联数量和内容
+	assert.Len(t, cfg.Relation, 2)
+
+	relMap := make(map[string]RelationConf)
+	for _, r := range cfg.Relation {
+		key := string(r.Resources[0]) + "_" + string(r.Resources[1])
+		relMap[key] = r
+	}
+
+	nodePodRel := relMap["node_pod"]
+	assert.Equal(t, cmdb.Resource("node"), nodePodRel.Resources[0])
+	assert.Equal(t, cmdb.Resource("pod"), nodePodRel.Resources[1])
+}
+
+func TestConfigAdapter_GetConfig_EmptyProvider(t *testing.T) {
+	provider := &mockSchemaProvider{
+		resources: []*cmdb.ResourceDefinition{},
+		relations: []*cmdb.RelationDefinition{},
+	}
+
+	adapter := NewConfigAdapter(provider)
+	_, err := adapter.GetConfig(context.Background(), "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no resource or relation definitions found")
+}
+
+func TestConfigAdapter_GetConfig_SkipInvalidRelation(t *testing.T) {
+	provider := &mockSchemaProvider{
+		resources: []*cmdb.ResourceDefinition{
+			{
+				Namespace: "",
+				Name:      "pod",
+				Fields:    []cmdb.FieldDefinition{{Name: "pod", Required: true}},
+			},
+		},
+		relations: []*cmdb.RelationDefinition{
+			{
+				Namespace:    "",
+				Name:         "valid_rel",
+				FromResource: "pod",
+				ToResource:   "node",
+			},
+			{
+				Namespace:    "",
+				Name:         "invalid_rel",
+				FromResource: "",
+				ToResource:   "node",
+			},
+		},
+	}
+
+	adapter := NewConfigAdapter(provider)
+	cfg, err := adapter.GetConfig(context.Background(), "")
+	require.NoError(t, err)
+	// invalid relation should be skipped
+	assert.Len(t, cfg.Relation, 1)
+	assert.Equal(t, cmdb.Resource("pod"), cfg.Relation[0].Resources[0])
+}
+
+func TestConfigAdapter_GetConfig_DeduplicateByName(t *testing.T) {
+	// 模拟跨 namespace 出现同名资源和同边关联的场景（Redis 返回多个 namespace 的数据）
+	provider := &mockSchemaProvider{
+		resources: []*cmdb.ResourceDefinition{
+			{Namespace: "bkcc__2", Name: "pod", Fields: []cmdb.FieldDefinition{{Name: "pod", Required: true}}},
+			{Namespace: "bkcc__3", Name: "pod", Fields: []cmdb.FieldDefinition{{Name: "pod", Required: true}}},
+			{Namespace: "__all__", Name: "pod", Fields: []cmdb.FieldDefinition{{Name: "pod", Required: true}}},
+			{Namespace: "bkcc__2", Name: "node", Fields: []cmdb.FieldDefinition{{Name: "node", Required: true}}},
+			{Namespace: "__all__", Name: "node", Fields: []cmdb.FieldDefinition{{Name: "node", Required: true}}},
+		},
+		relations: []*cmdb.RelationDefinition{
+			{Namespace: "bkcc__2", Name: "node_with_pod", FromResource: "node", ToResource: "pod"},
+			{Namespace: "bkcc__3", Name: "node_with_pod", FromResource: "node", ToResource: "pod"},
+			{Namespace: "__all__", Name: "node_with_pod", FromResource: "node", ToResource: "pod"},
+		},
+	}
+
+	adapter := NewConfigAdapter(provider)
+	cfg, err := adapter.GetConfig(context.Background(), "")
+	require.NoError(t, err)
+
+	// 应该只有 2 个去重后的资源
+	assert.Len(t, cfg.Resource, 2)
+	// 应该只有 1 个去重后的关联
+	assert.Len(t, cfg.Relation, 1)
+}
+
+func TestConfigAdapter_GetConfig_DeduplicateUndirectedEdge(t *testing.T) {
+	// v1beta1 使用无向图，"pod->node" 和 "node->pod" 是同一条边
+	// 模拟 Redis 有 pod->node，Static 有 node->pod 的情况
+	provider := &mockSchemaProvider{
+		resources: []*cmdb.ResourceDefinition{
+			{Namespace: "", Name: "pod", Fields: []cmdb.FieldDefinition{{Name: "pod", Required: true}}},
+			{Namespace: "", Name: "node", Fields: []cmdb.FieldDefinition{{Name: "node", Required: true}}},
+		},
+		relations: []*cmdb.RelationDefinition{
+			{Namespace: "__all__", Name: "global_pod_to_node", FromResource: "pod", ToResource: "node"},
+			{Namespace: "", Name: "node_with_pod", FromResource: "node", ToResource: "pod"},
+		},
+	}
+
+	adapter := NewConfigAdapter(provider)
+	cfg, err := adapter.GetConfig(context.Background(), "")
+	require.NoError(t, err)
+
+	// pod->node 和 node->pod 在无向图中是同一条边，应只保留 1 个
+	assert.Len(t, cfg.Relation, 1)
+}
+
+func TestConvertResourceDefinition(t *testing.T) {
+	rd := &cmdb.ResourceDefinition{
+		Namespace: "",
+		Name:      "container",
+		Fields: []cmdb.FieldDefinition{
+			{Name: "bcs_cluster_id", Required: true},
+			{Name: "namespace", Required: true},
+			{Name: "pod", Required: true},
+			{Name: "container", Required: true},
+			{Name: "version", Required: false},
+		},
+	}
+
+	conf := convertResourceDefinition(rd)
+	assert.Equal(t, cmdb.Resource("container"), conf.Name)
+	assert.Equal(t, cmdb.Index{"bcs_cluster_id", "namespace", "pod", "container"}, conf.Index)
+	assert.Equal(t, cmdb.Index{"version"}, conf.Info)
+}
+
+func TestConvertRelationDefinition(t *testing.T) {
+	t.Run("valid relation", func(t *testing.T) {
+		rd := &cmdb.RelationDefinition{
+			Namespace:    "",
+			Name:         "node_with_system",
+			FromResource: "node",
+			ToResource:   "system",
+		}
+
+		conf, err := convertRelationDefinition(rd)
+		require.NoError(t, err)
+		assert.Len(t, conf.Resources, 2)
+		assert.Equal(t, cmdb.Resource("node"), conf.Resources[0])
+		assert.Equal(t, cmdb.Resource("system"), conf.Resources[1])
+	})
+
+	t.Run("empty from_resource", func(t *testing.T) {
+		rd := &cmdb.RelationDefinition{
+			Namespace:    "",
+			Name:         "bad_rel",
+			FromResource: "",
+			ToResource:   "node",
+		}
+
+		_, err := convertRelationDefinition(rd)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty to_resource", func(t *testing.T) {
+		rd := &cmdb.RelationDefinition{
+			Namespace:    "",
+			Name:         "bad_rel",
+			FromResource: "node",
+			ToResource:   "",
+		}
+
+		_, err := convertRelationDefinition(rd)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/unify-query/cmdb/v1beta1/query_maker.go
+++ b/pkg/unify-query/cmdb/v1beta1/query_maker.go
@@ -162,7 +162,7 @@ func (q *QueryFactory) buildInfoQuery(resource cmdb.Resource, indexMatcher, expa
 
 	allIndex := ResourcesIndex(resource)
 
-	field := fmt.Sprintf("%s_info_relation", resource)
+	field := fmt.Sprintf("%s_info_relation_value", resource)
 	ref := string(rune(ascii + q.index))
 	query = &structured.Query{
 		FieldName:     field,
@@ -190,7 +190,7 @@ func (q *QueryFactory) buildRelationQueries(path cmdb.Relation) (queries []*stru
 
 	resources := []string{string(source), string(target)}
 	sort.Strings(resources)
-	field := fmt.Sprintf("%s_relation", strings.Join(resources, "_with_"))
+	field := fmt.Sprintf("%s_relation_value", strings.Join(resources, "_with_"))
 
 	ref := string(rune(ascii + q.index))
 

--- a/pkg/unify-query/cmdb/v1beta1/v1beta1.go
+++ b/pkg/unify-query/cmdb/v1beta1/v1beta1.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/query"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/query/promql"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
@@ -35,15 +36,28 @@ const (
 )
 
 var (
-	mdl *model
-	mtx sync.Mutex
+	mdl      *model
+	mtx      sync.Mutex
+	provider cmdb.SchemaProvider
 )
+
+// InitSchemaProvider 初始化 SchemaProvider，应在服务启动时（Redis 初始化之后）调用
+// 设置后，GetModel 会优先从 SchemaProvider 获取配置，获取失败则回退到硬编码 configData
+func InitSchemaProvider(p cmdb.SchemaProvider) {
+	mtx.Lock()
+	defer mtx.Unlock()
+	provider = p
+	// 重置 model，下次 GetModel 调用时会用新的 provider 重建
+	mdl = nil
+}
 
 func GetModel(ctx context.Context) (cmdb.CMDB, error) {
 	var err error
 	if mdl == nil {
 		mtx.Lock()
-		mdl, err = newModel(ctx)
+		if mdl == nil {
+			mdl, err = newModel(ctx)
+		}
 		mtx.Unlock()
 	}
 	return mdl, err
@@ -56,11 +70,65 @@ type model struct {
 }
 
 // newModel 初始化
+// 优先从 SchemaProvider 获取配置，失败则回退到硬编码 configData
 func newModel(ctx context.Context) (*model, error) {
 	var (
-		err error
-		cfg = configData
+		err        error
+		cfg        *Config
+		configSource string
 	)
+
+	ctx, span := trace.NewSpan(ctx, "v1beta1-new-model")
+	defer span.End(&err)
+
+	// 尝试从 SchemaProvider 获取动态配置
+	if provider != nil {
+		span.Set("schema_provider.available", true)
+		adapter := NewConfigAdapter(provider)
+		cfg, err = adapter.GetConfig(ctx, "")
+		if err != nil {
+			log.Warnf(ctx, "failed to get config from SchemaProvider, falling back to hardcoded config: %v", err)
+			span.Set("schema_provider.error", err.Error())
+			cfg = nil
+			err = nil // 清除错误，允许回退
+		} else {
+			configSource = "schema_provider"
+			log.Infof(ctx, "v1beta1 model loaded from SchemaProvider: %d resources, %d relations",
+				len(cfg.Resource), len(cfg.Relation))
+		}
+	} else {
+		span.Set("schema_provider.available", false)
+	}
+
+	// 回退到硬编码配置
+	if cfg == nil {
+		cfg = configData
+		configSource = "hardcoded"
+		log.Infof(ctx, "v1beta1 model using hardcoded config: %d resources, %d relations",
+			len(cfg.Resource), len(cfg.Relation))
+	}
+
+	// 记录 trace 信息：配置来源、资源/关联数量和名称
+	span.Set("config_source", configSource)
+	span.Set("resource_count", len(cfg.Resource))
+	span.Set("relation_count", len(cfg.Relation))
+
+	resourceNames := make([]string, 0, len(cfg.Resource))
+	for _, r := range cfg.Resource {
+		resourceNames = append(resourceNames, string(r.Name))
+	}
+	span.Set("resource_names", resourceNames)
+
+	relationNames := make([]string, 0, len(cfg.Relation))
+	for _, r := range cfg.Relation {
+		if len(r.Resources) == 2 {
+			relationNames = append(relationNames, fmt.Sprintf("%s->%s", r.Resources[0], r.Resources[1]))
+		}
+	}
+	span.Set("relation_names", relationNames)
+
+	// 更新全局 resourceConfig 映射（供 ResourcesIndex/ResourcesInfo/AllResources 使用）
+	updateResourceConfig(cfg)
 
 	// 初始化 graph 存储结构
 	g := graph.New(graph.StringHash)
@@ -508,4 +576,44 @@ func shimMatcherWithTimestamp(matchers []cmdb.MatchersWithTimestamp) cmdb.Matche
 
 	pick := matchers[len(matchers)-1]
 	return pick.Matchers
+}
+
+func (r *model) QueryDynamicPaths(ctx context.Context, lookBackDelta, spaceUid string, timestamp string, target, source cmdb.Resource, indexesMatcher, expandMatcher cmdb.Matcher, expandShow bool, pathResource []cmdb.Resource) (cmdb.Resource, cmdb.Matcher, []cmdb.PathV2, cmdb.Resource, cmdb.Matchers, error) {
+	resSource, resIndexMatcher, pathStrings, resTarget, resMatchers, err := r.QueryResourceMatcher(ctx, lookBackDelta, spaceUid, timestamp, target, source, indexesMatcher, expandMatcher, expandShow, pathResource)
+	if err != nil {
+		return resSource, resIndexMatcher, nil, resTarget, resMatchers, err
+	}
+
+	return resSource, resIndexMatcher, convertStringsToPathsV2(pathStrings), resTarget, resMatchers, nil
+}
+
+func (r *model) QueryDynamicPathsRange(ctx context.Context, lookBackDelta, spaceUid string, step string, startTs, endTs string, target, source cmdb.Resource, indexesMatcher, expandMatcher cmdb.Matcher, expandShow bool, pathResource []cmdb.Resource) (cmdb.Resource, cmdb.Matcher, []cmdb.PathV2, cmdb.Resource, []cmdb.MatchersWithTimestamp, error) {
+	resSource, resIndexMatcher, pathStrings, resTarget, result, err := r.QueryResourceMatcherRange(ctx, lookBackDelta, spaceUid, step, startTs, endTs, target, source, indexesMatcher, expandMatcher, expandShow, pathResource)
+	if err != nil {
+		return resSource, resIndexMatcher, nil, resTarget, result, err
+	}
+
+	return resSource, resIndexMatcher, convertStringsToPathsV2(pathStrings), resTarget, result, nil
+}
+
+func convertStringsToPathsV2(pathStrings []string) []cmdb.PathV2 {
+	if len(pathStrings) == 0 {
+		return nil
+	}
+
+	pathsV2 := make([]cmdb.PathV2, len(pathStrings))
+	for i, pathStr := range pathStrings {
+		// pathStr 格式为 "resource1 -> resource2 -> resource3"
+		// 将其转换为 PathV2 结构
+		pathV2 := cmdb.PathV2{
+			Steps: []cmdb.PathStepV2{
+				{
+					ResourceType: pathStr,
+					// v1beta1 没有详细的关系类型信息，只存储完整路径字符串
+				},
+			},
+		}
+		pathsV2[i] = pathV2
+	}
+	return pathsV2
 }

--- a/pkg/unify-query/cmdb/v1beta3/composite_provider.go
+++ b/pkg/unify-query/cmdb/v1beta3/composite_provider.go
@@ -1,0 +1,266 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+)
+
+// CompositeSchemaProvider 组合 Schema 提供器
+// 支持多个提供器的级联查找，按优先级顺序查询
+// 典型用法：RedisSchemaProvider(高优先级) -> StaticSchemaProvider(兜底)
+type CompositeSchemaProvider struct {
+	providers []SchemaProvider // 按优先级排序，索引越小优先级越高
+	mu        sync.RWMutex
+	ctx       context.Context
+}
+
+// NewCompositeSchemaProvider 创建组合 Schema 提供器
+// providers 参数按优先级顺序传入，索引越小优先级越高
+// 例如: NewCompositeSchemaProvider(redisProvider, staticProvider)
+// 会先查询 redisProvider，如果找不到再查询 staticProvider
+func NewCompositeSchemaProvider(providers ...SchemaProvider) *CompositeSchemaProvider {
+	return &CompositeSchemaProvider{
+		providers: providers,
+		ctx:       context.Background(),
+	}
+}
+
+// AddProvider 添加提供器（追加到最低优先级）
+func (csp *CompositeSchemaProvider) AddProvider(provider SchemaProvider) {
+	csp.mu.Lock()
+	defer csp.mu.Unlock()
+	csp.providers = append(csp.providers, provider)
+}
+
+// GetResourceDefinition 获取资源定义
+// 按优先级顺序查询各个提供器，返回第一个找到的结果
+func (csp *CompositeSchemaProvider) GetResourceDefinition(namespace, name string) (*cmdb.ResourceDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.get_resource_definition")
+	var err error
+	defer span.End(&err)
+
+	span.Set("resource.namespace", namespace)
+	span.Set("resource.name", name)
+	span.Set("providers.count", len(csp.providers))
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	var lastErr error
+	for i, provider := range csp.providers {
+		rd, providerErr := provider.GetResourceDefinition(namespace, name)
+		if providerErr == nil {
+			span.Set("provider.index", i)
+			return rd, nil
+		}
+		if !errors.Is(providerErr, cmdb.ErrResourceDefinitionNotFound) {
+			lastErr = providerErr
+		}
+	}
+
+	if lastErr != nil {
+		err = lastErr
+		return nil, err
+	}
+	err = cmdb.ErrResourceDefinitionNotFound
+	return nil, err
+}
+
+// ListResourceDefinitions 列出资源定义
+// 合并所有提供器的结果，去重（以高优先级为准）
+func (csp *CompositeSchemaProvider) ListResourceDefinitions(namespace string) ([]*cmdb.ResourceDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.list_resource_definitions")
+	var err error
+	defer span.End(&err)
+
+	span.Set("resource.namespace", namespace)
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	seen := make(map[string]bool) // key: namespace:name
+	result := make([]*cmdb.ResourceDefinition, 0)
+
+	for _, provider := range csp.providers {
+		list, listErr := provider.ListResourceDefinitions(namespace)
+		if listErr != nil {
+			continue
+		}
+
+		for _, rd := range list {
+			key := makeResourceCacheKey(rd.Namespace, rd.Name)
+			if !seen[key] {
+				seen[key] = true
+				result = append(result, rd)
+			}
+		}
+	}
+
+	span.Set("result.count", len(result))
+	return result, nil
+}
+
+// GetRelationDefinition 获取关联定义
+// 按优先级顺序查询各个提供器，返回第一个找到的结果
+func (csp *CompositeSchemaProvider) GetRelationDefinition(namespace, name string) (*cmdb.RelationDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.get_relation_definition")
+	var err error
+	defer span.End(&err)
+
+	span.Set("relation.namespace", namespace)
+	span.Set("relation.name", name)
+	span.Set("providers.count", len(csp.providers))
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	var lastErr error
+	for i, provider := range csp.providers {
+		rd, providerErr := provider.GetRelationDefinition(namespace, name)
+		if providerErr == nil {
+			span.Set("provider.index", i)
+			return rd, nil
+		}
+		if !errors.Is(providerErr, cmdb.ErrRelationDefinitionNotFound) {
+			lastErr = providerErr
+		}
+	}
+
+	if lastErr != nil {
+		err = lastErr
+		return nil, err
+	}
+	err = cmdb.ErrRelationDefinitionNotFound
+	return nil, err
+}
+
+// ListRelationDefinitions 列出关联定义
+// 合并所有提供器的结果，去重（以高优先级为准）
+func (csp *CompositeSchemaProvider) ListRelationDefinitions(namespace string) ([]*cmdb.RelationDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.list_relation_definitions")
+	var err error
+	defer span.End(&err)
+
+	span.Set("relation.namespace", namespace)
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	seen := make(map[string]bool) // key: namespace:name
+	result := make([]*cmdb.RelationDefinition, 0)
+
+	for _, provider := range csp.providers {
+		list, listErr := provider.ListRelationDefinitions(namespace)
+		if listErr != nil {
+			continue
+		}
+
+		for _, rd := range list {
+			key := makeRelationCacheKey(rd.Namespace, rd.Name)
+			if !seen[key] {
+				seen[key] = true
+				result = append(result, rd)
+			}
+		}
+	}
+
+	span.Set("result.count", len(result))
+	return result, nil
+}
+
+// GetResourcePrimaryKeys 获取资源主键字段列表
+// 按优先级顺序查询各个提供器，返回第一个非空结果
+func (csp *CompositeSchemaProvider) GetResourcePrimaryKeys(resourceType ResourceType) []string {
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	for _, provider := range csp.providers {
+		keys := provider.GetResourcePrimaryKeys(resourceType)
+		if len(keys) > 0 {
+			return keys
+		}
+	}
+
+	return []string{}
+}
+
+// GetRelationSchema 获取关联 Schema
+// 按优先级顺序查询各个提供器，返回第一个找到的结果
+func (csp *CompositeSchemaProvider) GetRelationSchema(relationType RelationType) (*RelationSchema, error) {
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	var lastErr error
+	for _, provider := range csp.providers {
+		schema, err := provider.GetRelationSchema(relationType)
+		if err == nil {
+			return schema, nil
+		}
+		if !errors.Is(err, cmdb.ErrRelationDefinitionNotFound) {
+			lastErr = err
+		}
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, cmdb.ErrRelationDefinitionNotFound
+}
+
+// ListRelationSchemas 列出所有关联 Schema
+// 合并所有提供器的结果，去重（以高优先级为准）
+func (csp *CompositeSchemaProvider) ListRelationSchemas() []RelationSchema {
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	seen := make(map[RelationType]bool)
+	result := make([]RelationSchema, 0)
+
+	for _, provider := range csp.providers {
+		schemas := provider.ListRelationSchemas()
+		for _, schema := range schemas {
+			if !seen[schema.RelationType] {
+				seen[schema.RelationType] = true
+				result = append(result, schema)
+			}
+		}
+	}
+
+	return result
+}
+
+// Ensure CompositeSchemaProvider implements SchemaProvider
+var _ SchemaProvider = (*CompositeSchemaProvider)(nil)
+
+// normalizeNamespaceForDedup 将空串 namespace 归一化为 __all__
+// Static Provider 使用空串作为全局 namespace，Redis Provider 使用 "__all__"
+// 在去重时需要统一，否则同一条关联/资源会因 namespace 不同而被认为是不同记录
+func normalizeNamespaceForDedup(namespace string) string {
+	if namespace == "" {
+		return NamespaceAll
+	}
+	return namespace
+}
+
+// makeResourceCacheKey 生成资源定义去重 key
+func makeResourceCacheKey(namespace, name string) string {
+	return normalizeNamespaceForDedup(namespace) + ":" + name
+}
+
+// makeRelationCacheKey 生成关联定义去重 key
+func makeRelationCacheKey(namespace, name string) string {
+	return normalizeNamespaceForDedup(namespace) + ":" + name
+}

--- a/pkg/unify-query/cmdb/v1beta3/composite_provider_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/composite_provider_test.go
@@ -1,0 +1,303 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+// TestCompositeSchemaProvider_Priority 测试优先级查询
+func TestCompositeSchemaProvider_Priority(t *testing.T) {
+	// 创建 StaticSchemaProvider（低优先级）
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider（高优先级）
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	// 在 Redis 中添加一个自定义资源（与静态资源重名）
+	customRd := &cmdb.ResourceDefinition{
+		Namespace: "",
+		Name:      "pod", // 与 StaticSchemaProvider 中的 pod 重名（注意是小写）
+		Fields: []cmdb.FieldDefinition{
+			{Name: "custom_field", Required: true}, // 不同的字段
+		},
+		Labels: map[string]string{"source": "redis"},
+	}
+	setResourceDefinitions(t, mr, "", customRd)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider：Redis 优先级高于 Static
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试查询 pod 资源，应该返回 Redis 中的版本
+	t.Run("HighPriorityWins", func(t *testing.T) {
+		rd, err := composite.GetResourceDefinition("", "pod")
+		require.NoError(t, err)
+		assert.Equal(t, "pod", rd.Name)
+		assert.Len(t, rd.Fields, 1)
+		assert.Equal(t, "custom_field", rd.Fields[0].Name)
+		assert.Equal(t, "redis", rd.Labels["source"])
+	})
+
+	// 测试查询只存在于 Static 中的资源
+	t.Run("FallbackToLowPriority", func(t *testing.T) {
+		rd, err := composite.GetResourceDefinition("", "node")
+		require.NoError(t, err)
+		assert.Equal(t, "node", rd.Name)
+	})
+
+	// 测试不存在的资源
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := composite.GetResourceDefinition("", "NonExistent")
+		assert.ErrorIs(t, err, cmdb.ErrResourceDefinitionNotFound)
+	})
+}
+
+// TestCompositeSchemaProvider_ListMerge 测试列表合并
+func TestCompositeSchemaProvider_ListMerge(t *testing.T) {
+	// 创建 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider 并添加自定义资源
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	customRd1 := &cmdb.ResourceDefinition{
+		Namespace: "custom",
+		Name:      "app_instance",
+		Fields:    []cmdb.FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	customRd2 := &cmdb.ResourceDefinition{
+		Namespace: "custom",
+		Name:      "git_commit",
+		Fields:    []cmdb.FieldDefinition{{Name: "commit_sha", Required: true}},
+	}
+
+	setResourceDefinitions(t, mr, "custom", customRd1, customRd2)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试列出全局资源（包含 Static 的所有资源）
+	t.Run("ListGlobalResources", func(t *testing.T) {
+		list, err := composite.ListResourceDefinitions("")
+		require.NoError(t, err)
+		assert.Greater(t, len(list), 0) // 应该包含 Static 中的资源
+	})
+
+	// 测试列出自定义命名空间的资源（只来自 Redis）
+	t.Run("ListCustomNamespace", func(t *testing.T) {
+		list, err := composite.ListResourceDefinitions("custom")
+		require.NoError(t, err)
+		assert.Len(t, list, 2)
+
+		names := make(map[string]bool)
+		for _, rd := range list {
+			names[rd.Name] = true
+		}
+		assert.True(t, names["app_instance"])
+		assert.True(t, names["git_commit"])
+	})
+}
+
+// TestCompositeSchemaProvider_RelationMerge 测试关联定义合并
+func TestCompositeSchemaProvider_RelationMerge(t *testing.T) {
+	// 创建 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider 并添加自定义关联
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	customRel := &cmdb.RelationDefinition{
+		Namespace:    "custom",
+		Name:         "app_to_commit",
+		FromResource: "app_instance",
+		ToResource:   "git_commit",
+		Category:     "dynamic",
+		IsBelongsTo:  false,
+	}
+
+	setRelationDefinitions(t, mr, "custom", customRel)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试获取自定义关联
+	t.Run("GetCustomRelation", func(t *testing.T) {
+		rd, err := composite.GetRelationDefinition("custom", "app_to_commit")
+		require.NoError(t, err)
+		assert.Equal(t, "app_to_commit", rd.Name)
+		assert.Equal(t, "dynamic", rd.Category)
+	})
+
+	// 测试获取静态关联
+	t.Run("GetStaticRelation", func(t *testing.T) {
+		list, _ := staticProvider.ListRelationDefinitions("")
+		if len(list) > 0 {
+			firstRelName := list[0].Name
+			rd, err := composite.GetRelationDefinition("", firstRelName)
+			require.NoError(t, err)
+			assert.Equal(t, firstRelName, rd.Name)
+		}
+	})
+
+	// 测试 ListRelationSchemas 合并
+	t.Run("ListRelationSchemas", func(t *testing.T) {
+		schemas := composite.ListRelationSchemas()
+		// 应该包含 Static 的所有 Schema + Redis 的自定义 Schema
+		assert.Greater(t, len(schemas), 0)
+
+		// 验证自定义关联存在
+		found := false
+		for _, schema := range schemas {
+			if schema.RelationType == "custom:app_to_commit" {
+				found = true
+				assert.Equal(t, RelationCategoryDynamic, schema.Category)
+				break
+			}
+		}
+		assert.True(t, found, "custom relation should be in the merged list")
+	})
+}
+
+// TestCompositeSchemaProvider_GetResourcePrimaryKeys 测试主键查询
+func TestCompositeSchemaProvider_GetResourcePrimaryKeys(t *testing.T) {
+	// 创建 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider 并添加自定义资源
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	customRd := &cmdb.ResourceDefinition{
+		Namespace: "custom",
+		Name:      "app",
+		Fields: []cmdb.FieldDefinition{
+			{Name: "app_id", Required: true},
+			{Name: "env", Required: true},
+		},
+	}
+
+	setResourceDefinitions(t, mr, "custom", customRd)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试获取自定义资源的主键
+	t.Run("CustomResourcePrimaryKeys", func(t *testing.T) {
+		keys := composite.GetResourcePrimaryKeys("app")
+		assert.Equal(t, []string{"app_id", "env"}, keys)
+	})
+
+	// 测试获取静态资源的主键
+	t.Run("StaticResourcePrimaryKeys", func(t *testing.T) {
+		keys := composite.GetResourcePrimaryKeys("pod")
+		assert.Greater(t, len(keys), 0)
+	})
+
+	// 测试不存在的资源
+	t.Run("NonExistentResource", func(t *testing.T) {
+		keys := composite.GetResourcePrimaryKeys("NonExistent")
+		assert.Empty(t, keys)
+	})
+}
+
+// TestCompositeSchemaProvider_EmptyProviders 测试空提供器列表
+func TestCompositeSchemaProvider_EmptyProviders(t *testing.T) {
+	composite := NewCompositeSchemaProvider()
+
+	t.Run("GetResourceDefinition", func(t *testing.T) {
+		_, err := composite.GetResourceDefinition("", "Pod")
+		assert.ErrorIs(t, err, cmdb.ErrResourceDefinitionNotFound)
+	})
+
+	t.Run("ListResourceDefinitions", func(t *testing.T) {
+		list, err := composite.ListResourceDefinitions("")
+		require.NoError(t, err)
+		assert.Empty(t, list)
+	})
+
+	t.Run("GetRelationSchema", func(t *testing.T) {
+		_, err := composite.GetRelationSchema("some_relation")
+		assert.ErrorIs(t, err, cmdb.ErrRelationDefinitionNotFound)
+	})
+
+	t.Run("ListRelationSchemas", func(t *testing.T) {
+		schemas := composite.ListRelationSchemas()
+		assert.Empty(t, schemas)
+	})
+}
+
+// TestCompositeSchemaProvider_AddProvider 测试动态添加提供器
+func TestCompositeSchemaProvider_AddProvider(t *testing.T) {
+	composite := NewCompositeSchemaProvider()
+
+	// 初始状态应该为空
+	_, err := composite.GetResourceDefinition("", "pod")
+	assert.ErrorIs(t, err, cmdb.ErrResourceDefinitionNotFound)
+
+	// 添加 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+	composite.AddProvider(staticProvider)
+
+	// 现在应该能找到资源了
+	rd, err := composite.GetResourceDefinition("", "pod")
+	require.NoError(t, err)
+	assert.Equal(t, "pod", rd.Name)
+}
+
+// TestCompositeSchemaProvider_Deduplication 测试去重逻辑
+func TestCompositeSchemaProvider_Deduplication(t *testing.T) {
+	// 创建两个 StaticSchemaProvider（包含相同的资源）
+	provider1 := NewStaticSchemaProvider()
+	provider2 := NewStaticSchemaProvider()
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(provider1, provider2)
+
+	// 列出所有资源
+	list, err := composite.ListResourceDefinitions("")
+	require.NoError(t, err)
+
+	// 检查是否有重复
+	seen := make(map[string]bool)
+	for _, rd := range list {
+		key := makeResourceCacheKey(rd.Namespace, rd.Name)
+		assert.False(t, seen[key], "duplicate resource found: %s", key)
+		seen[key] = true
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/graph_e2e_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/graph_e2e_test.go
@@ -1,0 +1,890 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// E2ETestCase 端到端测试用例
+// 完整测试流程：QueryRequest → SurrealQL → MockResponse → []*LivenessGraph
+type E2ETestCase struct {
+	Name           string           // 测试用例名称
+	QueryRequest   *QueryRequest    // 输入：查询请求
+	ExpectedSQL    string           // 期望：生成的 SurrealQL（完整匹配）
+	MockResponse   []map[string]any // Mock：SurrealDB 返回的响应
+	ExpectedGraphs []*LivenessGraph // 期望：解析后的 LivenessGraph 列表（每个起始实体一个图）
+}
+
+// 测试用例 1: Node 查询（单跳静态关系）- 关系数量可控
+func getNodeStaticTestCase() E2ETestCase {
+	return E2ETestCase{
+		Name: "Node_SingleHop_StaticOnly",
+		QueryRequest: &QueryRequest{
+			Timestamp:            600000,
+			SourceType:           ResourceTypeNode,
+			SourceInfo:           map[string]string{"bcs_cluster_id": "BCS-K8S-00001", "node": "node-1"},
+			MaxHops:              1,
+			AllowedRelationTypes: []RelationCategory{RelationCategoryStatic},
+			LookBackDelta:        600000,
+			Limit:                10,
+		},
+		ExpectedSQL: `LET $timestamp = 600000;
+LET $look_back_delta = 600000;
+LET $start = 0;
+LET $end = 600000;
+
+SELECT {
+    root: {
+        entity_type: meta::tb(id),
+        entity_id: <string>id,
+        entity_data: { bcs_cluster_id: bcs_cluster_id, node: node },
+        created_at: created_at,
+        updated_at: updated_at,
+        liveness: (SELECT * FROM node_liveness_record WHERE node_id = $parent.id AND period_end >= $start AND period_start <= $end)
+    },
+
+    hop1: {
+        node_with_system: (SELECT {
+            hop: 1,
+            relation_type: 'node_with_system',
+            relation_category: 'static',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM node_with_system_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'system',
+                entity_id: <string>target_id,
+                entity_data: { bk_cloud_id: target_id.bk_cloud_id, bk_target_ip: target_id.bk_target_ip },
+                liveness: (SELECT * FROM system_liveness_record WHERE system_id = $parent.target_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM node_with_system WHERE source_id = $parent.id
+          AND (SELECT count() FROM only node_with_system_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0),
+        node_with_pod: (SELECT {
+            hop: 1,
+            relation_type: 'node_with_pod',
+            relation_category: 'static',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'pod',
+                entity_id: <string>target_id,
+                entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod },
+                liveness: (SELECT * FROM pod_liveness_record WHERE pod_id = $parent.target_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM node_with_pod WHERE source_id = $parent.id
+          AND (SELECT count() FROM only node_with_pod_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0),
+        datasource_with_node: (SELECT {
+            hop: 1,
+            relation_type: 'datasource_with_node',
+            relation_category: 'static',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM datasource_with_node_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'datasource',
+                entity_id: <string>source_id,
+                entity_data: { bk_data_id: source_id.bk_data_id },
+                liveness: (SELECT * FROM datasource_liveness_record WHERE datasource_id = $parent.source_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM datasource_with_node WHERE target_id = $parent.id
+          AND (SELECT count() FROM only datasource_with_node_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0)
+    }
+} AS result
+FROM node
+WHERE bcs_cluster_id = 'BCS-K8S-00001'
+  AND node = 'node-1'
+  AND (SELECT count() FROM only node_liveness_record WHERE node_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0
+LIMIT 10;`,
+		MockResponse: []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_type": "node",
+								"entity_id":   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+								"entity_data": map[string]any{
+									"bcs_cluster_id": "BCS-K8S-00001",
+									"node":           "node-1",
+								},
+								"liveness": []any{
+									map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+								},
+							},
+							"hop1": map[string]any{
+								"node_with_system": []any{
+									map[string]any{
+										"hop":               float64(1),
+										"relation_type":     "node_with_system",
+										"relation_category": "static",
+										"relation_id":       "node_with_system:1",
+										"relation_liveness": []any{
+											map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+										},
+										"target": map[string]any{
+											"entity_type": "system",
+											"entity_id":   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+											"entity_data": map[string]any{
+												"bk_cloud_id":  "0",
+												"bk_target_ip": "192.168.1.1",
+											},
+											"liveness": []any{
+												map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+											},
+										},
+									},
+								},
+								"node_with_pod": []any{
+									map[string]any{
+										"hop":               float64(1),
+										"relation_type":     "node_with_pod",
+										"relation_category": "static",
+										"relation_id":       "node_with_pod:1",
+										"relation_liveness": []any{
+											map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+										},
+										"target": map[string]any{
+											"entity_type": "pod",
+											"entity_id":   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+											"entity_data": map[string]any{
+												"bcs_cluster_id": "BCS-K8S-00001",
+												"namespace":      "default",
+												"pod":            "nginx-1",
+											},
+											"liveness": []any{
+												map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ExpectedGraphs: []*LivenessGraph{
+			{
+				QueryStart: 0,
+				QueryEnd:   600000,
+				Nodes: map[string]*NodeLiveness{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {
+						ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+						ResourceType: ResourceTypeNode,
+						Labels: map[string]string{
+							"bcs_cluster_id": "BCS-K8S-00001",
+							"node":           "node-1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩": {
+						ResourceID:   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						ResourceType: ResourceTypeSystem,
+						Labels: map[string]string{
+							"bk_cloud_id":  "0",
+							"bk_target_ip": "192.168.1.1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {
+						ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+						ResourceType: ResourceTypePod,
+						Labels: map[string]string{
+							"bcs_cluster_id": "BCS-K8S-00001",
+							"namespace":      "default",
+							"pod":            "nginx-1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+				},
+				Edges: map[string]*EdgeLiveness{
+					"node_with_system:1": {
+						RelationID:   "node_with_system:1",
+						RelationType: RelationNodeWithSystem,
+						Category:     RelationCategoryStatic,
+						Direction:    "",
+						FromID:       "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+						ToID:         "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						RawPeriods:   []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"node_with_pod:1": {
+						RelationID:   "node_with_pod:1",
+						RelationType: RelationNodeWithPod,
+						Category:     RelationCategoryStatic,
+						Direction:    "",
+						FromID:       "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+						ToID:         "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+						RawPeriods:   []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+				},
+				Adjacency: map[string][]string{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩":                  {"node_with_system:1", "node_with_pod:1"},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩":                  {},
+					"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {},
+				},
+			},
+		},
+	}
+}
+
+// 测试用例 2: System 查询（动态关系 outbound）- 关系数量可控
+func getSystemDynamicOutboundTestCase() E2ETestCase {
+	return E2ETestCase{
+		Name: "System_DynamicOutbound",
+		QueryRequest: &QueryRequest{
+			Timestamp:                600000,
+			SourceType:               ResourceTypeSystem,
+			SourceInfo:               map[string]string{"bk_cloud_id": "0", "bk_target_ip": "192.168.1.1"},
+			MaxHops:                  1,
+			AllowedRelationTypes:     []RelationCategory{RelationCategoryDynamic},
+			DynamicRelationDirection: DirectionOutbound,
+			LookBackDelta:            600000,
+			Limit:                    10,
+		},
+		ExpectedSQL: `LET $timestamp = 600000;
+LET $look_back_delta = 600000;
+LET $start = 0;
+LET $end = 600000;
+
+SELECT {
+    root: {
+        entity_type: meta::tb(id),
+        entity_id: <string>id,
+        entity_data: { bk_cloud_id: bk_cloud_id, bk_target_ip: bk_target_ip },
+        created_at: created_at,
+        updated_at: updated_at,
+        liveness: (SELECT * FROM system_liveness_record WHERE system_id = $parent.id AND period_end >= $start AND period_start <= $end)
+    },
+
+    hop1: {
+        system_to_pod_outbound: (SELECT {
+            hop: 1,
+            relation_type: 'system_to_pod',
+            relation_category: 'dynamic',
+            direction: 'outbound',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM system_to_pod_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'pod',
+                entity_id: <string>target_id,
+                entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod },
+                liveness: (SELECT * FROM pod_liveness_record WHERE pod_id = $parent.target_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM system_to_pod WHERE source_id = $parent.id
+          AND (SELECT count() FROM only system_to_pod_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0),
+        system_to_system_outbound: (SELECT {
+            hop: 1,
+            relation_type: 'system_to_system',
+            relation_category: 'dynamic',
+            direction: 'outbound',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM system_to_system_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'system',
+                entity_id: <string>target_id,
+                entity_data: { bk_cloud_id: target_id.bk_cloud_id, bk_target_ip: target_id.bk_target_ip },
+                liveness: (SELECT * FROM system_liveness_record WHERE system_id = $parent.target_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM system_to_system WHERE source_id = $parent.id
+          AND (SELECT count() FROM only system_to_system_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0)
+    }
+} AS result
+FROM system
+WHERE bk_cloud_id = '0'
+  AND bk_target_ip = '192.168.1.1'
+  AND (SELECT count() FROM only system_liveness_record WHERE system_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0
+LIMIT 10;`,
+		MockResponse: []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_type": "system",
+								"entity_id":   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+								"entity_data": map[string]any{
+									"bk_cloud_id":  "0",
+									"bk_target_ip": "192.168.1.1",
+								},
+								"liveness": []any{
+									map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+								},
+							},
+							"hop1": map[string]any{
+								"system_to_pod_outbound": []any{
+									map[string]any{
+										"hop":               float64(1),
+										"relation_type":     "system_to_pod",
+										"relation_category": "dynamic",
+										"direction":         "outbound",
+										"relation_id":       "system_to_pod:1",
+										"relation_liveness": []any{
+											map[string]any{"period_start": float64(200000), "period_end": float64(400000)},
+										},
+										"target": map[string]any{
+											"entity_type": "pod",
+											"entity_id":   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+											"entity_data": map[string]any{
+												"bcs_cluster_id": "BCS-K8S-00001",
+												"namespace":      "default",
+												"pod":            "nginx-1",
+											},
+											"liveness": []any{
+												map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ExpectedGraphs: []*LivenessGraph{
+			{
+				QueryStart: 0,
+				QueryEnd:   600000,
+				Nodes: map[string]*NodeLiveness{
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩": {
+						ResourceID:   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						ResourceType: ResourceTypeSystem,
+						Labels: map[string]string{
+							"bk_cloud_id":  "0",
+							"bk_target_ip": "192.168.1.1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {
+						ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+						ResourceType: ResourceTypePod,
+						Labels: map[string]string{
+							"bcs_cluster_id": "BCS-K8S-00001",
+							"namespace":      "default",
+							"pod":            "nginx-1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+				},
+				Edges: map[string]*EdgeLiveness{
+					"system_to_pod:1": {
+						RelationID:   "system_to_pod:1",
+						RelationType: RelationSystemToPod,
+						Category:     RelationCategoryDynamic,
+						Direction:    DirectionOutbound,
+						FromID:       "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						ToID:         "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+						RawPeriods:   []*VisiblePeriod{{Start: 200000, End: 400000}},
+					},
+				},
+				Adjacency: map[string][]string{
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩":                  {"system_to_pod:1"},
+					"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {},
+				},
+			},
+		},
+	}
+}
+
+// 测试用例 3: 空响应
+func getEmptyResponseTestCase() E2ETestCase {
+	return E2ETestCase{
+		Name: "EmptyResponse_NoMatchingNode",
+		QueryRequest: &QueryRequest{
+			Timestamp:            600000,
+			SourceType:           ResourceTypeNode,
+			SourceInfo:           map[string]string{"bcs_cluster_id": "BCS-K8S-00001", "node": "non-existent"},
+			MaxHops:              1,
+			AllowedRelationTypes: []RelationCategory{RelationCategoryStatic},
+			LookBackDelta:        600000,
+			Limit:                10,
+		},
+		ExpectedSQL: `LET $timestamp = 600000;
+LET $look_back_delta = 600000;
+LET $start = 0;
+LET $end = 600000;
+
+SELECT {
+    root: {
+        entity_type: meta::tb(id),
+        entity_id: <string>id,
+        entity_data: { bcs_cluster_id: bcs_cluster_id, node: node },
+        created_at: created_at,
+        updated_at: updated_at,
+        liveness: (SELECT * FROM node_liveness_record WHERE node_id = $parent.id AND period_end >= $start AND period_start <= $end)
+    },
+
+    hop1: {
+        node_with_system: (SELECT {
+            hop: 1,
+            relation_type: 'node_with_system',
+            relation_category: 'static',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM node_with_system_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'system',
+                entity_id: <string>target_id,
+                entity_data: { bk_cloud_id: target_id.bk_cloud_id, bk_target_ip: target_id.bk_target_ip },
+                liveness: (SELECT * FROM system_liveness_record WHERE system_id = $parent.target_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM node_with_system WHERE source_id = $parent.id
+          AND (SELECT count() FROM only node_with_system_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0),
+        node_with_pod: (SELECT {
+            hop: 1,
+            relation_type: 'node_with_pod',
+            relation_category: 'static',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'pod',
+                entity_id: <string>target_id,
+                entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod },
+                liveness: (SELECT * FROM pod_liveness_record WHERE pod_id = $parent.target_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM node_with_pod WHERE source_id = $parent.id
+          AND (SELECT count() FROM only node_with_pod_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0),
+        datasource_with_node: (SELECT {
+            hop: 1,
+            relation_type: 'datasource_with_node',
+            relation_category: 'static',
+            relation_id: <string>id,
+            relation_liveness: (SELECT * FROM datasource_with_node_liveness_record WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end),
+            target: {
+                entity_type: 'datasource',
+                entity_id: <string>source_id,
+                entity_data: { bk_data_id: source_id.bk_data_id },
+                liveness: (SELECT * FROM datasource_liveness_record WHERE datasource_id = $parent.source_id AND period_end >= $start AND period_start <= $end)
+            }
+        } FROM datasource_with_node WHERE target_id = $parent.id
+          AND (SELECT count() FROM only datasource_with_node_liveness_record WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0)
+    }
+} AS result
+FROM node
+WHERE bcs_cluster_id = 'BCS-K8S-00001'
+  AND node = 'non-existent'
+  AND (SELECT count() FROM only node_liveness_record WHERE node_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0
+LIMIT 10;`,
+		MockResponse: []map[string]any{
+			{
+				"result": []any{},
+			},
+		},
+		ExpectedGraphs: []*LivenessGraph{},
+	}
+}
+
+// 测试用例 4: 多跳查询 Node -> System（2跳静态）
+func getMultiHopNodeToSystemTestCase() E2ETestCase {
+	return E2ETestCase{
+		Name: "MultiHop_NodeToSystem",
+		QueryRequest: &QueryRequest{
+			Timestamp:            600000,
+			SourceType:           ResourceTypeNode,
+			SourceInfo:           map[string]string{"bcs_cluster_id": "BCS-K8S-00001", "node": "node-1"},
+			MaxHops:              2,
+			AllowedRelationTypes: []RelationCategory{RelationCategoryStatic},
+			LookBackDelta:        600000,
+			Limit:                10,
+		},
+		// SQL 太长，此处省略完整 SQL，改用 MockResponse 和 ExpectedGraph 验证解析逻辑
+		ExpectedSQL: "", // 设为空表示跳过 SQL 验证
+		MockResponse: []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_type": "node",
+								"entity_id":   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+								"entity_data": map[string]any{
+									"bcs_cluster_id": "BCS-K8S-00001",
+									"node":           "node-1",
+								},
+								"liveness": []any{
+									map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+								},
+							},
+							"hop1": map[string]any{
+								"node_with_system": []any{
+									map[string]any{
+										"hop":               float64(1),
+										"relation_type":     "node_with_system",
+										"relation_category": "static",
+										"relation_id":       "node_with_system:1",
+										"relation_liveness": []any{
+											map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+										},
+										"target": map[string]any{
+											"entity_type": "system",
+											"entity_id":   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+											"entity_data": map[string]any{
+												"bk_cloud_id":  "0",
+												"bk_target_ip": "192.168.1.1",
+											},
+											"liveness": []any{
+												map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+											},
+											"hop2": map[string]any{
+												"host_with_system": []any{
+													map[string]any{
+														"hop":               float64(2),
+														"relation_type":     "host_with_system",
+														"relation_category": "static",
+														"relation_id":       "host_with_system:1",
+														"relation_liveness": []any{
+															map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+														},
+														"target": map[string]any{
+															"entity_type": "host",
+															"entity_id":   "host:⟨bk_host_id=12345⟩",
+															"entity_data": map[string]any{
+																"bk_host_id": "12345",
+															},
+															"liveness": []any{
+																map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ExpectedGraphs: []*LivenessGraph{
+			{
+				QueryStart: 0,
+				QueryEnd:   600000,
+				Nodes: map[string]*NodeLiveness{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {
+						ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+						ResourceType: ResourceTypeNode,
+						Labels: map[string]string{
+							"bcs_cluster_id": "BCS-K8S-00001",
+							"node":           "node-1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩": {
+						ResourceID:   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						ResourceType: ResourceTypeSystem,
+						Labels: map[string]string{
+							"bk_cloud_id":  "0",
+							"bk_target_ip": "192.168.1.1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"host:⟨bk_host_id=12345⟩": {
+						ResourceID:   "host:⟨bk_host_id=12345⟩",
+						ResourceType: ResourceTypeHost,
+						Labels: map[string]string{
+							"bk_host_id": "12345",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+				},
+				Edges: map[string]*EdgeLiveness{
+					"node_with_system:1": {
+						RelationID:   "node_with_system:1",
+						RelationType: RelationNodeWithSystem,
+						Category:     RelationCategoryStatic,
+						Direction:    "",
+						FromID:       "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+						ToID:         "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						RawPeriods:   []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"host_with_system:1": {
+						RelationID:   "host_with_system:1",
+						RelationType: RelationHostWithSystem,
+						Category:     RelationCategoryStatic,
+						Direction:    "",
+						FromID:       "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						ToID:         "host:⟨bk_host_id=12345⟩",
+						RawPeriods:   []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+				},
+				Adjacency: map[string][]string{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {"node_with_system:1"},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩": {"host_with_system:1"},
+					"host:⟨bk_host_id=12345⟩":                         {},
+				},
+			},
+		},
+	}
+}
+
+// 测试用例 5: 多个起始实体（返回多个图）
+func getMultipleRootsTestCase() E2ETestCase {
+	return E2ETestCase{
+		Name: "MultipleRoots_TwoNodes",
+		QueryRequest: &QueryRequest{
+			Timestamp:            600000,
+			SourceType:           ResourceTypeNode,
+			SourceInfo:           map[string]string{"bcs_cluster_id": "BCS-K8S-00001"}, // 只指定 cluster，可能匹配多个 node
+			MaxHops:              1,
+			AllowedRelationTypes: []RelationCategory{RelationCategoryStatic},
+			LookBackDelta:        600000,
+			Limit:                10,
+		},
+		ExpectedSQL: "", // 跳过 SQL 验证
+		MockResponse: []map[string]any{
+			{
+				"result": []any{
+					// 第一个起始实体: node-1
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_type": "node",
+								"entity_id":   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+								"entity_data": map[string]any{
+									"bcs_cluster_id": "BCS-K8S-00001",
+									"node":           "node-1",
+								},
+								"liveness": []any{
+									map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+								},
+							},
+							"hop1": map[string]any{
+								"node_with_system": []any{
+									map[string]any{
+										"hop":               float64(1),
+										"relation_type":     "node_with_system",
+										"relation_category": "static",
+										"relation_id":       "node_with_system:1",
+										"relation_liveness": []any{
+											map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+										},
+										"target": map[string]any{
+											"entity_type": "system",
+											"entity_id":   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+											"entity_data": map[string]any{
+												"bk_cloud_id":  "0",
+												"bk_target_ip": "192.168.1.1",
+											},
+											"liveness": []any{
+												map[string]any{"period_start": float64(100000), "period_end": float64(500000)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					// 第二个起始实体: node-2
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_type": "node",
+								"entity_id":   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-2⟩",
+								"entity_data": map[string]any{
+									"bcs_cluster_id": "BCS-K8S-00001",
+									"node":           "node-2",
+								},
+								"liveness": []any{
+									map[string]any{"period_start": float64(200000), "period_end": float64(600000)},
+								},
+							},
+							"hop1": map[string]any{
+								"node_with_system": []any{
+									map[string]any{
+										"hop":               float64(1),
+										"relation_type":     "node_with_system",
+										"relation_category": "static",
+										"relation_id":       "node_with_system:2",
+										"relation_liveness": []any{
+											map[string]any{"period_start": float64(200000), "period_end": float64(600000)},
+										},
+										"target": map[string]any{
+											"entity_type": "system",
+											"entity_id":   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.2⟩",
+											"entity_data": map[string]any{
+												"bk_cloud_id":  "0",
+												"bk_target_ip": "192.168.1.2",
+											},
+											"liveness": []any{
+												map[string]any{"period_start": float64(200000), "period_end": float64(600000)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ExpectedGraphs: []*LivenessGraph{
+			// 第一个图: node-1 -> system-1
+			{
+				QueryStart: 0,
+				QueryEnd:   600000,
+				Nodes: map[string]*NodeLiveness{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {
+						ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+						ResourceType: ResourceTypeNode,
+						Labels: map[string]string{
+							"bcs_cluster_id": "BCS-K8S-00001",
+							"node":           "node-1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩": {
+						ResourceID:   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						ResourceType: ResourceTypeSystem,
+						Labels: map[string]string{
+							"bk_cloud_id":  "0",
+							"bk_target_ip": "192.168.1.1",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+				},
+				Edges: map[string]*EdgeLiveness{
+					"node_with_system:1": {
+						RelationID:   "node_with_system:1",
+						RelationType: RelationNodeWithSystem,
+						Category:     RelationCategoryStatic,
+						Direction:    "",
+						FromID:       "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+						ToID:         "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩",
+						RawPeriods:   []*VisiblePeriod{{Start: 100000, End: 500000}},
+					},
+				},
+				Adjacency: map[string][]string{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {"node_with_system:1"},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.1⟩": {},
+				},
+			},
+			// 第二个图: node-2 -> system-2
+			{
+				QueryStart: 0,
+				QueryEnd:   600000,
+				Nodes: map[string]*NodeLiveness{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-2⟩": {
+						ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-2⟩",
+						ResourceType: ResourceTypeNode,
+						Labels: map[string]string{
+							"bcs_cluster_id": "BCS-K8S-00001",
+							"node":           "node-2",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 200000, End: 600000}},
+					},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.2⟩": {
+						ResourceID:   "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.2⟩",
+						ResourceType: ResourceTypeSystem,
+						Labels: map[string]string{
+							"bk_cloud_id":  "0",
+							"bk_target_ip": "192.168.1.2",
+						},
+						RawPeriods: []*VisiblePeriod{{Start: 200000, End: 600000}},
+					},
+				},
+				Edges: map[string]*EdgeLiveness{
+					"node_with_system:2": {
+						RelationID:   "node_with_system:2",
+						RelationType: RelationNodeWithSystem,
+						Category:     RelationCategoryStatic,
+						Direction:    "",
+						FromID:       "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-2⟩",
+						ToID:         "system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.2⟩",
+						RawPeriods:   []*VisiblePeriod{{Start: 200000, End: 600000}},
+					},
+				},
+				Adjacency: map[string][]string{
+					"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-2⟩": {"node_with_system:2"},
+					"system:⟨bk_cloud_id=0,bk_target_ip=192.168.1.2⟩": {},
+				},
+			},
+		},
+	}
+}
+
+func TestGraphE2E(t *testing.T) {
+	testCases := []E2ETestCase{
+		getNodeStaticTestCase(),
+		getSystemDynamicOutboundTestCase(),
+		getEmptyResponseTestCase(),
+		getMultiHopNodeToSystemTestCase(),
+		getMultipleRootsTestCase(),
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// Step 1: 构建查询
+			builder := NewSurrealQueryBuilder(tc.QueryRequest)
+			actualSQL := builder.Build()
+
+			// Step 2: 验证 SQL（如果 ExpectedSQL 非空）
+			if tc.ExpectedSQL != "" {
+				assert.Equal(t, tc.ExpectedSQL, actualSQL, "Generated SQL mismatch")
+			} else {
+				t.Logf("Generated SQL (length=%d):\n%s", len(actualSQL), actualSQL)
+			}
+
+			// Step 3: 解析响应
+			start, end := tc.QueryRequest.GetQueryRange()
+			parser := NewSurrealResponseParser(start, end)
+			actualGraphs, err := parser.Parse(tc.MockResponse)
+			require.NoError(t, err, "Parse should not return error")
+
+			// Step 4: 验证图的数量
+			require.Equal(t, len(tc.ExpectedGraphs), len(actualGraphs), "Number of graphs mismatch")
+
+			// Step 5: 对每个图进行比较（排序 Adjacency 以忽略顺序差异）
+			for i, expectedGraph := range tc.ExpectedGraphs {
+				assertLivenessGraphEqual(t, expectedGraph, actualGraphs[i], "LivenessGraph[%d] mismatch", i)
+			}
+		})
+	}
+}
+
+// assertLivenessGraphEqual 比较两个 LivenessGraph，忽略 Adjacency 中的顺序差异
+func assertLivenessGraphEqual(t *testing.T, expected, actual *LivenessGraph, msgAndArgs ...any) {
+	t.Helper()
+
+	// 对 Adjacency 排序后比较
+	sortedExpected := sortAdjacency(expected)
+	sortedActual := sortAdjacency(actual)
+
+	expectedJSON, err := json.Marshal(sortedExpected)
+	require.NoError(t, err, "Marshal expected graph failed")
+
+	actualJSON, err := json.Marshal(sortedActual)
+	require.NoError(t, err, "Marshal actual graph failed")
+
+	assert.JSONEq(t, string(expectedJSON), string(actualJSON), msgAndArgs...)
+}
+
+// sortAdjacency 返回一个新的 LivenessGraph，其 Adjacency 中的 slice 已排序
+func sortAdjacency(g *LivenessGraph) *LivenessGraph {
+	sorted := &LivenessGraph{
+		QueryStart:      g.QueryStart,
+		QueryEnd:        g.QueryEnd,
+		Nodes:           g.Nodes,
+		Edges:           g.Edges,
+		TraversalErrors: g.TraversalErrors,
+		Adjacency:       make(map[string][]string, len(g.Adjacency)),
+	}
+	for k, v := range g.Adjacency {
+		sortedSlice := make([]string, len(v))
+		copy(sortedSlice, v)
+		sort.Strings(sortedSlice)
+		sorted.Adjacency[k] = sortedSlice
+	}
+	return sorted
+}

--- a/pkg/unify-query/cmdb/v1beta3/hook.go
+++ b/pkg/unify-query/cmdb/v1beta3/hook.go
@@ -1,0 +1,66 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/eventbus"
+)
+
+func setDefaultConfig() {
+	viper.SetDefault(MaxHopsConfigPath, 2)
+	viper.SetDefault(MaxAllowedHopsConfigPath, 5)
+	viper.SetDefault(DefaultLimitConfigPath, 100)
+	viper.SetDefault(DefaultLookBackDeltaConfigPath, 86400000) // 24小时（毫秒）
+
+	viper.SetDefault(BKBaseSurrealDBUrlConfigPath, DefaultBKBaseSurrealDBUrl)
+	viper.SetDefault(BKBaseSurrealDBResultTableIDConfigPath, DefaultBKBaseSurrealDBResultTableID)
+	viper.SetDefault(BKBaseSurrealDBPreferStorageConfigPath, DefaultBKBaseSurrealDBPreferStorage)
+	viper.SetDefault(BKBaseSurrealDBAuthMethodConfigPath, DefaultBKBaseSurrealDBAuthMethod)
+	viper.SetDefault(BKBaseSurrealDBUsernameConfigPath, DefaultBKBaseSurrealDBUsername)
+	viper.SetDefault(BKBaseSurrealDBAppCodeConfigPath, DefaultBKBaseSurrealDBAppCode)
+	viper.SetDefault(BKBaseSurrealDBAppSecretConfigPath, DefaultBKBaseSurrealDBAppSecret)
+	viper.SetDefault(BKBaseSurrealDBTimeoutConfigPath, DefaultBKBaseSurrealDBTimeout)
+}
+
+func LoadConfig() {
+	DefaultMaxHops = viper.GetInt(MaxHopsConfigPath)
+	MaxAllowedHops = viper.GetInt(MaxAllowedHopsConfigPath)
+	DefaultLimit = viper.GetInt(DefaultLimitConfigPath)
+	DefaultLookBackDelta = viper.GetInt64(DefaultLookBackDeltaConfigPath)
+
+	BKBaseSurrealDBUrl = viper.GetString(BKBaseSurrealDBUrlConfigPath)
+	BKBaseSurrealDBResultTableID = viper.GetString(BKBaseSurrealDBResultTableIDConfigPath)
+	BKBaseSurrealDBPreferStorage = viper.GetString(BKBaseSurrealDBPreferStorageConfigPath)
+	BKBaseSurrealDBAuthMethod = viper.GetString(BKBaseSurrealDBAuthMethodConfigPath)
+	BKBaseSurrealDBUsername = viper.GetString(BKBaseSurrealDBUsernameConfigPath)
+	BKBaseSurrealDBAppCode = viper.GetString(BKBaseSurrealDBAppCodeConfigPath)
+	BKBaseSurrealDBAppSecret = viper.GetString(BKBaseSurrealDBAppSecretConfigPath)
+	BKBaseSurrealDBTimeout = viper.GetDuration(BKBaseSurrealDBTimeoutConfigPath)
+}
+
+func init() {
+	if err := eventbus.EventBus.Subscribe(eventbus.EventSignalConfigPreParse, setDefaultConfig); err != nil {
+		fmt.Printf(
+			"failed to subscribe event->[%s] for cmdb v1beta3 module for default config, maybe cmdb v1beta3 module won't working.",
+			eventbus.EventSignalConfigPreParse,
+		)
+	}
+
+	if err := eventbus.EventBus.Subscribe(eventbus.EventSignalConfigPostParse, LoadConfig); err != nil {
+		fmt.Printf(
+			"failed to subscribe event->[%s] for cmdb v1beta3 module for new config, maybe cmdb v1beta3 module won't working.",
+			eventbus.EventSignalConfigPostParse,
+		)
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/liveness_graph.go
+++ b/pkg/unify-query/cmdb/v1beta3/liveness_graph.go
@@ -1,0 +1,117 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+type LivenessGraph struct {
+	QueryStart      int64                    `json:"query_start"`
+	QueryEnd        int64                    `json:"query_end"`
+	Nodes           map[string]*NodeLiveness `json:"nodes"`
+	Edges           map[string]*EdgeLiveness `json:"edges"`
+	Adjacency       map[string][]string      `json:"adjacency"`
+	TraversalErrors []string                 `json:"traversal_errors,omitempty"`
+}
+
+type NodeLiveness struct {
+	ResourceID   string            `json:"resource_id"`
+	ResourceType ResourceType      `json:"resource_type"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	RawPeriods   []*VisiblePeriod  `json:"raw_periods"`
+}
+
+type EdgeLiveness struct {
+	RelationID   string             `json:"relation_id"`
+	RelationType RelationType       `json:"relation_type"`
+	Category     RelationCategory   `json:"category"`
+	Direction    TraversalDirection `json:"direction,omitempty"`
+	FromID       string             `json:"from_id"`
+	ToID         string             `json:"to_id"`
+	RawPeriods   []*VisiblePeriod   `json:"raw_periods"`
+}
+
+func NewLivenessGraph(queryStart, queryEnd int64) *LivenessGraph {
+	return &LivenessGraph{
+		QueryStart: queryStart,
+		QueryEnd:   queryEnd,
+		Nodes:      make(map[string]*NodeLiveness),
+		Edges:      make(map[string]*EdgeLiveness),
+		Adjacency:  make(map[string][]string),
+	}
+}
+
+func (g *LivenessGraph) AddNode(node *NodeLiveness) {
+	g.Nodes[node.ResourceID] = node
+	if _, exists := g.Adjacency[node.ResourceID]; !exists {
+		g.Adjacency[node.ResourceID] = []string{}
+	}
+}
+
+func (g *LivenessGraph) AddEdge(edge *EdgeLiveness) {
+	_, exists := g.Edges[edge.RelationID]
+	g.Edges[edge.RelationID] = edge
+	if !exists {
+		g.Adjacency[edge.FromID] = append(g.Adjacency[edge.FromID], edge.RelationID)
+	}
+}
+
+func (g *LivenessGraph) GetNode(resourceID string) *NodeLiveness {
+	return g.Nodes[resourceID]
+}
+
+func (g *LivenessGraph) GetEdge(relationID string) *EdgeLiveness {
+	return g.Edges[relationID]
+}
+
+func (g *LivenessGraph) AddTraversalError(errMsg string) {
+	g.TraversalErrors = append(g.TraversalErrors, errMsg)
+}
+
+func (g *LivenessGraph) HasErrors() bool {
+	return len(g.TraversalErrors) > 0
+}
+
+func (g *LivenessGraph) IsComplete() bool {
+	return len(g.TraversalErrors) == 0
+}
+
+func (g *LivenessGraph) GetOutEdges(resourceID string) []*EdgeLiveness {
+	relationIDs := g.Adjacency[resourceID]
+	edges := make([]*EdgeLiveness, 0, len(relationIDs))
+	for _, rid := range relationIDs {
+		if edge := g.Edges[rid]; edge != nil {
+			edges = append(edges, edge)
+		}
+	}
+	return edges
+}
+
+func (g *LivenessGraph) ExtractTargetMatchersWithID(targetType ResourceType) map[string]cmdb.Matcher {
+	result := make(map[string]cmdb.Matcher)
+	if g == nil || len(g.Nodes) == 0 {
+		return result
+	}
+
+	for _, node := range g.Nodes {
+		if node.ResourceType == targetType {
+			if _, exists := result[node.ResourceID]; !exists {
+				matcher := make(cmdb.Matcher, len(node.Labels))
+				for k, v := range node.Labels {
+					matcher[k] = v
+				}
+				result[node.ResourceID] = matcher
+			}
+		}
+	}
+
+	return result
+}

--- a/pkg/unify-query/cmdb/v1beta3/mock/surrealdb.go
+++ b/pkg/unify-query/cmdb/v1beta3/mock/surrealdb.go
@@ -1,0 +1,85 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package mock
+
+import (
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/jarcoal/httpmock"
+)
+
+// SurrealDB Mock 地址和默认配置
+const (
+	SurrealDBUrl     = "http://127.0.0.1:8000"
+	DefaultNamespace = "default"
+	DefaultDatabase  = "test"
+)
+
+// SurrealDB mock 数据存储（类似 ES 的 resultData）
+var SurrealDB = &surrealDBMockData{}
+
+type surrealDBMockData struct {
+	lock sync.RWMutex
+	data map[string]any
+}
+
+// Set 设置 mock 数据（精确匹配）
+// key: SQL 查询语句
+// value: JSON 格式的响应字符串
+func (s *surrealDBMockData) Set(in map[string]any) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.data == nil {
+		s.data = make(map[string]any)
+	}
+	for k, v := range in {
+		s.data[k] = v
+	}
+}
+
+// Clear 清空所有 mock 数据
+func (s *surrealDBMockData) Clear() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.data = make(map[string]any)
+}
+
+// Get 获取 mock 数据（精确匹配）
+func (s *surrealDBMockData) Get(query string) (any, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	d, ok := s.data[query]
+	return d, ok
+}
+
+// RegisterHandler 注册 SurrealDB 的 httpmock 处理器
+func RegisterHandler() {
+	httpmock.RegisterResponder(http.MethodPost, SurrealDBUrl+"/sql",
+		func(r *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(r.Body)
+			query := string(body)
+
+			// 尝试从 mock 数据中获取响应（精确匹配）
+			if resp, ok := SurrealDB.Get(query); ok {
+				switch v := resp.(type) {
+				case string:
+					return httpmock.NewStringResponse(http.StatusOK, v), nil
+				default:
+					return httpmock.NewJsonResponse(http.StatusOK, v)
+				}
+			}
+
+			// 默认返回空结果
+			return httpmock.NewStringResponse(http.StatusOK, EmptyResponse), nil
+		})
+}

--- a/pkg/unify-query/cmdb/v1beta3/mock/testdata.go
+++ b/pkg/unify-query/cmdb/v1beta3/mock/testdata.go
@@ -1,0 +1,89 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package mock
+
+import (
+	"fmt"
+)
+
+// PodData Pod 测试数据
+type PodData struct {
+	ClusterID   string
+	Namespace   string
+	Pod         string
+	PeriodStart int64
+	PeriodEnd   int64
+}
+
+// GetResourceID 获取资源 ID
+func (p *PodData) GetResourceID() string {
+	return fmt.Sprintf("pod:⟨bcs_cluster_id=%s,namespace=%s,pod=%s⟩", p.ClusterID, p.Namespace, p.Pod)
+}
+
+// NodeData Node 测试数据
+type NodeData struct {
+	ClusterID   string
+	Node        string
+	PeriodStart int64
+	PeriodEnd   int64
+}
+
+// GetResourceID 获取资源 ID
+func (n *NodeData) GetResourceID() string {
+	return fmt.Sprintf("node:⟨bcs_cluster_id=%s,node=%s⟩", n.ClusterID, n.Node)
+}
+
+// EmptyResponse 空响应的 JSON 字符串
+const EmptyResponse = `[{"status":"OK","result":null},{"status":"OK","result":[]}]`
+
+// InfoForDBResponse INFO FOR DB 查询的响应
+const InfoForDBResponse = `[{"status":"OK","result":null},{"status":"OK","result":{}}]`
+
+// MockData 预定义的 Mock 数据
+// key: 完整的 SQL 查询语句（包含 USE NS DB 前缀）
+// value: JSON 格式的响应字符串
+//
+// 使用方式:
+//
+//	mock.SurrealDB.Set(mock.MockData)
+//
+// 或者追加自定义数据:
+//
+//	mock.SurrealDB.Set(map[string]any{
+//	    "USE NS default DB test; SELECT * FROM ...": `[{"status":"OK","result":null},{"status":"OK","result":[...]}]`,
+//	})
+var MockData = map[string]any{
+	// ========== 系统查询 ==========
+
+	// INFO FOR DB - 数据库信息查询
+	`USE NS default DB test; INFO FOR DB`: InfoForDBResponse,
+
+	// ========== Pod liveness 查询 ==========
+	// 基准时间: queryEnd=1736510400000 (2025-01-10 12:00:00 UTC)
+	//          queryStart=1736424000000 (2025-01-09 12:00:00 UTC, 24小时前)
+	//          tolerance=600000 (10分钟)
+	// 实际查询: period_start <= 1736511000000, period_end >= 1736423400000
+
+	// Pod liveness - BCS-K8S-00001, default, nginx-pod-1
+	"USE NS default DB test; SELECT * FROM pod_liveness_record \nWHERE pod_id = 'pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-pod-1⟩' \nAND period_start <= 1736511000000 \nAND period_end >= 1736423400000\nORDER BY period_start ASC\nLIMIT 1000": `[{"status":"OK","result":null},{"status":"OK","result":[{"id":"pod_liveness_record:1","pod_id":"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-pod-1⟩","period_start":1736424000000,"period_end":1736510400000}]}]`,
+
+	// Pod liveness - 不存在的 Pod，返回空结果
+	"USE NS default DB test; SELECT * FROM pod_liveness_record \nWHERE pod_id = 'pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=non-existent-pod⟩' \nAND period_start <= 1736511000000 \nAND period_end >= 1736423400000\nORDER BY period_start ASC\nLIMIT 1000": EmptyResponse,
+
+	// ========== Node liveness 查询 ==========
+
+	// Node liveness - BCS-K8S-00001, node-1
+	"USE NS default DB test; SELECT * FROM node_liveness_record \nWHERE node_id = 'node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩' \nAND period_start <= 1736511000000 \nAND period_end >= 1736423400000\nORDER BY period_start ASC\nLIMIT 1000": `[{"status":"OK","result":null},{"status":"OK","result":[{"id":"node_liveness_record:1","node_id":"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩","period_start":1736424000000,"period_end":1736510400000}]}]`,
+
+	// ========== 关联关系查询 ==========
+
+	// Pod -> Node 关联关系 (node_with_pod)
+	"USE NS default DB test; SELECT \n    id AS relation_id,\n    out AS from_id,\n    in AS to_id,\n    period_start,\n    period_end,\n    is_active\nFROM node_with_pod \nWHERE out = 'pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-pod-1⟩' \nAND period_start <= 1736511000000 \nAND period_end >= 1736423400000\nORDER BY period_start ASC\nLIMIT 1000": `[{"status":"OK","result":null},{"status":"OK","result":[{"relation_id":"node_with_pod:1","from_id":"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-pod-1⟩","to_id":"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩","period_start":1736424000000,"period_end":1736510400000,"is_active":true}]}]`,
+}

--- a/pkg/unify-query/cmdb/v1beta3/path.go
+++ b/pkg/unify-query/cmdb/v1beta3/path.go
@@ -1,0 +1,284 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"fmt"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+// PathFinder 路径发现器，用于查找资源之间的关联路径
+type PathFinder struct {
+	schemaProvider    SchemaProvider
+	allowedCategories []RelationCategory
+	dynamicDirection  TraversalDirection
+	maxHops           int
+}
+
+// PathFinderOption PathFinder 配置选项
+type PathFinderOption func(*PathFinder)
+
+// WithSchemaProvider 设置 SchemaProvider
+func WithSchemaProvider(provider SchemaProvider) PathFinderOption {
+	return func(pf *PathFinder) {
+		if provider != nil {
+			pf.schemaProvider = provider
+		}
+	}
+}
+
+// WithAllowedCategories 设置允许的关系类别
+func WithAllowedCategories(categories ...RelationCategory) PathFinderOption {
+	return func(pf *PathFinder) {
+		if len(categories) > 0 {
+			pf.allowedCategories = categories
+		}
+	}
+}
+
+// WithDynamicDirection 设置动态关系方向
+func WithDynamicDirection(direction TraversalDirection) PathFinderOption {
+	return func(pf *PathFinder) {
+		pf.dynamicDirection = direction
+	}
+}
+
+// WithMaxHops 设置最大跳数
+func WithMaxHops(maxHops int) PathFinderOption {
+	return func(pf *PathFinder) {
+		pf.maxHops = maxHops
+	}
+}
+
+// NewPathFinder 创建路径发现器
+// 如果不提供 schemaProvider,将使用默认的 StaticSchemaProvider
+func NewPathFinder(opts ...PathFinderOption) *PathFinder {
+	pf := &PathFinder{
+		schemaProvider:    NewStaticSchemaProvider(),
+		allowedCategories: []RelationCategory{RelationCategoryStatic, RelationCategoryDynamic},
+		dynamicDirection:  DirectionBoth,
+		maxHops:           DefaultMaxHops,
+	}
+	for _, opt := range opts {
+		opt(pf)
+	}
+	return pf
+}
+
+// FindAllPaths 查找从 source 到 target 的所有路径
+func (pf *PathFinder) FindAllPaths(source, target ResourceType, pathResource []ResourceType) ([]cmdb.PathV2, error) {
+	if source == target {
+		return []cmdb.PathV2{{Steps: []cmdb.PathStepV2{{ResourceType: string(source)}}}}, nil
+	}
+
+	var results []cmdb.PathV2
+	visited := make(map[ResourceType]bool)
+	currentPath := []cmdb.PathStepV2{{ResourceType: string(source)}}
+	visited[source] = true
+
+	pf.dfs(source, target, pathResource, 0, visited, currentPath, &results)
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("empty paths with %s => %s through %v", source, target, pathResource)
+	}
+
+	return results, nil
+}
+
+// dfs 深度优先搜索所有路径
+func (pf *PathFinder) dfs(
+	current, target ResourceType,
+	pathResource []ResourceType,
+	pathIdx int,
+	visited map[ResourceType]bool,
+	currentPath []cmdb.PathStepV2,
+	results *[]cmdb.PathV2,
+) {
+	if len(currentPath) > pf.maxHops+1 {
+		return
+	}
+
+	if current == target {
+		if pf.satisfiesPathConstraint(currentPath, pathResource) {
+			pathCopy := make([]cmdb.PathStepV2, len(currentPath))
+			copy(pathCopy, currentPath)
+			*results = append(*results, cmdb.PathV2{Steps: pathCopy})
+		}
+		return
+	}
+
+	relations := pf.getRelationsForType(current)
+
+	for _, rel := range relations {
+		nextType := rel.TargetType
+		if visited[nextType] {
+			continue
+		}
+
+		if len(pathResource) > 0 && pathIdx < len(pathResource) {
+			if nextType != pathResource[pathIdx] && nextType != target {
+				continue
+			}
+		}
+
+		visited[nextType] = true
+		nextStep := cmdb.PathStepV2{
+			ResourceType: string(nextType),
+			RelationType: string(rel.Schema.RelationType),
+			Category:     string(rel.Schema.Category),
+			Direction:    string(rel.Direction),
+		}
+		currentPath = append(currentPath, nextStep)
+
+		nextPathIdx := pathIdx
+		if len(pathResource) > 0 && pathIdx < len(pathResource) && nextType == pathResource[pathIdx] {
+			nextPathIdx++
+		}
+
+		pf.dfs(nextType, target, pathResource, nextPathIdx, visited, currentPath, results)
+
+		currentPath = currentPath[:len(currentPath)-1]
+		visited[nextType] = false
+	}
+}
+
+// satisfiesPathConstraint 检查路径是否满足 pathResource 约束
+func (pf *PathFinder) satisfiesPathConstraint(path []cmdb.PathStepV2, pathResource []ResourceType) bool {
+	if len(pathResource) == 0 {
+		return true
+	}
+
+	pathTypes := make([]ResourceType, 0, len(path))
+	for _, step := range path {
+		pathTypes = append(pathTypes, ResourceType(step.ResourceType))
+	}
+
+	pathIdx := 0
+	for _, required := range pathResource {
+		if required == "" {
+			continue
+		}
+		found := false
+		for ; pathIdx < len(pathTypes); pathIdx++ {
+			if pathTypes[pathIdx] == required {
+				found = true
+				pathIdx++
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+// getRelationsForType 获取指定资源类型的所有可用关系
+func (pf *PathFinder) getRelationsForType(resourceType ResourceType) []*RelationQueryInfo {
+	var results []*RelationQueryInfo
+
+	// 从 SchemaProvider 获取所有关联 Schema
+	schemas := pf.schemaProvider.ListRelationSchemas()
+
+	for i := range schemas {
+		schema := &schemas[i]
+
+		if !pf.isRelationCategoryAllowed(schema.Category) {
+			continue
+		}
+
+		if schema.FromType != resourceType && schema.ToType != resourceType {
+			continue
+		}
+
+		if schema.Category == RelationCategoryStatic {
+			info := pf.buildStaticRelationInfo(schema, resourceType)
+			if info != nil {
+				results = append(results, info)
+			}
+		} else {
+			infos := pf.buildDynamicRelationInfos(schema, resourceType)
+			results = append(results, infos...)
+		}
+	}
+
+	return results
+}
+
+// isRelationCategoryAllowed 检查关系类别是否允许
+func (pf *PathFinder) isRelationCategoryAllowed(category RelationCategory) bool {
+	for _, c := range pf.allowedCategories {
+		if c == category {
+			return true
+		}
+	}
+	return false
+}
+
+// buildStaticRelationInfo 构建静态关系查询信息
+func (pf *PathFinder) buildStaticRelationInfo(schema *RelationSchema, currentType ResourceType) *RelationQueryInfo {
+	info := &RelationQueryInfo{
+		Schema:    schema,
+		KeySuffix: "",
+	}
+
+	if schema.FromType == currentType {
+		info.Direction = DirectionOutbound
+		info.WhereField = fieldSourceID
+		info.SelectField = fieldTargetID
+		info.TargetField = fieldTargetID
+		info.TargetType = schema.ToType
+	} else {
+		info.Direction = DirectionInbound
+		info.WhereField = fieldTargetID
+		info.SelectField = fieldSourceID
+		info.TargetField = fieldSourceID
+		info.TargetType = schema.FromType
+	}
+
+	return info
+}
+
+// buildDynamicRelationInfos 构建动态关系查询信息
+func (pf *PathFinder) buildDynamicRelationInfos(schema *RelationSchema, currentType ResourceType) []*RelationQueryInfo {
+	var results []*RelationQueryInfo
+	direction := pf.dynamicDirection
+
+	canOutbound := schema.FromType == currentType
+	canInbound := schema.ToType == currentType
+
+	if (direction == DirectionOutbound || direction == DirectionBoth) && canOutbound {
+		results = append(results, &RelationQueryInfo{
+			Schema:      schema,
+			Direction:   DirectionOutbound,
+			KeySuffix:   "_outbound",
+			WhereField:  fieldSourceID,
+			SelectField: fieldTargetID,
+			TargetField: fieldTargetID,
+			TargetType:  schema.ToType,
+		})
+	}
+
+	if (direction == DirectionInbound || direction == DirectionBoth) && canInbound {
+		results = append(results, &RelationQueryInfo{
+			Schema:      schema,
+			Direction:   DirectionInbound,
+			KeySuffix:   "_inbound",
+			WhereField:  fieldTargetID,
+			SelectField: fieldSourceID,
+			TargetField: fieldSourceID,
+			TargetType:  schema.FromType,
+		})
+	}
+
+	return results
+}

--- a/pkg/unify-query/cmdb/v1beta3/path_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/path_test.go
@@ -1,0 +1,222 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+func TestPathFinder_FindAllPaths(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		Source           ResourceType
+		Target           ResourceType
+		PathResource     []ResourceType
+		AllowedCategory  []RelationCategory
+		DynamicDirection TraversalDirection
+		MaxHops          int
+		Expected         []cmdb.PathV2
+		ExpectError      bool
+	}{
+		{
+			Name:            "node_to_system_static",
+			Source:          ResourceTypeNode,
+			Target:          ResourceTypeSystem,
+			AllowedCategory: []RelationCategory{RelationCategoryStatic},
+			MaxHops:         2,
+			Expected: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "node_with_system", Category: "static", Direction: "outbound"},
+				}},
+			},
+		},
+		{
+			Name:             "system_to_pod_dynamic_outbound",
+			Source:           ResourceTypeSystem,
+			Target:           ResourceTypePod,
+			AllowedCategory:  []RelationCategory{RelationCategoryDynamic},
+			DynamicDirection: DirectionOutbound,
+			MaxHops:          2,
+			Expected: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "system", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "system_to_pod", Category: "dynamic", Direction: "outbound"},
+				}},
+			},
+		},
+		{
+			Name:             "pod_to_system_dynamic_outbound",
+			Source:           ResourceTypePod,
+			Target:           ResourceTypeSystem,
+			AllowedCategory:  []RelationCategory{RelationCategoryDynamic},
+			DynamicDirection: DirectionOutbound,
+			MaxHops:          2,
+			Expected: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "pod", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "pod_to_system", Category: "dynamic", Direction: "outbound"},
+				}},
+			},
+		},
+		{
+			Name:             "pod_to_system_dynamic_inbound",
+			Source:           ResourceTypePod,
+			Target:           ResourceTypeSystem,
+			AllowedCategory:  []RelationCategory{RelationCategoryDynamic},
+			DynamicDirection: DirectionInbound,
+			MaxHops:          2,
+			Expected: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "pod", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "system_to_pod", Category: "dynamic", Direction: "inbound"},
+				}},
+			},
+		},
+		{
+			Name:             "pod_to_system_dynamic_both",
+			Source:           ResourceTypePod,
+			Target:           ResourceTypeSystem,
+			AllowedCategory:  []RelationCategory{RelationCategoryDynamic},
+			DynamicDirection: DirectionBoth,
+			MaxHops:          2,
+			Expected: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "pod", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "pod_to_system", Category: "dynamic", Direction: "outbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "pod", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "system_to_pod", Category: "dynamic", Direction: "inbound"},
+				}},
+			},
+		},
+		{
+			Name:             "system_to_node_static_and_dynamic",
+			Source:           ResourceTypeSystem,
+			Target:           ResourceTypeNode,
+			AllowedCategory:  []RelationCategory{RelationCategoryStatic, RelationCategoryDynamic},
+			DynamicDirection: DirectionOutbound,
+			MaxHops:          2,
+			Expected: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "system", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "node", RelationType: "node_with_system", Category: "static", Direction: "inbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "system", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "system_to_pod", Category: "dynamic", Direction: "outbound"},
+					{ResourceType: "node", RelationType: "node_with_pod", Category: "static", Direction: "inbound"},
+				}},
+			},
+		},
+		{
+			Name:             "node_to_system_static_and_dynamic_both",
+			Source:           ResourceTypeNode,
+			Target:           ResourceTypeSystem,
+			AllowedCategory:  []RelationCategory{RelationCategoryStatic, RelationCategoryDynamic},
+			DynamicDirection: DirectionBoth,
+			MaxHops:          2,
+			Expected: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "node_with_system", Category: "static", Direction: "outbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
+					{ResourceType: "system", RelationType: "pod_to_system", Category: "dynamic", Direction: "outbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
+					{ResourceType: "system", RelationType: "system_to_pod", Category: "dynamic", Direction: "inbound"},
+				}},
+			},
+		},
+		{
+			Name:             "node_to_system_static_and_dynamic_both_maxhops3",
+			Source:           ResourceTypeNode,
+			Target:           ResourceTypeSystem,
+			AllowedCategory:  []RelationCategory{RelationCategoryStatic, RelationCategoryDynamic},
+			DynamicDirection: DirectionBoth,
+			MaxHops:          3,
+			Expected: []cmdb.PathV2{
+				// 1跳: node -> system (静态)
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "node_with_system", Category: "static", Direction: "outbound"},
+				}},
+				// 3跳: node -> pod -> apm_service_instance -> system (静态)
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
+					{ResourceType: "apm_service_instance", RelationType: "apm_service_instance_with_pod", Category: "static", Direction: "inbound"},
+					{ResourceType: "system", RelationType: "apm_service_instance_with_system", Category: "static", Direction: "outbound"},
+				}},
+				// 2跳: node -> pod -> system (动态 outbound)
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
+					{ResourceType: "system", RelationType: "pod_to_system", Category: "dynamic", Direction: "outbound"},
+				}},
+				// 2跳: node -> pod -> system (动态 inbound)
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
+					{ResourceType: "system", RelationType: "system_to_pod", Category: "dynamic", Direction: "inbound"},
+				}},
+				// 3跳: node -> datasource -> pod -> system (动态 outbound)
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "datasource", RelationType: "datasource_with_node", Category: "static", Direction: "inbound"},
+					{ResourceType: "pod", RelationType: "datasource_with_pod", Category: "static", Direction: "outbound"},
+					{ResourceType: "system", RelationType: "pod_to_system", Category: "dynamic", Direction: "outbound"},
+				}},
+				// 3跳: node -> datasource -> pod -> system (动态 inbound)
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "datasource", RelationType: "datasource_with_node", Category: "static", Direction: "inbound"},
+					{ResourceType: "pod", RelationType: "datasource_with_pod", Category: "static", Direction: "outbound"},
+					{ResourceType: "system", RelationType: "system_to_pod", Category: "dynamic", Direction: "inbound"},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			opts := []PathFinderOption{
+				WithMaxHops(tc.MaxHops),
+			}
+			if len(tc.AllowedCategory) > 0 {
+				opts = append(opts, WithAllowedCategories(tc.AllowedCategory...))
+			}
+			if tc.DynamicDirection != "" {
+				opts = append(opts, WithDynamicDirection(tc.DynamicDirection))
+			}
+
+			pf := NewPathFinder(opts...)
+			paths, err := pf.FindAllPaths(tc.Source, tc.Target, tc.PathResource)
+
+			if tc.ExpectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Expected, paths)
+		})
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/redis_provider.go
+++ b/pkg/unify-query/cmdb/v1beta3/redis_provider.go
@@ -1,0 +1,584 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
+	unifyRedis "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+)
+
+const (
+	// Redis Key 前缀（与 bk-monitor-worker 保持一致）
+	DefaultRedisKeyPrefix = "bkmonitorv3:entity"
+
+	// Pub/Sub 通道后缀
+	DefaultRedisPubSubChannelSuffix = ":channel"
+
+	// 实体 Kind 名称（与 bk-monitor-worker 保持一致）
+	KindResourceDef = "ResourceDefinition"
+	KindRelationDef = "RelationDefinition"
+
+	// Redis Hash key（与 bk-monitor-worker 保持一致）
+	// 结构: bkmonitorv3:entity:{Kind} -> namespace -> {name: JSON, ...}
+	DefaultRedisKeyPrefixResourceDef = DefaultRedisKeyPrefix + ":" + KindResourceDef
+	DefaultRedisKeyPrefixRelationDef = DefaultRedisKeyPrefix + ":" + KindRelationDef
+
+	// Pub/Sub 通道名称
+	DefaultRedisPubSubChannelResourceDef = DefaultRedisKeyPrefixResourceDef + DefaultRedisPubSubChannelSuffix
+	DefaultRedisPubSubChannelRelationDef = DefaultRedisKeyPrefixRelationDef + DefaultRedisPubSubChannelSuffix
+
+	// 空 namespace 的映射值（与 bk-monitor-worker 保持一致）
+	NamespaceAll = "__all__"
+
+	// 内部默认值
+	defaultRedisReconnectInterval = 5 * time.Second
+	defaultRedisReconnectMaxRetry = 10
+)
+
+// RedisSchemaProviderConfig Redis Schema 提供器配置
+type RedisSchemaProviderConfig struct {
+	ReconnectInterval time.Duration
+	ReconnectMaxRetry int
+	ReloadOnStart     bool
+}
+
+// DefaultRedisSchemaProviderConfig 返回默认配置
+func DefaultRedisSchemaProviderConfig() *RedisSchemaProviderConfig {
+	return &RedisSchemaProviderConfig{
+		ReconnectInterval: defaultRedisReconnectInterval,
+		ReconnectMaxRetry: defaultRedisReconnectMaxRetry,
+		ReloadOnStart:     true,
+	}
+}
+
+// RedisSchemaProvider Redis Schema 提供器
+// 从 Redis 动态加载资源和关联定义，支持 Pub/Sub 热更新
+//
+// Redis 数据结构（与 bk-monitor-worker 保持一致）:
+//   - key:   bkmonitorv3:entity:ResourceDefinition
+//   - field: {namespace}
+//   - value: {"name1": {JSON}, "name2": {JSON}, ...}
+type RedisSchemaProvider struct {
+	client redis.UniversalClient
+	config *RedisSchemaProviderConfig
+
+	// 外层 key: namespace, 内层 key: resource/relation name
+	resourceDefinitions map[string]map[string]*cmdb.ResourceDefinition
+	relationDefinitions map[string]map[string]*cmdb.RelationDefinition
+	mu                  sync.RWMutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// RedisSchemaProviderOption Redis Schema 提供器配置选项
+type RedisSchemaProviderOption func(*RedisSchemaProviderConfig)
+
+// WithReloadOnStart 设置启动时是否重新加载所有数据
+func WithReloadOnStart(reload bool) RedisSchemaProviderOption {
+	return func(config *RedisSchemaProviderConfig) {
+		config.ReloadOnStart = reload
+	}
+}
+
+// WithReconnectConfig 设置重连配置
+func WithReconnectConfig(interval time.Duration, maxRetry int) RedisSchemaProviderOption {
+	return func(config *RedisSchemaProviderConfig) {
+		config.ReconnectInterval = interval
+		config.ReconnectMaxRetry = maxRetry
+	}
+}
+
+// NewRedisSchemaProvider 创建 Redis Schema 提供器（使用自定义客户端）
+func NewRedisSchemaProvider(client redis.UniversalClient, opts ...RedisSchemaProviderOption) (*RedisSchemaProvider, error) {
+	config := DefaultRedisSchemaProviderConfig()
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &RedisSchemaProvider{
+		client:              client,
+		config:              config,
+		resourceDefinitions: make(map[string]map[string]*cmdb.ResourceDefinition),
+		relationDefinitions: make(map[string]map[string]*cmdb.RelationDefinition),
+		ctx:                 ctx,
+		cancel:              cancel,
+	}
+
+	if config.ReloadOnStart {
+		if err := provider.loadAllEntities(); err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to load entities: %w", err)
+		}
+	}
+
+	provider.wg.Add(1)
+	go provider.subscribeEntities()
+
+	return provider, nil
+}
+
+// NewRedisSchemaProviderWithGlobalClient 创建 Redis Schema 提供器（使用全局客户端）
+func NewRedisSchemaProviderWithGlobalClient(opts ...RedisSchemaProviderOption) (*RedisSchemaProvider, error) {
+	client := unifyRedis.Client()
+	if client == nil {
+		return nil, fmt.Errorf("global redis client is not initialized, please call redis.SetInstance first")
+	}
+	return NewRedisSchemaProvider(client, opts...)
+}
+
+// Close 关闭提供器
+func (rsp *RedisSchemaProvider) Close() error {
+	rsp.cancel()
+	rsp.wg.Wait()
+	return nil
+}
+
+// normalizeNamespace 规范化 namespace，空的映射到 __all__（与 bk-monitor-worker 保持一致）
+func (rsp *RedisSchemaProvider) normalizeNamespace(namespace string) string {
+	if namespace == "" {
+		return NamespaceAll
+	}
+	return namespace
+}
+
+// loadAllEntities 启动时全量加载所有实体
+func (rsp *RedisSchemaProvider) loadAllEntities() error {
+	var err error
+	ctx, span := trace.NewSpan(rsp.ctx, "redis_provider.load_all_entities")
+	defer span.End(&err)
+
+	if err = rsp.loadEntitiesByKind(ctx, KindResourceDef); err != nil {
+		return fmt.Errorf("failed to load resource definitions: %w", err)
+	}
+	if err = rsp.loadEntitiesByKind(ctx, KindRelationDef); err != nil {
+		return fmt.Errorf("failed to load relation definitions: %w", err)
+	}
+
+	resourceCount := 0
+	for _, nsMap := range rsp.resourceDefinitions {
+		resourceCount += len(nsMap)
+	}
+	relationCount := 0
+	for _, nsMap := range rsp.relationDefinitions {
+		relationCount += len(nsMap)
+	}
+
+	log.Infof(ctx, "loaded %d resource definitions, %d relation definitions", resourceCount, relationCount)
+	return nil
+}
+
+// loadEntitiesByKind 按 Kind 全量加载实体
+// Redis 结构: {prefix}:{kind} -> namespace -> {name: JSON, ...}
+func (rsp *RedisSchemaProvider) loadEntitiesByKind(ctx context.Context, kind string) error {
+	redisKey := DefaultRedisKeyPrefix + ":" + kind
+
+	result, err := rsp.client.HGetAll(ctx, redisKey).Result()
+	if err != nil {
+		return fmt.Errorf("failed to hgetall %s: %w", redisKey, err)
+	}
+
+	for namespace, entitiesJSON := range result {
+		var entities map[string]json.RawMessage
+		if unmarshalErr := json.Unmarshal([]byte(entitiesJSON), &entities); unmarshalErr != nil {
+			log.Warnf(ctx, "failed to unmarshal entities for namespace %s: %v", namespace, unmarshalErr)
+			continue
+		}
+		for name, jsonData := range entities {
+			if loadErr := rsp.loadEntityByKind(kind, namespace, name, string(jsonData)); loadErr != nil {
+				log.Warnf(ctx, "failed to load %s %s:%s: %v", kind, namespace, name, loadErr)
+			}
+		}
+	}
+	return nil
+}
+
+// loadEntityByKind 加载单个实体到缓存
+func (rsp *RedisSchemaProvider) loadEntityByKind(kind, namespace, name, jsonData string) error {
+	normalizedNs := rsp.normalizeNamespace(namespace)
+	switch kind {
+	case KindResourceDef:
+		var def cmdb.ResourceDefinition
+		if err := json.Unmarshal([]byte(jsonData), &def); err != nil {
+			return fmt.Errorf("failed to unmarshal ResourceDefinition: %w", err)
+		}
+		rsp.mu.Lock()
+		if _, ok := rsp.resourceDefinitions[normalizedNs]; !ok {
+			rsp.resourceDefinitions[normalizedNs] = make(map[string]*cmdb.ResourceDefinition)
+		}
+		rsp.resourceDefinitions[normalizedNs][name] = &def
+		rsp.mu.Unlock()
+
+	case KindRelationDef:
+		var def cmdb.RelationDefinition
+		if err := json.Unmarshal([]byte(jsonData), &def); err != nil {
+			return fmt.Errorf("failed to unmarshal RelationDefinition: %w", err)
+		}
+		rsp.mu.Lock()
+		if _, ok := rsp.relationDefinitions[normalizedNs]; !ok {
+			rsp.relationDefinitions[normalizedNs] = make(map[string]*cmdb.RelationDefinition)
+		}
+		rsp.relationDefinitions[normalizedNs][name] = &def
+		rsp.mu.Unlock()
+	}
+	return nil
+}
+
+// reloadNamespace 按 namespace 全量重建该 kind 的本地缓存（与 bk-monitor-worker 保持一致）
+func (rsp *RedisSchemaProvider) reloadNamespace(ctx context.Context, kind, namespace string) error {
+	redisKey := DefaultRedisKeyPrefix + ":" + kind
+	normalizedNs := rsp.normalizeNamespace(namespace)
+
+	entitiesJSON, err := rsp.client.HGet(ctx, redisKey, namespace).Result()
+	if errors.Is(err, redis.Nil) {
+		// namespace 已不存在，清空缓存
+		rsp.mu.Lock()
+		switch kind {
+		case KindResourceDef:
+			delete(rsp.resourceDefinitions, normalizedNs)
+		case KindRelationDef:
+			delete(rsp.relationDefinitions, normalizedNs)
+		}
+		rsp.mu.Unlock()
+		log.Infof(ctx, "cleared namespace cache: kind=%s, ns=%s", kind, namespace)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to hget: %w", err)
+	}
+
+	var entities map[string]json.RawMessage
+	if err = json.Unmarshal([]byte(entitiesJSON), &entities); err != nil {
+		return fmt.Errorf("failed to unmarshal entities: %w", err)
+	}
+
+	switch kind {
+	case KindResourceDef:
+		newMap := make(map[string]*cmdb.ResourceDefinition, len(entities))
+		for name, jsonData := range entities {
+			var def cmdb.ResourceDefinition
+			if unmarshalErr := json.Unmarshal(jsonData, &def); unmarshalErr != nil {
+				log.Warnf(ctx, "failed to unmarshal ResourceDefinition %s:%s: %v", namespace, name, unmarshalErr)
+				continue
+			}
+			newMap[name] = &def
+		}
+		rsp.mu.Lock()
+		rsp.resourceDefinitions[normalizedNs] = newMap
+		rsp.mu.Unlock()
+
+	case KindRelationDef:
+		newMap := make(map[string]*cmdb.RelationDefinition, len(entities))
+		for name, jsonData := range entities {
+			var def cmdb.RelationDefinition
+			if unmarshalErr := json.Unmarshal(jsonData, &def); unmarshalErr != nil {
+				log.Warnf(ctx, "failed to unmarshal RelationDefinition %s:%s: %v", namespace, name, unmarshalErr)
+				continue
+			}
+			newMap[name] = &def
+		}
+		rsp.mu.Lock()
+		rsp.relationDefinitions[normalizedNs] = newMap
+		rsp.mu.Unlock()
+	}
+
+	log.Infof(ctx, "reloaded namespace cache: kind=%s, ns=%s, count=%d", kind, namespace, len(entities))
+	return nil
+}
+
+// MsgPayload Pub/Sub 消息体（与 bk-monitor-worker 保持一致）
+type MsgPayload struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+}
+
+// subscribeEntities 订阅实体变更通知
+func (rsp *RedisSchemaProvider) subscribeEntities() {
+	defer rsp.wg.Done()
+
+	channels := []string{
+		DefaultRedisPubSubChannelResourceDef,
+		DefaultRedisPubSubChannelRelationDef,
+	}
+
+	retryCount := 0
+	for {
+		select {
+		case <-rsp.ctx.Done():
+			return
+		default:
+		}
+
+		pubsub := rsp.client.Subscribe(rsp.ctx, channels...)
+		log.Infof(rsp.ctx, "subscribed to entity channels: %v", channels)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			ch := pubsub.Channel()
+			for {
+				select {
+				case <-rsp.ctx.Done():
+					return
+				case msg := <-ch:
+					if msg == nil {
+						return
+					}
+
+					var payload MsgPayload
+					if err := json.Unmarshal([]byte(msg.Payload), &payload); err != nil {
+						log.Warnf(rsp.ctx, "invalid pubsub payload: %s, err: %v", msg.Payload, err)
+						continue
+					}
+					if payload.Namespace == "" || payload.Kind == "" {
+						log.Warnf(rsp.ctx, "empty namespace or kind in payload: %s", msg.Payload)
+						continue
+					}
+
+					log.Infof(rsp.ctx, "received entity update: kind=%s namespace=%s", payload.Kind, payload.Namespace)
+					if err := rsp.reloadNamespace(rsp.ctx, payload.Kind, payload.Namespace); err != nil {
+						log.Errorf(rsp.ctx, "failed to reload namespace %s:%s: %v", payload.Kind, payload.Namespace, err)
+					}
+				}
+			}
+		}()
+
+		select {
+		case <-rsp.ctx.Done():
+			pubsub.Close()
+			<-done
+			return
+		case <-done:
+			pubsub.Close()
+		}
+
+		retryCount++
+		if retryCount > rsp.config.ReconnectMaxRetry {
+			log.Errorf(rsp.ctx, "max retry count reached for entity subscription")
+			return
+		}
+
+		log.Warnf(rsp.ctx, "entity subscription disconnected, retrying in %v (attempt %d/%d)",
+			rsp.config.ReconnectInterval, retryCount, rsp.config.ReconnectMaxRetry)
+
+		select {
+		case <-rsp.ctx.Done():
+			return
+		case <-time.After(rsp.config.ReconnectInterval):
+		}
+	}
+}
+
+// GetResourceDefinition 获取资源定义
+func (rsp *RedisSchemaProvider) GetResourceDefinition(namespace, name string) (*cmdb.ResourceDefinition, error) {
+	var err error
+	ctx, span := trace.NewSpan(rsp.ctx, "redis_provider.get_resource_definition")
+	defer span.End(&err)
+
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	ns := rsp.normalizeNamespace(namespace)
+
+	// 先从指定 namespace 查找
+	if nsMap, ok := rsp.resourceDefinitions[ns]; ok {
+		if def, ok := nsMap[name]; ok {
+			span.Set("cache.hit", true)
+			return def, nil
+		}
+	}
+
+	// 如果指定 namespace 没找到，尝试从 __all__ 查找
+	if ns != NamespaceAll {
+		if allMap, ok := rsp.resourceDefinitions[NamespaceAll]; ok {
+			if def, ok := allMap[name]; ok {
+				span.Set("cache.hit", true)
+				return def, nil
+			}
+		}
+	}
+
+	err = cmdb.ErrResourceDefinitionNotFound
+	span.Set("cache.hit", false)
+	log.Debugf(ctx, "resource definition not found: namespace=%s, name=%s", namespace, name)
+	return nil, err
+}
+
+// ListResourceDefinitions 列出指定命名空间下的所有资源定义
+func (rsp *RedisSchemaProvider) ListResourceDefinitions(namespace string) ([]*cmdb.ResourceDefinition, error) {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	result := make([]*cmdb.ResourceDefinition, 0)
+	if namespace == "" {
+		for _, nsMap := range rsp.resourceDefinitions {
+			for _, def := range nsMap {
+				result = append(result, def)
+			}
+		}
+		return result, nil
+	}
+
+	ns := rsp.normalizeNamespace(namespace)
+	seen := make(map[string]struct{})
+
+	if nsMap, ok := rsp.resourceDefinitions[ns]; ok {
+		for name, def := range nsMap {
+			result = append(result, def)
+			seen[name] = struct{}{}
+		}
+	}
+
+	// 合并 __all__ 的定义（指定 namespace 优先）
+	if ns != NamespaceAll {
+		if allMap, ok := rsp.resourceDefinitions[NamespaceAll]; ok {
+			for name, def := range allMap {
+				if _, exists := seen[name]; !exists {
+					result = append(result, def)
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+// GetRelationDefinition 获取关联定义
+func (rsp *RedisSchemaProvider) GetRelationDefinition(namespace, name string) (*cmdb.RelationDefinition, error) {
+	var err error
+	ctx, span := trace.NewSpan(rsp.ctx, "redis_provider.get_relation_definition")
+	defer span.End(&err)
+
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	ns := rsp.normalizeNamespace(namespace)
+
+	// 先从指定 namespace 查找
+	if nsMap, ok := rsp.relationDefinitions[ns]; ok {
+		if def, ok := nsMap[name]; ok {
+			span.Set("cache.hit", true)
+			return def, nil
+		}
+	}
+
+	// 如果指定 namespace 没找到，尝试从 __all__ 查找
+	if ns != NamespaceAll {
+		if allMap, ok := rsp.relationDefinitions[NamespaceAll]; ok {
+			if def, ok := allMap[name]; ok {
+				span.Set("cache.hit", true)
+				return def, nil
+			}
+		}
+	}
+
+	err = cmdb.ErrRelationDefinitionNotFound
+	span.Set("cache.hit", false)
+	log.Debugf(ctx, "relation definition not found: namespace=%s, name=%s", namespace, name)
+	return nil, err
+}
+
+// ListRelationDefinitions 列出指定命名空间下的所有关联定义
+func (rsp *RedisSchemaProvider) ListRelationDefinitions(namespace string) ([]*cmdb.RelationDefinition, error) {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	result := make([]*cmdb.RelationDefinition, 0)
+	if namespace == "" {
+		for _, nsMap := range rsp.relationDefinitions {
+			for _, def := range nsMap {
+				result = append(result, def)
+			}
+		}
+		return result, nil
+	}
+
+	ns := rsp.normalizeNamespace(namespace)
+	seen := make(map[string]struct{})
+
+	if nsMap, ok := rsp.relationDefinitions[ns]; ok {
+		for name, def := range nsMap {
+			result = append(result, def)
+			seen[name] = struct{}{}
+		}
+	}
+
+	// 合并 __all__（指定 namespace 优先）
+	if ns != NamespaceAll {
+		if allMap, ok := rsp.relationDefinitions[NamespaceAll]; ok {
+			for name, def := range allMap {
+				if _, exists := seen[name]; !exists {
+					result = append(result, def)
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+// GetResourcePrimaryKeys 获取资源类型的主键字段列表
+func (rsp *RedisSchemaProvider) GetResourcePrimaryKeys(resourceType ResourceType) []string {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	for _, nsMap := range rsp.resourceDefinitions {
+		for _, rd := range nsMap {
+			if ToResourceType(rd) == resourceType {
+				return rd.GetPrimaryKeys()
+			}
+		}
+	}
+	return []string{}
+}
+
+// GetRelationSchema 获取关联关系的 Schema
+func (rsp *RedisSchemaProvider) GetRelationSchema(relationType RelationType) (*RelationSchema, error) {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	for _, nsMap := range rsp.relationDefinitions {
+		for _, rd := range nsMap {
+			if ToRelationType(rd) == relationType {
+				schema := ToRelationSchema(rd)
+				return &schema, nil
+			}
+		}
+	}
+	return nil, cmdb.ErrRelationDefinitionNotFound
+}
+
+// ListRelationSchemas 列出所有关联 Schema
+func (rsp *RedisSchemaProvider) ListRelationSchemas() []RelationSchema {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	result := make([]RelationSchema, 0)
+	for _, nsMap := range rsp.relationDefinitions {
+		for _, rd := range nsMap {
+			result = append(result, ToRelationSchema(rd))
+		}
+	}
+	return result
+}
+
+// Ensure RedisSchemaProvider implements SchemaProvider
+var _ SchemaProvider = (*RedisSchemaProvider)(nil)

--- a/pkg/unify-query/cmdb/v1beta3/redis_provider_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/redis_provider_test.go
@@ -1,0 +1,363 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+// setupTestRedis 创建测试用的 Redis 实例
+func setupTestRedis(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	return client, mr
+}
+
+// setResourceDefinitions 向 miniredis 写入资源定义
+// Redis 结构: bkmonitorv3:entity:ResourceDefinition -> namespace -> {name: JSON, ...}
+func setResourceDefinitions(t *testing.T, mr *miniredis.Miniredis, namespace string, defs ...*cmdb.ResourceDefinition) {
+	t.Helper()
+	entities := make(map[string]json.RawMessage, len(defs))
+	for _, def := range defs {
+		b, err := json.Marshal(def)
+		require.NoError(t, err)
+		entities[def.Name] = b
+	}
+	b, err := json.Marshal(entities)
+	require.NoError(t, err)
+	mr.HSet(DefaultRedisKeyPrefixResourceDef, namespace, string(b))
+}
+
+// setRelationDefinitions 向 miniredis 写入关联定义
+// Redis 结构: bkmonitorv3:entity:RelationDefinition -> namespace -> {name: JSON, ...}
+func setRelationDefinitions(t *testing.T, mr *miniredis.Miniredis, namespace string, defs ...*cmdb.RelationDefinition) {
+	t.Helper()
+	entities := make(map[string]json.RawMessage, len(defs))
+	for _, def := range defs {
+		b, err := json.Marshal(def)
+		require.NoError(t, err)
+		entities[def.Name] = b
+	}
+	b, err := json.Marshal(entities)
+	require.NoError(t, err)
+	mr.HSet(DefaultRedisKeyPrefixRelationDef, namespace, string(b))
+}
+
+// TestRedisSchemaProvider_LoadResourceDefinitions 测试加载资源定义
+func TestRedisSchemaProvider_LoadResourceDefinitions(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd1 := &cmdb.ResourceDefinition{
+		Namespace: "test",
+		Name:      "app_instance",
+		Fields: []cmdb.FieldDefinition{
+			{Name: "app_id", Required: true},
+			{Name: "instance_id", Required: true},
+			{Name: "version", Required: false},
+		},
+		Labels: map[string]string{"env": "test"},
+	}
+	rd2 := &cmdb.ResourceDefinition{
+		Namespace: "test",
+		Name:      "git_commit",
+		Fields: []cmdb.FieldDefinition{
+			{Name: "repo", Required: true},
+			{Name: "commit_sha", Required: true},
+		},
+	}
+	setResourceDefinitions(t, mr, "test", rd1, rd2)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	t.Run("GetResourceDefinition", func(t *testing.T) {
+		rd, err := provider.GetResourceDefinition("test", "app_instance")
+		require.NoError(t, err)
+		assert.Equal(t, "test", rd.Namespace)
+		assert.Equal(t, "app_instance", rd.Name)
+		assert.Len(t, rd.Fields, 3)
+		assert.Equal(t, []string{"app_id", "instance_id"}, rd.GetPrimaryKeys())
+	})
+
+	t.Run("ListResourceDefinitions", func(t *testing.T) {
+		list, err := provider.ListResourceDefinitions("test")
+		require.NoError(t, err)
+		assert.Len(t, list, 2)
+	})
+
+	t.Run("GetResourcePrimaryKeys", func(t *testing.T) {
+		keys := provider.GetResourcePrimaryKeys("app_instance")
+		assert.Equal(t, []string{"app_id", "instance_id"}, keys)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := provider.GetResourceDefinition("test", "nonexistent")
+		assert.ErrorIs(t, err, cmdb.ErrResourceDefinitionNotFound)
+	})
+}
+
+// TestRedisSchemaProvider_LoadRelationDefinitions 测试加载关联定义
+func TestRedisSchemaProvider_LoadRelationDefinitions(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd1 := &cmdb.RelationDefinition{
+		Namespace:    "test",
+		Name:         "app_to_commit",
+		FromResource: "app_instance",
+		ToResource:   "git_commit",
+		Category:     "dynamic",
+	}
+	rd2 := &cmdb.RelationDefinition{
+		Namespace:    "test",
+		Name:         "commit_to_author",
+		FromResource: "git_commit",
+		ToResource:   "developer",
+		Category:     "static",
+		IsBelongsTo:  true,
+	}
+	setRelationDefinitions(t, mr, "test", rd1, rd2)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	t.Run("GetRelationDefinition", func(t *testing.T) {
+		rd, err := provider.GetRelationDefinition("test", "app_to_commit")
+		require.NoError(t, err)
+		assert.Equal(t, "test", rd.Namespace)
+		assert.Equal(t, "app_to_commit", rd.Name)
+		assert.Equal(t, "app_instance", rd.FromResource)
+		assert.Equal(t, "git_commit", rd.ToResource)
+		assert.Equal(t, "dynamic", rd.Category)
+	})
+
+	t.Run("ListRelationDefinitions", func(t *testing.T) {
+		list, err := provider.ListRelationDefinitions("test")
+		require.NoError(t, err)
+		assert.Len(t, list, 2)
+	})
+
+	t.Run("GetRelationSchema", func(t *testing.T) {
+		schema, err := provider.GetRelationSchema("test:app_to_commit")
+		require.NoError(t, err)
+		assert.Equal(t, RelationType("test:app_to_commit"), schema.RelationType)
+		assert.Equal(t, RelationCategoryDynamic, schema.Category)
+		assert.Equal(t, ResourceType("app_instance"), schema.FromType)
+		assert.Equal(t, ResourceType("git_commit"), schema.ToType)
+		assert.False(t, schema.IsBelongsTo)
+	})
+
+	t.Run("ListRelationSchemas", func(t *testing.T) {
+		schemas := provider.ListRelationSchemas()
+		assert.Len(t, schemas, 2)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := provider.GetRelationDefinition("test", "nonexistent")
+		assert.ErrorIs(t, err, cmdb.ErrRelationDefinitionNotFound)
+	})
+}
+
+// TestRedisSchemaProvider_HotReload 测试热更新（Pub/Sub）
+func TestRedisSchemaProvider_HotReload(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &cmdb.ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []cmdb.FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 验证初始数据
+	result, err := provider.GetResourceDefinition("test", "app")
+	require.NoError(t, err)
+	assert.Len(t, result.Fields, 1)
+
+	// 等待 Pub/Sub 订阅建立
+	time.Sleep(100 * time.Millisecond)
+
+	// 更新 Redis 数据
+	rd.Fields = append(rd.Fields, cmdb.FieldDefinition{Name: "version", Required: false})
+	setResourceDefinitions(t, mr, "test", rd)
+
+	// 发送 Pub/Sub 通知（JSON 格式，与 bk-monitor-worker 保持一致）
+	ctx := context.Background()
+	payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+	client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+
+	// 等待热更新完成（轮询，最多 1 秒）
+	var updated *cmdb.ResourceDefinition
+	for i := 0; i < 20; i++ {
+		updated, err = provider.GetResourceDefinition("test", "app")
+		if err == nil && len(updated.Fields) == 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.NoError(t, err)
+	require.Len(t, updated.Fields, 2)
+	assert.Equal(t, "version", updated.Fields[1].Name)
+}
+
+// TestRedisSchemaProvider_HotDelete 测试热删除（namespace 不存在时清空缓存）
+func TestRedisSchemaProvider_HotDelete(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &cmdb.ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []cmdb.FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 验证初始数据
+	_, err = provider.GetResourceDefinition("test", "app")
+	require.NoError(t, err)
+
+	// 等待 Pub/Sub 订阅建立
+	time.Sleep(100 * time.Millisecond)
+
+	// 删除 Redis Hash field（整个 namespace）
+	mr.HDel(DefaultRedisKeyPrefixResourceDef, "test")
+
+	// 发送 Pub/Sub 通知
+	ctx := context.Background()
+	payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+	client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+
+	// 等待删除完成
+	for i := 0; i < 20; i++ {
+		_, err = provider.GetResourceDefinition("test", "app")
+		if err != nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	assert.ErrorIs(t, err, cmdb.ErrResourceDefinitionNotFound)
+}
+
+// TestRedisSchemaProvider_WithoutReloadOnStart 测试不预加载
+func TestRedisSchemaProvider_WithoutReloadOnStart(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &cmdb.ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []cmdb.FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	// 创建提供器，不预加载
+	provider, err := NewRedisSchemaProvider(client, WithReloadOnStart(false))
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 等待 Pub/Sub 订阅建立
+	time.Sleep(100 * time.Millisecond)
+
+	// 立即查询，应该找不到（因为没有预加载）
+	_, err = provider.GetResourceDefinition("test", "app")
+	assert.ErrorIs(t, err, cmdb.ErrResourceDefinitionNotFound)
+
+	// 发送 Pub/Sub 通知触发加载
+	ctx := context.Background()
+	payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+	client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+
+	// 等待加载完成
+	var result *cmdb.ResourceDefinition
+	for i := 0; i < 20; i++ {
+		result, err = provider.GetResourceDefinition("test", "app")
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.NoError(t, err)
+	assert.Equal(t, "app", result.Name)
+}
+
+// TestRedisSchemaProvider_ConcurrentAccess 测试并发访问
+func TestRedisSchemaProvider_ConcurrentAccess(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &cmdb.ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []cmdb.FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 并发读写测试
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_, _ = provider.GetResourceDefinition("test", "app")
+				_ = provider.ListRelationSchemas()
+			}
+			done <- true
+		}()
+	}
+
+	// 同时进行更新
+	go func() {
+		ctx := context.Background()
+		payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+		for i := 0; i < 50; i++ {
+			client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// 验证数据一致性
+	result, err := provider.GetResourceDefinition("test", "app")
+	require.NoError(t, err)
+	assert.Equal(t, "app", result.Name)
+}

--- a/pkg/unify-query/cmdb/v1beta3/request.go
+++ b/pkg/unify-query/cmdb/v1beta3/request.go
@@ -1,0 +1,74 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+// QueryRequest 关联查询请求
+type QueryRequest struct {
+	Timestamp                int64              `json:"timestamp"`                            // 查询时间点（毫秒时间戳）
+	SourceType               ResourceType       `json:"source_type"`                          // 源资源类型
+	SourceInfo               map[string]string  `json:"source_info"`                          // 源资源过滤条件
+	TargetType               ResourceType       `json:"target_type,omitempty"`                // 目标资源类型（可选，用于定向查询）
+	PathResource             []ResourceType     `json:"path_resource,omitempty"`              // 路径约束资源类型
+	MaxHops                  int                `json:"max_hops,omitempty"`                   // 最大跳数（默认2，范围1-5）
+	AllowedRelationTypes     []RelationCategory `json:"allowed_relation_types,omitempty"`     // 允许的关系类别
+	DynamicRelationDirection TraversalDirection `json:"dynamic_relation_direction,omitempty"` // 动态关系方向（默认both）
+	LookBackDelta            int64              `json:"look_back_delta,omitempty"`            // 回溯时间窗口（毫秒，默认86400000）
+	Limit                    int                `json:"limit,omitempty"`                      // 返回的Root数量限制（默认100）
+}
+
+// Normalize 规范化请求参数，填充默认值
+func (r *QueryRequest) Normalize() {
+	if r.MaxHops <= 0 {
+		r.MaxHops = DefaultMaxHops
+	}
+	if r.MaxHops > MaxAllowedHops {
+		r.MaxHops = MaxAllowedHops
+	}
+	if r.Limit <= 0 {
+		r.Limit = DefaultLimit
+	}
+	if r.LookBackDelta <= 0 {
+		r.LookBackDelta = DefaultLookBackDelta
+	}
+	if r.DynamicRelationDirection == "" {
+		r.DynamicRelationDirection = DirectionBoth
+	}
+	if len(r.AllowedRelationTypes) == 0 {
+		r.AllowedRelationTypes = []RelationCategory{RelationCategoryStatic, RelationCategoryDynamic}
+	}
+}
+
+// GetQueryRange 获取查询时间范围
+func (r *QueryRequest) GetQueryRange() (start, end int64) {
+	end = r.Timestamp
+	start = r.Timestamp - r.LookBackDelta
+	if start < 0 {
+		start = 0
+	}
+	return start, end
+}
+
+// GetSourceResourceID 获取源资源ID
+func (r *QueryRequest) GetSourceResourceID() string {
+	return GenerateResourceID(r.SourceType, r.SourceInfo)
+}
+
+// IsRelationCategoryAllowed 检查关系类别是否允许
+func (r *QueryRequest) IsRelationCategoryAllowed(category RelationCategory) bool {
+	if len(r.AllowedRelationTypes) == 0 {
+		return true // 默认允许所有
+	}
+	for _, allowed := range r.AllowedRelationTypes {
+		if allowed == category {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/unify-query/cmdb/v1beta3/schema.go
+++ b/pkg/unify-query/cmdb/v1beta3/schema.go
@@ -1,0 +1,54 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+type RelationSchema struct {
+	RelationType RelationType
+	Category     RelationCategory
+	FromType     ResourceType
+	ToType       ResourceType
+	IsBelongsTo  bool
+}
+
+var schemaRegistry = []RelationSchema{
+	{RelationNodeWithSystem, RelationCategoryStatic, ResourceTypeNode, ResourceTypeSystem, false},
+	{RelationNodeWithPod, RelationCategoryStatic, ResourceTypeNode, ResourceTypePod, false},
+	{RelationJobWithPod, RelationCategoryStatic, ResourceTypeJob, ResourceTypePod, false},
+	{RelationPodWithReplicaSet, RelationCategoryStatic, ResourceTypePod, ResourceTypeReplicaSet, true},
+	{RelationPodWithStatefulSet, RelationCategoryStatic, ResourceTypePod, ResourceTypeStatefulSet, true},
+	{RelationDaemonSetWithPod, RelationCategoryStatic, ResourceTypeDaemonSet, ResourceTypePod, true},
+	{RelationDeploymentWithReplicaSet, RelationCategoryStatic, ResourceTypeDeployment, ResourceTypeReplicaSet, true},
+	{RelationPodWithService, RelationCategoryStatic, ResourceTypePod, ResourceTypeService, false},
+	{RelationIngressWithService, RelationCategoryStatic, ResourceTypeIngress, ResourceTypeService, false},
+	{RelationK8sAddressWithService, RelationCategoryStatic, ResourceTypeK8sAddress, ResourceTypeService, false},
+	{RelationDomainWithService, RelationCategoryStatic, ResourceTypeDomain, ResourceTypeService, false},
+	{RelationAPMServiceInstanceWithPod, RelationCategoryStatic, ResourceTypeAPMServiceInstance, ResourceTypePod, false},
+	{RelationAPMServiceInstanceWithSystem, RelationCategoryStatic, ResourceTypeAPMServiceInstance, ResourceTypeSystem, false},
+	{RelationAPMServiceWithAPMServiceInstance, RelationCategoryStatic, ResourceTypeAPMService, ResourceTypeAPMServiceInstance, true},
+	{RelationContainerWithPod, RelationCategoryStatic, ResourceTypeContainer, ResourceTypePod, true},
+	{RelationDataSourceWithPod, RelationCategoryStatic, ResourceTypeDataSource, ResourceTypePod, false},
+	{RelationDataSourceWithNode, RelationCategoryStatic, ResourceTypeDataSource, ResourceTypeNode, false},
+	{RelationBKLogConfigWithDataSource, RelationCategoryStatic, ResourceTypeBKLogConfig, ResourceTypeDataSource, false},
+	{RelationBizWithSet, RelationCategoryStatic, ResourceTypeBiz, ResourceTypeSet, true},
+	{RelationModuleWithSet, RelationCategoryStatic, ResourceTypeModule, ResourceTypeSet, true},
+	{RelationHostWithModule, RelationCategoryStatic, ResourceTypeHost, ResourceTypeModule, true},
+	{RelationHostWithSystem, RelationCategoryStatic, ResourceTypeHost, ResourceTypeSystem, false},
+	{RelationAppVersionWithContainer, RelationCategoryStatic, ResourceTypeAppVersion, ResourceTypeContainer, false},
+	{RelationAppVersionWithSystem, RelationCategoryStatic, ResourceTypeAppVersion, ResourceTypeSystem, false},
+	{RelationContainerWithEnvironment, RelationCategoryStatic, ResourceTypeContainer, ResourceTypeEnvironment, false},
+	{RelationEnvironmentWithSystem, RelationCategoryStatic, ResourceTypeEnvironment, ResourceTypeSystem, false},
+	{RelationAppVersionWithGitCommit, RelationCategoryStatic, ResourceTypeAppVersion, ResourceTypeGitCommit, false},
+
+	{RelationPodToPod, RelationCategoryDynamic, ResourceTypePod, ResourceTypePod, false},
+	{RelationPodToSystem, RelationCategoryDynamic, ResourceTypePod, ResourceTypeSystem, false},
+	{RelationSystemToPod, RelationCategoryDynamic, ResourceTypeSystem, ResourceTypePod, false},
+	{RelationSystemToSystem, RelationCategoryDynamic, ResourceTypeSystem, ResourceTypeSystem, false},
+	{RelationServiceToService, RelationCategoryDynamic, ResourceTypeService, ResourceTypeService, false},
+}

--- a/pkg/unify-query/cmdb/v1beta3/schema_provider.go
+++ b/pkg/unify-query/cmdb/v1beta3/schema_provider.go
@@ -1,0 +1,58 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"fmt"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+// SchemaProvider v1beta3 扩展的 Schema 提供器接口
+// 嵌入 cmdb.SchemaProvider 基础接口，并添加 v1beta3 特有的方法
+type SchemaProvider interface {
+	cmdb.SchemaProvider
+	// GetResourcePrimaryKeys 获取资源类型的主键字段列表
+	GetResourcePrimaryKeys(resourceType ResourceType) []string
+	// GetRelationSchema 获取关联关系的 Schema
+	GetRelationSchema(relationType RelationType) (*RelationSchema, error)
+	// ListRelationSchemas 列出所有关联 Schema
+	ListRelationSchemas() []RelationSchema
+}
+
+// ToResourceType 将 ResourceDefinition 转换为 v1beta3 ResourceType
+func ToResourceType(rd *cmdb.ResourceDefinition) ResourceType {
+	return ResourceType(rd.Name)
+}
+
+// ToRelationType 将 RelationDefinition 转换为 v1beta3 RelationType
+func ToRelationType(rd *cmdb.RelationDefinition) RelationType {
+	// 如果有 namespace,格式为 {namespace}:{name}
+	if rd.Namespace != "" {
+		return RelationType(fmt.Sprintf("%s:%s", rd.Namespace, rd.Name))
+	}
+	return RelationType(rd.Name)
+}
+
+// ToRelationSchema 将 RelationDefinition 转换为 v1beta3 RelationSchema
+func ToRelationSchema(rd *cmdb.RelationDefinition) RelationSchema {
+	category := RelationCategoryStatic
+	if rd.Category == "dynamic" {
+		category = RelationCategoryDynamic
+	}
+
+	return RelationSchema{
+		RelationType: ToRelationType(rd),
+		Category:     category,
+		FromType:     ResourceType(rd.FromResource),
+		ToType:       ResourceType(rd.ToResource),
+		IsBelongsTo:  rd.IsBelongsTo,
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/settings.go
+++ b/pkg/unify-query/cmdb/v1beta3/settings.go
@@ -1,0 +1,24 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+const (
+	MaxHopsConfigPath              = "cmdb.v1beta3.max_hops"
+	MaxAllowedHopsConfigPath       = "cmdb.v1beta3.max_allowed_hops"
+	DefaultLimitConfigPath         = "cmdb.v1beta3.default_limit"
+	DefaultLookBackDeltaConfigPath = "cmdb.v1beta3.look_back_delta"
+)
+
+var (
+	DefaultMaxHops       = 2
+	MaxAllowedHops       = 5
+	DefaultLimit         = 100
+	DefaultLookBackDelta = int64(86400000) // 24小时（毫秒）
+)

--- a/pkg/unify-query/cmdb/v1beta3/static_provider.go
+++ b/pkg/unify-query/cmdb/v1beta3/static_provider.go
@@ -1,0 +1,192 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"sync"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+// StaticSchemaProvider 静态 Schema 提供器
+// 从内置的硬编码数据(resourcePrimaryKeys 和 schemaRegistry)初始化
+// 提供向后兼容性,支持已有的 K8s 资源类型和关联关系
+type StaticSchemaProvider struct {
+	resourceDefinitions map[string]*cmdb.ResourceDefinition // key: name
+	relationDefinitions map[string]*cmdb.RelationDefinition // key: name
+	relationSchemas     []RelationSchema
+	mu                  sync.RWMutex
+}
+
+// NewStaticSchemaProvider 创建静态 Schema 提供器
+// 从现有的 resourcePrimaryKeys 和 schemaRegistry 初始化
+func NewStaticSchemaProvider() *StaticSchemaProvider {
+	provider := &StaticSchemaProvider{
+		resourceDefinitions: make(map[string]*cmdb.ResourceDefinition),
+		relationDefinitions: make(map[string]*cmdb.RelationDefinition),
+		relationSchemas:     make([]RelationSchema, 0, len(schemaRegistry)),
+	}
+
+	// 从 resourcePrimaryKeys 初始化资源定义
+	for resourceType, keys := range resourcePrimaryKeys {
+		fields := make([]cmdb.FieldDefinition, len(keys))
+		for i, key := range keys {
+			fields[i] = cmdb.FieldDefinition{
+				Name:     key,
+				Required: true,
+			}
+		}
+
+		rd := &cmdb.ResourceDefinition{
+			Namespace: "", // 全局资源
+			Name:      string(resourceType),
+			Fields:    fields,
+			Labels:    make(map[string]string),
+			Spec:      make(map[string]interface{}),
+		}
+		provider.resourceDefinitions[rd.Name] = rd
+	}
+
+	// 从 schemaRegistry 初始化关联定义
+	for _, schema := range schemaRegistry {
+		category := "static"
+		if schema.Category == RelationCategoryDynamic {
+			category = "dynamic"
+		}
+
+		rd := &cmdb.RelationDefinition{
+			Namespace:    "", // 全局关联
+			Name:         string(schema.RelationType),
+			FromResource: string(schema.FromType),
+			ToResource:   string(schema.ToType),
+			Category:     category,
+			IsBelongsTo:  schema.IsBelongsTo,
+			Labels:       make(map[string]string),
+			Spec:         make(map[string]interface{}),
+		}
+		provider.relationDefinitions[rd.Name] = rd
+		provider.relationSchemas = append(provider.relationSchemas, schema)
+	}
+
+	return provider
+}
+
+// GetResourceDefinition 获取资源定义
+func (sp *StaticSchemaProvider) GetResourceDefinition(namespace, name string) (*cmdb.ResourceDefinition, error) {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	// 静态提供器只支持全局资源(namespace = "")
+	if namespace != "" {
+		return nil, cmdb.ErrResourceDefinitionNotFound
+	}
+
+	rd, ok := sp.resourceDefinitions[name]
+	if !ok {
+		return nil, cmdb.ErrResourceDefinitionNotFound
+	}
+
+	return rd, nil
+}
+
+// ListResourceDefinitions 列出资源定义
+func (sp *StaticSchemaProvider) ListResourceDefinitions(namespace string) ([]*cmdb.ResourceDefinition, error) {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	// 静态提供器只支持全局资源(namespace = "")
+	if namespace != "" {
+		return []*cmdb.ResourceDefinition{}, nil
+	}
+
+	result := make([]*cmdb.ResourceDefinition, 0, len(sp.resourceDefinitions))
+	for _, rd := range sp.resourceDefinitions {
+		result = append(result, rd)
+	}
+
+	return result, nil
+}
+
+// GetRelationDefinition 获取关联定义
+func (sp *StaticSchemaProvider) GetRelationDefinition(namespace, name string) (*cmdb.RelationDefinition, error) {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	// 静态提供器只支持全局关联(namespace = "")
+	if namespace != "" {
+		return nil, cmdb.ErrRelationDefinitionNotFound
+	}
+
+	rd, ok := sp.relationDefinitions[name]
+	if !ok {
+		return nil, cmdb.ErrRelationDefinitionNotFound
+	}
+
+	return rd, nil
+}
+
+// ListRelationDefinitions 列出关联定义
+func (sp *StaticSchemaProvider) ListRelationDefinitions(namespace string) ([]*cmdb.RelationDefinition, error) {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	// 静态提供器只支持全局关联(namespace = "")
+	if namespace != "" {
+		return []*cmdb.RelationDefinition{}, nil
+	}
+
+	result := make([]*cmdb.RelationDefinition, 0, len(sp.relationDefinitions))
+	for _, rd := range sp.relationDefinitions {
+		result = append(result, rd)
+	}
+
+	return result, nil
+}
+
+// GetResourcePrimaryKeys 获取资源主键字段列表
+func (sp *StaticSchemaProvider) GetResourcePrimaryKeys(resourceType ResourceType) []string {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	rd, ok := sp.resourceDefinitions[string(resourceType)]
+	if !ok {
+		return []string{}
+	}
+
+	return rd.GetPrimaryKeys()
+}
+
+// GetRelationSchema 获取关联 Schema
+func (sp *StaticSchemaProvider) GetRelationSchema(relationType RelationType) (*RelationSchema, error) {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	for i := range sp.relationSchemas {
+		if sp.relationSchemas[i].RelationType == relationType {
+			return &sp.relationSchemas[i], nil
+		}
+	}
+
+	return nil, cmdb.ErrRelationDefinitionNotFound
+}
+
+// ListRelationSchemas 列出所有关联 Schema
+func (sp *StaticSchemaProvider) ListRelationSchemas() []RelationSchema {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	// 返回副本以避免外部修改
+	result := make([]RelationSchema, len(sp.relationSchemas))
+	copy(result, sp.relationSchemas)
+	return result
+}
+
+// Ensure StaticSchemaProvider implements SchemaProvider
+var _ SchemaProvider = (*StaticSchemaProvider)(nil)

--- a/pkg/unify-query/cmdb/v1beta3/static_provider_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/static_provider_test.go
@@ -1,0 +1,307 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+func TestStaticSchemaProvider_GetResourceDefinition(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	t.Run("get existing resource", func(t *testing.T) {
+		rd, err := provider.GetResourceDefinition("", "pod")
+		assert.NoError(t, err)
+		assert.NotNil(t, rd)
+		assert.Equal(t, "pod", rd.Name)
+		assert.Equal(t, "", rd.Namespace)
+		assert.True(t, len(rd.Fields) > 0)
+
+		// 验证主键字段
+		keys := rd.GetPrimaryKeys()
+		assert.Equal(t, []string{"bcs_cluster_id", "namespace", "pod"}, keys)
+	})
+
+	t.Run("get non-existing resource", func(t *testing.T) {
+		rd, err := provider.GetResourceDefinition("", "non_existing")
+		assert.Error(t, err)
+		assert.Nil(t, rd)
+		assert.Equal(t, cmdb.ErrResourceDefinitionNotFound, err)
+	})
+
+	t.Run("get resource with namespace", func(t *testing.T) {
+		// 静态提供器不支持带命名空间的资源
+		rd, err := provider.GetResourceDefinition("bkcc__2", "pod")
+		assert.Error(t, err)
+		assert.Nil(t, rd)
+	})
+}
+
+func TestStaticSchemaProvider_ListResourceDefinitions(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	t.Run("list global resources", func(t *testing.T) {
+		resources, err := provider.ListResourceDefinitions("")
+		assert.NoError(t, err)
+		assert.NotNil(t, resources)
+		assert.True(t, len(resources) > 0)
+
+		// 验证包含已知的资源类型
+		resourceNames := make(map[string]bool)
+		for _, rd := range resources {
+			resourceNames[rd.Name] = true
+		}
+		assert.True(t, resourceNames["pod"])
+		assert.True(t, resourceNames["node"])
+		assert.True(t, resourceNames["container"])
+	})
+
+	t.Run("list resources with namespace", func(t *testing.T) {
+		// 静态提供器不支持带命名空间的资源,返回空列表
+		resources, err := provider.ListResourceDefinitions("bkcc__2")
+		assert.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+}
+
+func TestStaticSchemaProvider_GetRelationDefinition(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	t.Run("get existing relation", func(t *testing.T) {
+		rd, err := provider.GetRelationDefinition("", "pod_with_service")
+		assert.NoError(t, err)
+		assert.NotNil(t, rd)
+		assert.Equal(t, "pod_with_service", rd.Name)
+		assert.Equal(t, "", rd.Namespace)
+		assert.Equal(t, "pod", rd.FromResource)
+		assert.Equal(t, "service", rd.ToResource)
+		assert.Equal(t, "static", rd.Category)
+	})
+
+	t.Run("get non-existing relation", func(t *testing.T) {
+		rd, err := provider.GetRelationDefinition("", "non_existing")
+		assert.Error(t, err)
+		assert.Nil(t, rd)
+		assert.Equal(t, cmdb.ErrRelationDefinitionNotFound, err)
+	})
+
+	t.Run("get relation with namespace", func(t *testing.T) {
+		// 静态提供器不支持带命名空间的关联
+		rd, err := provider.GetRelationDefinition("bkcc__2", "pod_with_service")
+		assert.Error(t, err)
+		assert.Nil(t, rd)
+	})
+}
+
+func TestStaticSchemaProvider_ListRelationDefinitions(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	t.Run("list global relations", func(t *testing.T) {
+		relations, err := provider.ListRelationDefinitions("")
+		assert.NoError(t, err)
+		assert.NotNil(t, relations)
+		assert.True(t, len(relations) > 0)
+
+		// 验证包含已知的关联类型
+		relationNames := make(map[string]bool)
+		for _, rd := range relations {
+			relationNames[rd.Name] = true
+		}
+		assert.True(t, relationNames["pod_with_service"])
+		assert.True(t, relationNames["node_with_pod"])
+	})
+
+	t.Run("list relations with namespace", func(t *testing.T) {
+		// 静态提供器不支持带命名空间的关联,返回空列表
+		relations, err := provider.ListRelationDefinitions("bkcc__2")
+		assert.NoError(t, err)
+		assert.Empty(t, relations)
+	})
+}
+
+func TestStaticSchemaProvider_GetResourcePrimaryKeys(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	t.Run("get primary keys for pod", func(t *testing.T) {
+		keys := provider.GetResourcePrimaryKeys(ResourceTypePod)
+		assert.Equal(t, []string{"bcs_cluster_id", "namespace", "pod"}, keys)
+	})
+
+	t.Run("get primary keys for node", func(t *testing.T) {
+		keys := provider.GetResourcePrimaryKeys(ResourceTypeNode)
+		assert.Equal(t, []string{"bcs_cluster_id", "node"}, keys)
+	})
+
+	t.Run("get primary keys for non-existing resource", func(t *testing.T) {
+		keys := provider.GetResourcePrimaryKeys(ResourceType("non_existing"))
+		assert.Empty(t, keys)
+	})
+}
+
+func TestStaticSchemaProvider_GetRelationSchema(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	t.Run("get schema for existing relation", func(t *testing.T) {
+		schema, err := provider.GetRelationSchema(RelationPodWithService)
+		assert.NoError(t, err)
+		assert.NotNil(t, schema)
+		assert.Equal(t, RelationPodWithService, schema.RelationType)
+		assert.Equal(t, RelationCategoryStatic, schema.Category)
+		assert.Equal(t, ResourceTypePod, schema.FromType)
+		assert.Equal(t, ResourceTypeService, schema.ToType)
+	})
+
+	t.Run("get schema for non-existing relation", func(t *testing.T) {
+		schema, err := provider.GetRelationSchema(RelationType("non_existing"))
+		assert.Error(t, err)
+		assert.Nil(t, schema)
+		assert.Equal(t, cmdb.ErrRelationDefinitionNotFound, err)
+	})
+}
+
+func TestStaticSchemaProvider_ListRelationSchemas(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	schemas := provider.ListRelationSchemas()
+	assert.NotNil(t, schemas)
+	assert.True(t, len(schemas) > 0)
+
+	// 验证包含已知的关联
+	schemaMap := make(map[RelationType]RelationSchema)
+	for _, schema := range schemas {
+		schemaMap[schema.RelationType] = schema
+	}
+
+	// 验证静态关联
+	assert.Contains(t, schemaMap, RelationPodWithService)
+	assert.Contains(t, schemaMap, RelationNodeWithPod)
+
+	// 验证动态关联
+	assert.Contains(t, schemaMap, RelationPodToPod)
+	assert.Equal(t, RelationCategoryDynamic, schemaMap[RelationPodToPod].Category)
+}
+
+func TestResourceDefinition_GetPrimaryKeys(t *testing.T) {
+	rd := &cmdb.ResourceDefinition{
+		Name: "test_resource",
+		Fields: []cmdb.FieldDefinition{
+			{Name: "id", Required: true},
+			{Name: "name", Required: true},
+			{Name: "optional_field", Required: false},
+		},
+	}
+
+	keys := rd.GetPrimaryKeys()
+	assert.Equal(t, []string{"id", "name"}, keys)
+}
+
+func TestRelationDefinition_ToRelationType(t *testing.T) {
+	t.Run("global relation", func(t *testing.T) {
+		rd := &cmdb.RelationDefinition{
+			Namespace: "",
+			Name:      "pod_with_service",
+		}
+		assert.Equal(t, RelationType("pod_with_service"), ToRelationType(rd))
+	})
+
+	t.Run("namespaced relation", func(t *testing.T) {
+		rd := &cmdb.RelationDefinition{
+			Namespace: "bkcc__2",
+			Name:      "app_version_with_git_commit",
+		}
+		assert.Equal(t, RelationType("bkcc__2:app_version_with_git_commit"), ToRelationType(rd))
+	})
+}
+
+func TestRelationDefinition_ToRelationSchema(t *testing.T) {
+	t.Run("static relation", func(t *testing.T) {
+		rd := &cmdb.RelationDefinition{
+			Namespace:    "bkcc__2",
+			Name:         "app_version_with_container",
+			FromResource: "app_version",
+			ToResource:   "container",
+			Category:     "static",
+			IsBelongsTo:  false,
+		}
+
+		schema := ToRelationSchema(rd)
+		assert.Equal(t, RelationType("bkcc__2:app_version_with_container"), schema.RelationType)
+		assert.Equal(t, RelationCategoryStatic, schema.Category)
+		assert.Equal(t, ResourceType("app_version"), schema.FromType)
+		assert.Equal(t, ResourceType("container"), schema.ToType)
+		assert.False(t, schema.IsBelongsTo)
+	})
+
+	t.Run("dynamic relation", func(t *testing.T) {
+		rd := &cmdb.RelationDefinition{
+			Namespace:    "",
+			Name:         "pod_to_pod",
+			FromResource: "pod",
+			ToResource:   "pod",
+			Category:     "dynamic",
+			IsBelongsTo:  false,
+		}
+
+		schema := ToRelationSchema(rd)
+		assert.Equal(t, RelationType("pod_to_pod"), schema.RelationType)
+		assert.Equal(t, RelationCategoryDynamic, schema.Category)
+	})
+}
+
+// TestStaticSchemaProvider_Compatibility 测试与现有代码的兼容性
+func TestStaticSchemaProvider_Compatibility(t *testing.T) {
+	provider := NewStaticSchemaProvider()
+
+	// 测试所有已有的资源类型都能正确获取主键
+	testCases := []struct {
+		resourceType ResourceType
+		expectedKeys []string
+	}{
+		{ResourceTypePod, []string{"bcs_cluster_id", "namespace", "pod"}},
+		{ResourceTypeNode, []string{"bcs_cluster_id", "node"}},
+		{ResourceTypeContainer, []string{"bcs_cluster_id", "namespace", "pod", "container"}},
+		{ResourceTypeSystem, []string{"bk_cloud_id", "bk_target_ip"}},
+		{ResourceTypeAppVersion, []string{"bcs_cluster_id", "namespace", "app_version"}},
+		{ResourceTypeGitCommit, []string{"git_repo", "commit_id"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run("compatibility_"+string(tc.resourceType), func(t *testing.T) {
+			// 测试新的 Provider 接口
+			keys := provider.GetResourcePrimaryKeys(tc.resourceType)
+			assert.Equal(t, tc.expectedKeys, keys)
+
+			// 测试与旧的全局函数返回值一致
+			oldKeys := GetResourcePrimaryKeys(tc.resourceType)
+			assert.Equal(t, oldKeys, keys)
+		})
+	}
+
+	// 测试所有已有的关联类型都能正确获取 Schema
+	relationTypes := []RelationType{
+		RelationPodWithService,
+		RelationNodeWithPod,
+		RelationPodToPod,
+		RelationAppVersionWithGitCommit,
+	}
+
+	for _, relationType := range relationTypes {
+		t.Run("compatibility_"+string(relationType), func(t *testing.T) {
+			schema, err := provider.GetRelationSchema(relationType)
+			assert.NoError(t, err)
+			assert.NotNil(t, schema)
+			assert.Equal(t, relationType, schema.RelationType)
+		})
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/surreal_query_builder.go
+++ b/pkg/unify-query/cmdb/v1beta3/surreal_query_builder.go
@@ -1,0 +1,463 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SQL 模板常量
+const (
+	sqlIndent1 = "    "                     // 1级缩进
+	sqlIndent2 = "        "                 // 2级缩进
+	sqlIndent3 = "            "             // 3级缩进
+	sqlIndent4 = "                "         // 4级缩进
+	sqlIndent5 = "                    "     // 5级缩进
+	sqlIndent6 = "                        " // 6级缩进
+
+	fieldSourceID   = "source_id"
+	fieldTargetID   = "target_id"
+	fieldRelationID = "relation_id"
+
+	// SQL 子查询模板
+	tplLivenessSelect    = "(SELECT * FROM %s WHERE %s = $parent.id AND period_end >= $start AND period_start <= $end)"
+	tplLivenessSelectRef = "(SELECT * FROM %s WHERE %s = $parent.%s AND period_end >= $start AND period_start <= $end)"
+	tplRelLivenessSelect = "(SELECT * FROM %s WHERE relation_id = $parent.id AND period_end >= $start AND period_start <= $end)"
+	tplLivenessFilter    = "(SELECT count() FROM only %s WHERE %s = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0"
+	tplRelLivenessFilter = "(SELECT count() FROM only %s WHERE relation_id = $parent.id AND $end >= period_start AND $start <= period_end GROUP ALL) > 0"
+)
+
+// buildEntityDataFields 构建 entity_data 字段列表
+func buildEntityDataFields(keys []string, prefix string) string {
+	fields := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if prefix == "" {
+			fields = append(fields, fmt.Sprintf("%s: %s", key, key))
+		} else {
+			fields = append(fields, fmt.Sprintf("%s: %s.%s", key, prefix, key))
+		}
+	}
+	return strings.Join(fields, ", ")
+}
+
+// SurrealQueryBuilder 构建 SurrealQL 关联查询
+type SurrealQueryBuilder struct {
+	request        *QueryRequest
+	pathFinder     *PathFinder
+	schemaProvider SchemaProvider
+}
+
+// NewSurrealQueryBuilder 创建查询构建器
+// 如果不提供 schemaProvider,将使用默认的 StaticSchemaProvider
+func NewSurrealQueryBuilder(request *QueryRequest, opts ...PathFinderOption) *SurrealQueryBuilder {
+	request.Normalize()
+
+	// 默认使用 StaticSchemaProvider
+	provider := NewStaticSchemaProvider()
+
+	// 创建 PathFinder 时传入 SchemaProvider
+	allOpts := append([]PathFinderOption{
+		WithSchemaProvider(provider),
+		WithAllowedCategories(request.AllowedRelationTypes...),
+		WithDynamicDirection(request.DynamicRelationDirection),
+		WithMaxHops(request.MaxHops),
+	}, opts...)
+
+	pf := NewPathFinder(allOpts...)
+
+	return &SurrealQueryBuilder{
+		request:        request,
+		pathFinder:     pf,
+		schemaProvider: provider,
+	}
+}
+
+// Build 构建完整的 SurrealQL 查询
+func (b *SurrealQueryBuilder) Build() string {
+	var sb strings.Builder
+	sb.WriteString(b.buildVariables())
+	sb.WriteString("\n\n")
+	sb.WriteString(b.buildMainQuery())
+	return sb.String()
+}
+
+// buildVariables 构建变量定义部分
+func (b *SurrealQueryBuilder) buildVariables() string {
+	start, end := b.request.GetQueryRange()
+	return fmt.Sprintf(`LET $timestamp = %d;
+LET $look_back_delta = %d;
+LET $start = %d;
+LET $end = %d;`,
+		b.request.Timestamp,
+		b.request.LookBackDelta,
+		start,
+		end)
+}
+
+// buildMainQuery 构建主查询
+func (b *SurrealQueryBuilder) buildMainQuery() string {
+	var sb strings.Builder
+
+	sb.WriteString("SELECT {\n")
+	sb.WriteString(sqlIndent1 + "root: ")
+	sb.WriteString(b.buildRootSelect())
+
+	if b.request.MaxHops > 0 {
+		sb.WriteString(",\n\n")
+		sb.WriteString(sqlIndent1 + "hop1: ")
+		sb.WriteString(b.buildHopSelect(1, b.request.SourceType))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("} AS result\n")
+	sb.WriteString(fmt.Sprintf("FROM %s\n", b.request.SourceType))
+	sb.WriteString(b.buildWhereClause())
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("LIMIT %d;", b.request.Limit))
+
+	return sb.String()
+}
+
+// buildRootSelect 构建 Root 实体的 SELECT 结构
+func (b *SurrealQueryBuilder) buildRootSelect() string {
+	sourceType := b.request.SourceType
+	primaryKeys := b.schemaProvider.GetResourcePrimaryKeys(sourceType)
+	livenessTable := GetLivenessRecordTableName(sourceType)
+	livenessIDField := GetLivenessIDField(sourceType)
+
+	return fmt.Sprintf(`{
+        entity_type: meta::tb(id),
+        entity_id: <string>id,
+        entity_data: { %s },
+        created_at: created_at,
+        updated_at: updated_at,
+        liveness: `+tplLivenessSelect+`
+    }`,
+		buildEntityDataFields(primaryKeys, ""),
+		livenessTable,
+		livenessIDField)
+}
+
+// buildHopSelect 构建指定跳数的 SELECT 结构
+func (b *SurrealQueryBuilder) buildHopSelect(hop int, currentType ResourceType) string {
+	if hop > b.request.MaxHops {
+		return "{}"
+	}
+
+	relations := b.getRelationsForType(currentType)
+	if len(relations) == 0 {
+		return "{}"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("{\n")
+
+	first := true
+	for _, rel := range relations {
+		if !first {
+			sb.WriteString(",\n")
+		}
+		first = false
+		sb.WriteString(b.buildRelationQuery(hop, currentType, rel))
+	}
+
+	sb.WriteString("\n" + sqlIndent1 + "}")
+
+	return sb.String()
+}
+
+// RelationQueryInfo 关系查询信息
+type RelationQueryInfo struct {
+	Schema      *RelationSchema
+	Direction   TraversalDirection
+	KeySuffix   string       // 键名后缀（动态关系才有）
+	TargetField string       // 目标字段 (source_id 或 target_id)
+	TargetType  ResourceType // 目标资源类型
+	WhereField  string       // WHERE 子句中用于匹配当前实体的字段
+	SelectField string       // SELECT 中获取目标实体的字段
+}
+
+// getRelationsForType 获取指定资源类型的所有可用关系查询
+func (b *SurrealQueryBuilder) getRelationsForType(resourceType ResourceType) []*RelationQueryInfo {
+	return b.pathFinder.getRelationsForType(resourceType)
+}
+
+// buildRelationQuery 构建单个关系的查询
+func (b *SurrealQueryBuilder) buildRelationQuery(hop int, _ ResourceType, rel *RelationQueryInfo) string {
+	relationType := rel.Schema.RelationType
+	relationTable := string(relationType)
+	relationLivenessTable := GetRelationLivenessRecordTableName(relationType)
+	targetLivenessTable := GetLivenessRecordTableName(rel.TargetType)
+	targetLivenessIDField := GetLivenessIDField(rel.TargetType)
+	keyName := relationTable + rel.KeySuffix
+	targetPrimaryKeys := b.schemaProvider.GetResourcePrimaryKeys(rel.TargetType)
+
+	var fieldsBuilder strings.Builder
+	fieldsBuilder.WriteString(fmt.Sprintf(`
+            hop: %d,
+            relation_type: '%s',
+            relation_category: '%s',`, hop, relationType, rel.Schema.Category))
+
+	if rel.Schema.Category == RelationCategoryDynamic {
+		fieldsBuilder.WriteString(fmt.Sprintf(`
+            direction: '%s',`, rel.Direction))
+	}
+
+	fieldsBuilder.WriteString(fmt.Sprintf(`
+            relation_id: <string>id,
+            relation_liveness: `+tplRelLivenessSelect+`,
+            target: {
+                entity_type: '%s',
+                entity_id: <string>%s,
+                entity_data: { %s },
+                liveness: `+tplLivenessSelectRef,
+		relationLivenessTable,
+		rel.TargetType,
+		rel.SelectField,
+		buildEntityDataFields(targetPrimaryKeys, rel.SelectField),
+		targetLivenessTable,
+		targetLivenessIDField,
+		rel.SelectField))
+
+	if hop < b.request.MaxHops {
+		nextHopKey := fmt.Sprintf("hop%d", hop+1)
+		nextHopSelect := b.buildNestedHopSelect(hop+1, rel.TargetType, rel.SelectField)
+		fieldsBuilder.WriteString(fmt.Sprintf(`,
+                %s: %s`, nextHopKey, nextHopSelect))
+	}
+
+	fieldsBuilder.WriteString(`
+            }`)
+
+	return fmt.Sprintf(sqlIndent2+`%s: (SELECT {%s
+        } FROM %s WHERE %s = $parent.id
+          AND `+tplRelLivenessFilter+`)`,
+		keyName,
+		fieldsBuilder.String(),
+		relationTable,
+		rel.WhereField,
+		relationLivenessTable)
+}
+
+// buildNestedHopSelect 构建嵌套在 target 内的下一跳查询
+func (b *SurrealQueryBuilder) buildNestedHopSelect(hop int, currentType ResourceType, parentField string) string {
+	if hop > b.request.MaxHops {
+		return "{}"
+	}
+
+	relations := b.getRelationsForType(currentType)
+	if len(relations) == 0 {
+		return "{}"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("{\n")
+
+	first := true
+	for _, rel := range relations {
+		if !first {
+			sb.WriteString(",\n")
+		}
+		first = false
+		sb.WriteString(b.buildNestedRelationQuery(hop, rel, parentField))
+	}
+
+	sb.WriteString("\n" + sqlIndent4 + "}")
+
+	return sb.String()
+}
+
+// buildNestedRelationQuery 构建嵌套的关系查询（用于 hop2+）
+func (b *SurrealQueryBuilder) buildNestedRelationQuery(hop int, rel *RelationQueryInfo, parentField string) string {
+	relationType := rel.Schema.RelationType
+	relationTable := string(relationType)
+	relationLivenessTable := GetRelationLivenessRecordTableName(relationType)
+	targetLivenessTable := GetLivenessRecordTableName(rel.TargetType)
+	targetLivenessIDField := GetLivenessIDField(rel.TargetType)
+	keyName := relationTable + rel.KeySuffix
+	targetPrimaryKeys := b.schemaProvider.GetResourcePrimaryKeys(rel.TargetType)
+
+	var fieldsBuilder strings.Builder
+	fieldsBuilder.WriteString(fmt.Sprintf(`
+                        hop: %d,
+                        relation_type: '%s',
+                        relation_category: '%s',`, hop, relationType, rel.Schema.Category))
+
+	if rel.Schema.Category == RelationCategoryDynamic {
+		fieldsBuilder.WriteString(fmt.Sprintf(`
+                        direction: '%s',`, rel.Direction))
+	}
+
+	fieldsBuilder.WriteString(fmt.Sprintf(`
+                        relation_id: <string>id,
+                        relation_liveness: `+tplRelLivenessSelect+`,
+                        target: {
+                            entity_type: '%s',
+                            entity_id: <string>%s,
+                            entity_data: { %s },
+                            liveness: `+tplLivenessSelectRef,
+		relationLivenessTable,
+		rel.TargetType,
+		rel.SelectField,
+		buildEntityDataFields(targetPrimaryKeys, rel.SelectField),
+		targetLivenessTable,
+		targetLivenessIDField,
+		rel.SelectField))
+
+	if hop < b.request.MaxHops {
+		nextHopKey := fmt.Sprintf("hop%d", hop+1)
+		nextHopSelect := b.buildDeeperNestedHopSelect(hop+1, rel.TargetType, rel.SelectField, 4)
+		fieldsBuilder.WriteString(fmt.Sprintf(`,
+                            %s: %s`, nextHopKey, nextHopSelect))
+	}
+
+	fieldsBuilder.WriteString(`
+                        }`)
+
+	return fmt.Sprintf(sqlIndent5+`%s: (SELECT {%s
+                    } FROM %s WHERE %s = $parent.%s
+                      AND `+tplRelLivenessFilter+`)`,
+		keyName,
+		fieldsBuilder.String(),
+		relationTable,
+		rel.WhereField,
+		parentField,
+		relationLivenessTable)
+}
+
+// buildDeeperNestedHopSelect 构建更深层嵌套的 hop（hop3+）
+func (b *SurrealQueryBuilder) buildDeeperNestedHopSelect(hop int, currentType ResourceType, parentField string, indentLevel int) string {
+	if hop > b.request.MaxHops {
+		return "{}"
+	}
+
+	relations := b.getRelationsForType(currentType)
+	if len(relations) == 0 {
+		return "{}"
+	}
+
+	indent := strings.Repeat(sqlIndent1, indentLevel)
+	var sb strings.Builder
+	sb.WriteString("{\n")
+
+	first := true
+	for _, rel := range relations {
+		if !first {
+			sb.WriteString(",\n")
+		}
+		first = false
+		sb.WriteString(b.buildDeeperNestedRelationQuery(hop, rel, parentField, indentLevel))
+	}
+
+	sb.WriteString(fmt.Sprintf("\n%s}", indent))
+
+	return sb.String()
+}
+
+// buildDeeperNestedRelationQuery 构建更深层嵌套的关系查询
+func (b *SurrealQueryBuilder) buildDeeperNestedRelationQuery(hop int, rel *RelationQueryInfo, parentField string, indentLevel int) string {
+	relationType := rel.Schema.RelationType
+	relationTable := string(relationType)
+	relationLivenessTable := GetRelationLivenessRecordTableName(relationType)
+	targetLivenessTable := GetLivenessRecordTableName(rel.TargetType)
+	targetLivenessIDField := GetLivenessIDField(rel.TargetType)
+
+	keyName := relationTable + rel.KeySuffix
+	indent := strings.Repeat(sqlIndent1, indentLevel)
+	innerIndent := strings.Repeat(sqlIndent1, indentLevel+1)
+	targetPrimaryKeys := b.schemaProvider.GetResourcePrimaryKeys(rel.TargetType)
+
+	var fieldsBuilder strings.Builder
+	fieldsBuilder.WriteString(fmt.Sprintf(`
+%shop: %d,
+%srelation_type: '%s',
+%srelation_category: '%s',`, innerIndent, hop, innerIndent, relationType, innerIndent, rel.Schema.Category))
+
+	if rel.Schema.Category == RelationCategoryDynamic {
+		fieldsBuilder.WriteString(fmt.Sprintf(`
+%sdirection: '%s',`, innerIndent, rel.Direction))
+	}
+
+	fieldsBuilder.WriteString(fmt.Sprintf(`
+%srelation_id: <string>id,
+%srelation_liveness: `+tplRelLivenessSelect+`,
+%starget: {
+%s    entity_type: '%s',
+%s    entity_id: <string>%s,
+%s    entity_data: { %s },
+%s    liveness: `+tplLivenessSelectRef,
+		innerIndent,
+		innerIndent, relationLivenessTable,
+		innerIndent,
+		innerIndent, rel.TargetType,
+		innerIndent, rel.SelectField,
+		innerIndent, buildEntityDataFields(targetPrimaryKeys, rel.SelectField),
+		innerIndent, targetLivenessTable, targetLivenessIDField, rel.SelectField))
+
+	if hop < b.request.MaxHops {
+		nextHopKey := fmt.Sprintf("hop%d", hop+1)
+		nextHopSelect := b.buildDeeperNestedHopSelect(hop+1, rel.TargetType, rel.SelectField, indentLevel+2)
+		fieldsBuilder.WriteString(fmt.Sprintf(`,
+%s    %s: %s`, innerIndent, nextHopKey, nextHopSelect))
+	}
+
+	fieldsBuilder.WriteString(fmt.Sprintf(`
+%s}`, innerIndent))
+
+	return fmt.Sprintf(`%s%s: (SELECT {%s
+%s} FROM %s WHERE %s = $parent.%s
+%s  AND `+tplRelLivenessFilter+`)`,
+		indent, keyName,
+		fieldsBuilder.String(),
+		indent, relationTable, rel.WhereField, parentField,
+		indent, relationLivenessTable)
+}
+
+// buildWhereClause 构建 WHERE 子句
+func (b *SurrealQueryBuilder) buildWhereClause() string {
+	var conditions []string
+
+	if len(b.request.SourceInfo) > 0 {
+		// 获取合法字段白名单（主键字段），防止字段名注入
+		allowedFields := make(map[string]bool)
+		for _, pk := range b.schemaProvider.GetResourcePrimaryKeys(b.request.SourceType) {
+			allowedFields[pk] = true
+		}
+
+		keys := make([]string, 0, len(b.request.SourceInfo))
+		for k := range b.request.SourceInfo {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			if !allowedFields[k] {
+				continue
+			}
+			v := b.request.SourceInfo[k]
+			conditions = append(conditions, fmt.Sprintf("%s = '%s'", k, escapeSurrealString(v)))
+		}
+	}
+
+	livenessTable := GetLivenessRecordTableName(b.request.SourceType)
+	livenessIDField := GetLivenessIDField(b.request.SourceType)
+	conditions = append(conditions, fmt.Sprintf(tplLivenessFilter, livenessTable, livenessIDField))
+
+	return "WHERE " + strings.Join(conditions, "\n  AND ")
+}
+
+// escapeSurrealString 转义 SurrealQL 字符串中的特殊字符
+func escapeSurrealString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return s
+}

--- a/pkg/unify-query/cmdb/v1beta3/surreal_response_parser.go
+++ b/pkg/unify-query/cmdb/v1beta3/surreal_response_parser.go
@@ -1,0 +1,264 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SurrealResponseParser 解析 SurrealDB 查询响应
+type SurrealResponseParser struct {
+	queryStart int64
+	queryEnd   int64
+}
+
+// NewSurrealResponseParser 创建响应解析器
+func NewSurrealResponseParser(queryStart, queryEnd int64) *SurrealResponseParser {
+	return &SurrealResponseParser{
+		queryStart: queryStart,
+		queryEnd:   queryEnd,
+	}
+}
+
+// Parse 解析 SurrealDB 响应为多个 LivenessGraph
+// 响应格式: [{"result": [{"result": {...}}, ...]}]
+// 每条记录（每个起始实体）对应一个独立的 LivenessGraph
+func (p *SurrealResponseParser) Parse(rawResponse []map[string]any) ([]*LivenessGraph, error) {
+	var graphs []*LivenessGraph
+
+	if len(rawResponse) == 0 {
+		return graphs, nil
+	}
+
+	// 获取第一个查询的结果
+	firstResult, ok := rawResponse[0][ResponseFieldResult]
+	if !ok {
+		return graphs, nil
+	}
+
+	results, ok := firstResult.([]any)
+	if !ok {
+		return graphs, nil
+	}
+
+	// 遍历每个结果记录，每条记录生成一个独立的 LivenessGraph
+	for _, r := range results {
+		record, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// 获取 result 字段（包含 root 和 hopN）
+		resultData, ok := record[ResponseFieldResult].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// 解析 root 节点
+		rootData, ok := resultData[ResponseFieldRoot].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		rootNode, err := p.parseEntity(rootData)
+		if err != nil {
+			// 创建一个带错误的空图
+			graph := NewLivenessGraph(p.queryStart, p.queryEnd)
+			graph.AddTraversalError(fmt.Sprintf("parse root: %v", err))
+			graphs = append(graphs, graph)
+			continue
+		}
+
+		// 为每条记录创建一个新的图
+		graph := NewLivenessGraph(p.queryStart, p.queryEnd)
+		graph.AddNode(rootNode)
+
+		// 解析 hop1, hop2, ... 的关系
+		for key, value := range resultData {
+			if !strings.HasPrefix(key, ResponseFieldHopPrefix) {
+				continue
+			}
+
+			hopData, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			p.parseHopRelations(graph, rootNode.ResourceID, hopData)
+		}
+
+		graphs = append(graphs, graph)
+	}
+
+	return graphs, nil
+}
+
+// parseEntity 解析实体数据为 NodeLiveness
+func (p *SurrealResponseParser) parseEntity(data map[string]any) (*NodeLiveness, error) {
+	entityID, ok := data[ResponseFieldEntityID].(string)
+	if !ok || entityID == "" {
+		return nil, fmt.Errorf("missing %s", ResponseFieldEntityID)
+	}
+
+	entityType, _ := data[ResponseFieldEntityType].(string)
+
+	// 解析 entity_data 为 labels
+	labels := make(map[string]string)
+	if entityData, ok := data[ResponseFieldEntityData].(map[string]any); ok {
+		for k, v := range entityData {
+			if s, ok := v.(string); ok {
+				labels[k] = s
+			} else if v != nil {
+				labels[k] = fmt.Sprintf("%v", v)
+			}
+		}
+	}
+
+	// 解析 liveness 时间段
+	rawPeriods := p.parseLivenessPeriods(data[ResponseFieldLiveness])
+
+	return &NodeLiveness{
+		ResourceID:   entityID,
+		ResourceType: ResourceType(entityType),
+		Labels:       labels,
+		RawPeriods:   rawPeriods,
+	}, nil
+}
+
+// parseHopRelations 解析单跳的所有关系
+func (p *SurrealResponseParser) parseHopRelations(graph *LivenessGraph, fromID string, hopData map[string]any) {
+	for relationKey, relationsValue := range hopData {
+		relations, ok := relationsValue.([]any)
+		if !ok {
+			continue
+		}
+
+		for _, rel := range relations {
+			relData, ok := rel.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			edge, targetNode, nestedHops, err := p.parseRelation(fromID, relationKey, relData)
+			if err != nil {
+				graph.AddTraversalError(fmt.Sprintf("parse relation %s: %v", relationKey, err))
+				continue
+			}
+
+			// 添加目标节点（如果不存在）
+			if graph.GetNode(targetNode.ResourceID) == nil {
+				graph.AddNode(targetNode)
+			}
+
+			// 添加边
+			graph.AddEdge(edge)
+
+			// 递归解析嵌套的 hop（hop2, hop3, ...）
+			for _, nestedHop := range nestedHops {
+				p.parseHopRelations(graph, targetNode.ResourceID, nestedHop)
+			}
+		}
+	}
+}
+
+// parseRelation 解析单个关系
+// 返回值：边、目标节点、嵌套的hop数据列表、错误
+func (p *SurrealResponseParser) parseRelation(fromID, relationKey string, data map[string]any) (*EdgeLiveness, *NodeLiveness, []map[string]any, error) {
+	relationID, ok := data[ResponseFieldRelationID].(string)
+	if !ok || relationID == "" {
+		return nil, nil, nil, fmt.Errorf("missing %s", ResponseFieldRelationID)
+	}
+
+	relationType, _ := data[ResponseFieldRelationType].(string)
+	relationCategory, _ := data[ResponseFieldRelationCategory].(string)
+	direction, _ := data[ResponseFieldDirection].(string)
+
+	// 解析关系的 liveness
+	relationLiveness := p.parseLivenessPeriods(data[ResponseFieldRelationLiveness])
+
+	// 解析 target 实体
+	targetData, ok := data[ResponseFieldTarget].(map[string]any)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("missing %s", ResponseFieldTarget)
+	}
+
+	targetNode, err := p.parseEntity(targetData)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("parse target: %w", err)
+	}
+
+	// 提取 target 中嵌套的 hop（hop2, hop3, ...）
+	var nestedHops []map[string]any
+	for key, value := range targetData {
+		if strings.HasPrefix(key, ResponseFieldHopPrefix) {
+			if hopData, ok := value.(map[string]any); ok {
+				nestedHops = append(nestedHops, hopData)
+			}
+		}
+	}
+
+	edge := &EdgeLiveness{
+		RelationID:   relationID,
+		RelationType: RelationType(relationType),
+		Category:     RelationCategory(relationCategory),
+		Direction:    TraversalDirection(direction),
+		FromID:       fromID,
+		ToID:         targetNode.ResourceID,
+		RawPeriods:   relationLiveness,
+	}
+
+	return edge, targetNode, nestedHops, nil
+}
+
+// parseLivenessPeriods 解析 liveness 数组为 VisiblePeriod 列表
+func (p *SurrealResponseParser) parseLivenessPeriods(data any) []*VisiblePeriod {
+	arr, ok := data.([]any)
+	if !ok || len(arr) == 0 {
+		return nil
+	}
+
+	periods := make([]*VisiblePeriod, 0, len(arr))
+	for _, item := range arr {
+		periodData, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		start := p.toInt64(periodData[FieldPeriodStart])
+		end := p.toInt64(periodData[FieldPeriodEnd])
+
+		if start <= end {
+			periods = append(periods, &VisiblePeriod{
+				Start: start,
+				End:   end,
+			})
+		}
+	}
+
+	return periods
+}
+
+// toInt64 将 any 类型转换为 int64
+func (p *SurrealResponseParser) toInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case string:
+		var i int64
+		fmt.Sscanf(n, "%d", &i)
+		return i
+	}
+	return 0
+}

--- a/pkg/unify-query/cmdb/v1beta3/surreal_response_parser_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surreal_response_parser_test.go
@@ -1,0 +1,1620 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSurrealResponseParser_parseHopRelations(t *testing.T) {
+	parser := NewSurrealResponseParser(1000, 2000)
+
+	t.Run("empty hop data", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+			Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{}
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+		}, graph)
+	})
+
+	t.Run("single relation in hop", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+			Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{
+						map[string]any{"period_start": float64(1000), "period_end": float64(2000)},
+					},
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{
+							"cluster":   "c1",
+							"namespace": "ns1",
+							"service":   "svc1",
+						},
+						"liveness": []any{
+							map[string]any{"period_start": float64(1000), "period_end": float64(2000)},
+						},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+				},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {
+					ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+					ResourceType: ResourceTypeService,
+					Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "service": "svc1"},
+					RawPeriods:   []*VisiblePeriod{{Start: 1000, End: 2000}},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{
+				"rel_1": {
+					RelationID:   "rel_1",
+					RelationType: RelationType("pod_with_service"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+					RawPeriods:   []*VisiblePeriod{{Start: 1000, End: 2000}},
+				},
+			},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩":           {"rel_1"},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {},
+			},
+		}, graph)
+	})
+
+	t.Run("multiple relations in single hop", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+			Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+					},
+				},
+				map[string]any{
+					"relation_id":       "rel_2",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc2⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+				},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {
+					ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+					ResourceType: ResourceTypeService,
+					Labels:       map[string]string{},
+				},
+				"service:⟨cluster=c1,namespace=ns1,service=svc2⟩": {
+					ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc2⟩",
+					ResourceType: ResourceTypeService,
+					Labels:       map[string]string{},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{
+				"rel_1": {
+					RelationID:   "rel_1",
+					RelationType: RelationType("pod_with_service"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+				},
+				"rel_2": {
+					RelationID:   "rel_2",
+					RelationType: RelationType("pod_with_service"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc2⟩",
+				},
+			},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩":           {"rel_1", "rel_2"},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {},
+				"service:⟨cluster=c1,namespace=ns1,service=svc2⟩": {},
+			},
+		}, graph)
+	})
+
+	t.Run("multiple relation types in single hop", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+			Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+					},
+				},
+			},
+			"pod_with_replicaset": []any{
+				map[string]any{
+					"relation_id":       "rel_2",
+					"relation_type":     "pod_with_replicaset",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩",
+						"entity_type": "replicaset",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, 3, len(graph.Nodes))
+		assert.Equal(t, 2, len(graph.Edges))
+		assert.NotNil(t, graph.GetNode("pod:⟨cluster=c1,namespace=ns1,pod=p1⟩"))
+		assert.NotNil(t, graph.GetNode("service:⟨cluster=c1,namespace=ns1,service=svc1⟩"))
+		assert.NotNil(t, graph.GetNode("replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩"))
+		assert.NotNil(t, graph.GetEdge("rel_1"))
+		assert.NotNil(t, graph.GetEdge("rel_2"))
+		assert.False(t, graph.HasErrors())
+	})
+
+	t.Run("nested hop relations (hop2 inside target)", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+			Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_replicaset": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_replicaset",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩",
+						"entity_type": "replicaset",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+						// Nested hop2: replicaset -> deployment
+						"hop2": map[string]any{
+							"deployment_with_replicaset": []any{
+								map[string]any{
+									"relation_id":       "rel_2",
+									"relation_type":     "deployment_with_replicaset",
+									"relation_category": "static",
+									"direction":         "inbound",
+									"relation_liveness": []any{},
+									"target": map[string]any{
+										"entity_id":   "deployment:⟨cluster=c1,namespace=ns1,deployment=dep1⟩",
+										"entity_type": "deployment",
+										"entity_data": map[string]any{},
+										"liveness":    []any{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+				},
+				"replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩": {
+					ResourceID:   "replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩",
+					ResourceType: ResourceTypeReplicaSet,
+					Labels:       map[string]string{},
+				},
+				"deployment:⟨cluster=c1,namespace=ns1,deployment=dep1⟩": {
+					ResourceID:   "deployment:⟨cluster=c1,namespace=ns1,deployment=dep1⟩",
+					ResourceType: ResourceTypeDeployment,
+					Labels:       map[string]string{},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{
+				"rel_1": {
+					RelationID:   "rel_1",
+					RelationType: RelationType("pod_with_replicaset"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩",
+				},
+				"rel_2": {
+					RelationID:   "rel_2",
+					RelationType: RelationType("deployment_with_replicaset"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionInbound,
+					FromID:       "replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩",
+					ToID:         "deployment:⟨cluster=c1,namespace=ns1,deployment=dep1⟩",
+				},
+			},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩":                 {"rel_1"},
+				"replicaset:⟨cluster=c1,namespace=ns1,replicaset=rs1⟩":  {"rel_2"},
+				"deployment:⟨cluster=c1,namespace=ns1,deployment=dep1⟩": {},
+			},
+		}, graph)
+	})
+
+	t.Run("deeply nested hops (hop3 inside hop2)", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "container:⟨cluster=c1,namespace=ns1,pod=p1,container=c1⟩",
+			ResourceType: ResourceTypeContainer,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"container_with_pod": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "container_with_pod",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+						"entity_type": "pod",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+						// hop2: pod -> node
+						"hop2": map[string]any{
+							"node_with_pod": []any{
+								map[string]any{
+									"relation_id":       "rel_2",
+									"relation_type":     "node_with_pod",
+									"relation_category": "static",
+									"direction":         "inbound",
+									"relation_liveness": []any{},
+									"target": map[string]any{
+										"entity_id":   "node:⟨cluster=c1,node=node1⟩",
+										"entity_type": "node",
+										"entity_data": map[string]any{},
+										"liveness":    []any{},
+										// hop3: node -> system
+										"hop3": map[string]any{
+											"node_with_system": []any{
+												map[string]any{
+													"relation_id":       "rel_3",
+													"relation_type":     "node_with_system",
+													"relation_category": "static",
+													"direction":         "outbound",
+													"relation_liveness": []any{},
+													"target": map[string]any{
+														"entity_id":   "system:⟨bk_cloud_id=0,bk_target_ip=10.0.0.1⟩",
+														"entity_type": "system",
+														"entity_data": map[string]any{},
+														"liveness":    []any{},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"container:⟨cluster=c1,namespace=ns1,pod=p1,container=c1⟩": {
+					ResourceID:   "container:⟨cluster=c1,namespace=ns1,pod=p1,container=c1⟩",
+					ResourceType: ResourceTypeContainer,
+				},
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{},
+				},
+				"node:⟨cluster=c1,node=node1⟩": {
+					ResourceID:   "node:⟨cluster=c1,node=node1⟩",
+					ResourceType: ResourceTypeNode,
+					Labels:       map[string]string{},
+				},
+				"system:⟨bk_cloud_id=0,bk_target_ip=10.0.0.1⟩": {
+					ResourceID:   "system:⟨bk_cloud_id=0,bk_target_ip=10.0.0.1⟩",
+					ResourceType: ResourceTypeSystem,
+					Labels:       map[string]string{},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{
+				"rel_1": {
+					RelationID:   "rel_1",
+					RelationType: RelationType("container_with_pod"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "container:⟨cluster=c1,namespace=ns1,pod=p1,container=c1⟩",
+					ToID:         "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+				},
+				"rel_2": {
+					RelationID:   "rel_2",
+					RelationType: RelationType("node_with_pod"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionInbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "node:⟨cluster=c1,node=node1⟩",
+				},
+				"rel_3": {
+					RelationID:   "rel_3",
+					RelationType: RelationType("node_with_system"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "node:⟨cluster=c1,node=node1⟩",
+					ToID:         "system:⟨bk_cloud_id=0,bk_target_ip=10.0.0.1⟩",
+				},
+			},
+			Adjacency: map[string][]string{
+				"container:⟨cluster=c1,namespace=ns1,pod=p1,container=c1⟩": {"rel_1"},
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩":                    {"rel_2"},
+				"node:⟨cluster=c1,node=node1⟩":                             {"rel_3"},
+				"system:⟨bk_cloud_id=0,bk_target_ip=10.0.0.1⟩":             {},
+			},
+		}, graph)
+	})
+
+	t.Run("invalid relation data type (not []any)", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": "invalid_string", // Should be []any
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+		}, graph)
+	})
+
+	t.Run("invalid relation item type (not map[string]any)", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				"invalid_string", // Should be map[string]any
+				123,              // Invalid type
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+		}, graph)
+	})
+
+	t.Run("missing relation_id adds error", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					// Missing relation_id
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+			TraversalErrors: []string{"parse relation pod_with_service: missing relation_id"},
+		}, graph)
+	})
+
+	t.Run("missing target adds error", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					// Missing target
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+			TraversalErrors: []string{"parse relation pod_with_service: missing target"},
+		}, graph)
+	})
+
+	t.Run("missing entity_id in target adds error", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"target": map[string]any{
+						// Missing entity_id
+						"entity_type": "service",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+			TraversalErrors: []string{"parse relation pod_with_service: parse target: missing entity_id"},
+		}, graph)
+	})
+
+	t.Run("duplicate target node not added twice", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		// Pre-add the target node
+		existingTarget := &NodeLiveness{
+			ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+			ResourceType: ResourceTypeService,
+			Labels:       map[string]string{"existing": "true"},
+		}
+		graph.AddNode(existingTarget)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{"new": "label"},
+						"liveness":    []any{},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+				},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {
+					ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+					ResourceType: ResourceTypeService,
+					Labels:       map[string]string{"existing": "true"},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{
+				"rel_1": {
+					RelationID:   "rel_1",
+					RelationType: RelationType("pod_with_service"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+				},
+			},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩":           {"rel_1"},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {},
+			},
+		}, graph)
+	})
+
+	t.Run("branching hops - multiple nested relations", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{},
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{},
+						"liveness":    []any{},
+						// hop2 with multiple relation types
+						"hop2": map[string]any{
+							"ingress_with_service": []any{
+								map[string]any{
+									"relation_id":       "rel_2",
+									"relation_type":     "ingress_with_service",
+									"relation_category": "static",
+									"direction":         "inbound",
+									"relation_liveness": []any{},
+									"target": map[string]any{
+										"entity_id":   "ingress:⟨cluster=c1,namespace=ns1,ingress=ing1⟩",
+										"entity_type": "ingress",
+										"entity_data": map[string]any{},
+										"liveness":    []any{},
+									},
+								},
+								map[string]any{
+									"relation_id":       "rel_3",
+									"relation_type":     "ingress_with_service",
+									"relation_category": "static",
+									"direction":         "inbound",
+									"relation_liveness": []any{},
+									"target": map[string]any{
+										"entity_id":   "ingress:⟨cluster=c1,namespace=ns1,ingress=ing2⟩",
+										"entity_type": "ingress",
+										"entity_data": map[string]any{},
+										"liveness":    []any{},
+									},
+								},
+							},
+							"k8s_address_with_service": []any{
+								map[string]any{
+									"relation_id":       "rel_4",
+									"relation_type":     "k8s_address_with_service",
+									"relation_category": "static",
+									"direction":         "inbound",
+									"relation_liveness": []any{},
+									"target": map[string]any{
+										"entity_id":   "k8s_address:⟨address=10.0.0.1:8080⟩",
+										"entity_type": "k8s_address",
+										"entity_data": map[string]any{},
+										"liveness":    []any{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, 5, len(graph.Nodes))
+		assert.Equal(t, 4, len(graph.Edges))
+		assert.NotNil(t, graph.GetNode("pod:⟨cluster=c1,namespace=ns1,pod=p1⟩"))
+		assert.NotNil(t, graph.GetNode("service:⟨cluster=c1,namespace=ns1,service=svc1⟩"))
+		assert.NotNil(t, graph.GetNode("ingress:⟨cluster=c1,namespace=ns1,ingress=ing1⟩"))
+		assert.NotNil(t, graph.GetNode("ingress:⟨cluster=c1,namespace=ns1,ingress=ing2⟩"))
+		assert.NotNil(t, graph.GetNode("k8s_address:⟨address=10.0.0.1:8080⟩"))
+		assert.NotNil(t, graph.GetEdge("rel_1"))
+		assert.NotNil(t, graph.GetEdge("rel_2"))
+		assert.NotNil(t, graph.GetEdge("rel_3"))
+		assert.NotNil(t, graph.GetEdge("rel_4"))
+		assert.False(t, graph.HasErrors())
+	})
+
+	t.Run("liveness periods parsed correctly", func(t *testing.T) {
+		graph := NewLivenessGraph(1000, 2000)
+		rootNode := &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+		}
+		graph.AddNode(rootNode)
+
+		hopData := map[string]any{
+			"pod_with_service": []any{
+				map[string]any{
+					"relation_id":       "rel_1",
+					"relation_type":     "pod_with_service",
+					"relation_category": "static",
+					"direction":         "outbound",
+					"relation_liveness": []any{
+						map[string]any{"period_start": float64(1100), "period_end": float64(1500)},
+						map[string]any{"period_start": float64(1600), "period_end": float64(1900)},
+					},
+					"target": map[string]any{
+						"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+						"entity_type": "service",
+						"entity_data": map[string]any{},
+						"liveness": []any{
+							map[string]any{"period_start": float64(1000), "period_end": float64(2000)},
+						},
+					},
+				},
+			},
+		}
+
+		parser.parseHopRelations(graph, rootNode.ResourceID, hopData)
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+				},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {
+					ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+					ResourceType: ResourceTypeService,
+					Labels:       map[string]string{},
+					RawPeriods:   []*VisiblePeriod{{Start: 1000, End: 2000}},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{
+				"rel_1": {
+					RelationID:   "rel_1",
+					RelationType: RelationType("pod_with_service"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+					RawPeriods: []*VisiblePeriod{
+						{Start: 1100, End: 1500},
+						{Start: 1600, End: 1900},
+					},
+				},
+			},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩":           {"rel_1"},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {},
+			},
+		}, graph)
+	})
+}
+
+func TestSurrealResponseParser_Parse(t *testing.T) {
+	t.Run("empty response", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		graphs, err := parser.Parse(nil)
+		require.NoError(t, err)
+		assert.Equal(t, ([]*LivenessGraph)(nil), graphs)
+	})
+
+	t.Run("empty array response", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		graphs, err := parser.Parse([]map[string]any{})
+		require.NoError(t, err)
+		assert.Equal(t, ([]*LivenessGraph)(nil), graphs)
+	})
+
+	t.Run("missing result field", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		graphs, err := parser.Parse([]map[string]any{
+			{"other_field": "value"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, ([]*LivenessGraph)(nil), graphs)
+	})
+
+	t.Run("result is not array", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		graphs, err := parser.Parse([]map[string]any{
+			{"result": "not_an_array"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, ([]*LivenessGraph)(nil), graphs)
+	})
+
+	t.Run("single record with root only", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		response := []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_id":   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+								"entity_type": "pod",
+								"entity_data": map[string]any{
+									"cluster":   "c1",
+									"namespace": "ns1",
+									"pod":       "p1",
+								},
+								"liveness": []any{
+									map[string]any{"period_start": float64(1000), "period_end": float64(2000)},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		graphs, err := parser.Parse(response)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(graphs))
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+					RawPeriods:   []*VisiblePeriod{{Start: 1000, End: 2000}},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+		}, graphs[0])
+	})
+
+	t.Run("single record with hop1", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		response := []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_id":   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+								"entity_type": "pod",
+								"entity_data": map[string]any{},
+								"liveness":    []any{},
+							},
+							"hop1": map[string]any{
+								"pod_with_service": []any{
+									map[string]any{
+										"relation_id":       "rel_1",
+										"relation_type":     "pod_with_service",
+										"relation_category": "static",
+										"direction":         "outbound",
+										"relation_liveness": []any{},
+										"target": map[string]any{
+											"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+											"entity_type": "service",
+											"entity_data": map[string]any{},
+											"liveness":    []any{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		graphs, err := parser.Parse(response)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(graphs))
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{},
+				},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {
+					ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+					ResourceType: ResourceTypeService,
+					Labels:       map[string]string{},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{
+				"rel_1": {
+					RelationID:   "rel_1",
+					RelationType: RelationType("pod_with_service"),
+					Category:     RelationCategoryStatic,
+					Direction:    DirectionOutbound,
+					FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+				},
+			},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩":           {"rel_1"},
+				"service:⟨cluster=c1,namespace=ns1,service=svc1⟩": {},
+			},
+		}, graphs[0])
+	})
+
+	t.Run("multiple records create separate graphs", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		response := []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_id":   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+								"entity_type": "pod",
+								"entity_data": map[string]any{},
+								"liveness":    []any{},
+							},
+						},
+					},
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_id":   "pod:⟨cluster=c1,namespace=ns1,pod=p2⟩",
+								"entity_type": "pod",
+								"entity_data": map[string]any{},
+								"liveness":    []any{},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		graphs, err := parser.Parse(response)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(graphs))
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p1⟩": {},
+			},
+		}, graphs[0])
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart: 1000,
+			QueryEnd:   2000,
+			Nodes: map[string]*NodeLiveness{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p2⟩": {
+					ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p2⟩",
+					ResourceType: ResourceTypePod,
+					Labels:       map[string]string{},
+				},
+			},
+			Edges: map[string]*EdgeLiveness{},
+			Adjacency: map[string][]string{
+				"pod:⟨cluster=c1,namespace=ns1,pod=p2⟩": {},
+			},
+		}, graphs[1])
+	})
+
+	t.Run("invalid root adds error to graph", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		response := []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								// Missing entity_id
+								"entity_type": "pod",
+								"entity_data": map[string]any{},
+								"liveness":    []any{},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		graphs, err := parser.Parse(response)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(graphs))
+
+		assert.Equal(t, &LivenessGraph{
+			QueryStart:      1000,
+			QueryEnd:        2000,
+			Nodes:           map[string]*NodeLiveness{},
+			Edges:           map[string]*EdgeLiveness{},
+			Adjacency:       map[string][]string{},
+			TraversalErrors: []string{"parse root: missing entity_id"},
+		}, graphs[0])
+	})
+
+	t.Run("record without result field skipped", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		response := []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"other": "data",
+					},
+				},
+			},
+		}
+
+		graphs, err := parser.Parse(response)
+		require.NoError(t, err)
+		assert.Equal(t, ([]*LivenessGraph)(nil), graphs)
+	})
+
+	t.Run("record without root field skipped", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		response := []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"hop1": map[string]any{}, // No root
+						},
+					},
+				},
+			},
+		}
+
+		graphs, err := parser.Parse(response)
+		require.NoError(t, err)
+		assert.Equal(t, ([]*LivenessGraph)(nil), graphs)
+	})
+
+	t.Run("multiple hops (hop1, hop2, hop3)", func(t *testing.T) {
+		parser := NewSurrealResponseParser(1000, 2000)
+		response := []map[string]any{
+			{
+				"result": []any{
+					map[string]any{
+						"result": map[string]any{
+							"root": map[string]any{
+								"entity_id":   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+								"entity_type": "pod",
+								"entity_data": map[string]any{},
+								"liveness":    []any{},
+							},
+							"hop1": map[string]any{
+								"node_with_pod": []any{
+									map[string]any{
+										"relation_id":       "rel_1",
+										"relation_type":     "node_with_pod",
+										"relation_category": "static",
+										"direction":         "inbound",
+										"relation_liveness": []any{},
+										"target": map[string]any{
+											"entity_id":   "node:⟨cluster=c1,node=node1⟩",
+											"entity_type": "node",
+											"entity_data": map[string]any{},
+											"liveness":    []any{},
+										},
+									},
+								},
+							},
+							"hop2": map[string]any{
+								"pod_with_service": []any{
+									map[string]any{
+										"relation_id":       "rel_2",
+										"relation_type":     "pod_with_service",
+										"relation_category": "static",
+										"direction":         "outbound",
+										"relation_liveness": []any{},
+										"target": map[string]any{
+											"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+											"entity_type": "service",
+											"entity_data": map[string]any{},
+											"liveness":    []any{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		graphs, err := parser.Parse(response)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(graphs))
+
+		graph := graphs[0]
+		assert.Equal(t, int64(1000), graph.QueryStart)
+		assert.Equal(t, int64(2000), graph.QueryEnd)
+		assert.Equal(t, 3, len(graph.Nodes))
+		assert.Equal(t, 2, len(graph.Edges))
+
+		// Check nodes
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+			Labels:       map[string]string{},
+		}, graph.Nodes["pod:⟨cluster=c1,namespace=ns1,pod=p1⟩"])
+
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "node:⟨cluster=c1,node=node1⟩",
+			ResourceType: ResourceTypeNode,
+			Labels:       map[string]string{},
+		}, graph.Nodes["node:⟨cluster=c1,node=node1⟩"])
+
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+			ResourceType: ResourceTypeService,
+			Labels:       map[string]string{},
+		}, graph.Nodes["service:⟨cluster=c1,namespace=ns1,service=svc1⟩"])
+
+		// Check edges
+		assert.Equal(t, &EdgeLiveness{
+			RelationID:   "rel_1",
+			RelationType: RelationType("node_with_pod"),
+			Category:     RelationCategoryStatic,
+			Direction:    DirectionInbound,
+			FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ToID:         "node:⟨cluster=c1,node=node1⟩",
+		}, graph.Edges["rel_1"])
+
+		assert.Equal(t, &EdgeLiveness{
+			RelationID:   "rel_2",
+			RelationType: RelationType("pod_with_service"),
+			Category:     RelationCategoryStatic,
+			Direction:    DirectionOutbound,
+			FromID:       "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+		}, graph.Edges["rel_2"])
+
+		// Check adjacency (order-insensitive)
+		assert.Equal(t, 3, len(graph.Adjacency))
+		assert.ElementsMatch(t, []string{"rel_1", "rel_2"}, graph.Adjacency["pod:⟨cluster=c1,namespace=ns1,pod=p1⟩"])
+		assert.Equal(t, []string{}, graph.Adjacency["node:⟨cluster=c1,node=node1⟩"])
+		assert.Equal(t, []string{}, graph.Adjacency["service:⟨cluster=c1,namespace=ns1,service=svc1⟩"])
+	})
+}
+
+func TestSurrealResponseParser_parseEntity(t *testing.T) {
+	parser := NewSurrealResponseParser(1000, 2000)
+
+	t.Run("valid entity", func(t *testing.T) {
+		data := map[string]any{
+			"entity_id":   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			"entity_type": "pod",
+			"entity_data": map[string]any{
+				"cluster":   "c1",
+				"namespace": "ns1",
+				"pod":       "p1",
+			},
+			"liveness": []any{
+				map[string]any{"period_start": float64(1000), "period_end": float64(2000)},
+			},
+		}
+
+		node, err := parser.parseEntity(data)
+		require.NoError(t, err)
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "pod:⟨cluster=c1,namespace=ns1,pod=p1⟩",
+			ResourceType: ResourceTypePod,
+			Labels:       map[string]string{"cluster": "c1", "namespace": "ns1", "pod": "p1"},
+			RawPeriods:   []*VisiblePeriod{{Start: 1000, End: 2000}},
+		}, node)
+	})
+
+	t.Run("missing entity_id", func(t *testing.T) {
+		data := map[string]any{
+			"entity_type": "pod",
+			"entity_data": map[string]any{},
+		}
+
+		_, err := parser.parseEntity(data)
+		assert.Equal(t, "missing entity_id", err.Error())
+	})
+
+	t.Run("empty entity_id", func(t *testing.T) {
+		data := map[string]any{
+			"entity_id":   "",
+			"entity_type": "pod",
+			"entity_data": map[string]any{},
+		}
+
+		_, err := parser.parseEntity(data)
+		assert.Equal(t, "missing entity_id", err.Error())
+	})
+
+	t.Run("non-string values in entity_data", func(t *testing.T) {
+		data := map[string]any{
+			"entity_id":   "test:⟨id=1⟩",
+			"entity_type": "test",
+			"entity_data": map[string]any{
+				"string_val": "test",
+				"int_val":    123,
+				"float_val":  45.67,
+				"bool_val":   true,
+				"nil_val":    nil,
+			},
+		}
+
+		node, err := parser.parseEntity(data)
+		require.NoError(t, err)
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "test:⟨id=1⟩",
+			ResourceType: ResourceType("test"),
+			Labels: map[string]string{
+				"string_val": "test",
+				"int_val":    "123",
+				"float_val":  "45.67",
+				"bool_val":   "true",
+			},
+		}, node)
+	})
+
+	t.Run("missing entity_data", func(t *testing.T) {
+		data := map[string]any{
+			"entity_id":   "test:⟨id=1⟩",
+			"entity_type": "test",
+		}
+
+		node, err := parser.parseEntity(data)
+		require.NoError(t, err)
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "test:⟨id=1⟩",
+			ResourceType: ResourceType("test"),
+			Labels:       map[string]string{},
+		}, node)
+	})
+
+	t.Run("missing liveness", func(t *testing.T) {
+		data := map[string]any{
+			"entity_id":   "test:⟨id=1⟩",
+			"entity_type": "test",
+		}
+
+		node, err := parser.parseEntity(data)
+		require.NoError(t, err)
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "test:⟨id=1⟩",
+			ResourceType: ResourceType("test"),
+			Labels:       map[string]string{},
+		}, node)
+	})
+}
+
+func TestSurrealResponseParser_parseLivenessPeriods(t *testing.T) {
+	parser := NewSurrealResponseParser(1000, 2000)
+
+	t.Run("valid periods", func(t *testing.T) {
+		data := []any{
+			map[string]any{"period_start": float64(1000), "period_end": float64(1500)},
+			map[string]any{"period_start": float64(1600), "period_end": float64(2000)},
+		}
+
+		periods := parser.parseLivenessPeriods(data)
+		assert.Equal(t, []*VisiblePeriod{
+			{Start: 1000, End: 1500},
+			{Start: 1600, End: 2000},
+		}, periods)
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		periods := parser.parseLivenessPeriods(nil)
+		assert.Equal(t, ([]*VisiblePeriod)(nil), periods)
+	})
+
+	t.Run("not array", func(t *testing.T) {
+		periods := parser.parseLivenessPeriods("not_array")
+		assert.Equal(t, ([]*VisiblePeriod)(nil), periods)
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		periods := parser.parseLivenessPeriods([]any{})
+		assert.Equal(t, ([]*VisiblePeriod)(nil), periods)
+	})
+
+	t.Run("invalid period item", func(t *testing.T) {
+		data := []any{
+			"not_a_map",
+			map[string]any{"period_start": float64(1000), "period_end": float64(1500)},
+		}
+
+		periods := parser.parseLivenessPeriods(data)
+		assert.Equal(t, []*VisiblePeriod{{Start: 1000, End: 1500}}, periods)
+	})
+
+	t.Run("period with start > end skipped", func(t *testing.T) {
+		data := []any{
+			map[string]any{"period_start": float64(2000), "period_end": float64(1000)}, // Invalid
+			map[string]any{"period_start": float64(1000), "period_end": float64(1500)}, // Valid
+		}
+
+		periods := parser.parseLivenessPeriods(data)
+		assert.Equal(t, []*VisiblePeriod{{Start: 1000, End: 1500}}, periods)
+	})
+
+	t.Run("int64 values", func(t *testing.T) {
+		data := []any{
+			map[string]any{"period_start": int64(1000), "period_end": int64(1500)},
+		}
+
+		periods := parser.parseLivenessPeriods(data)
+		assert.Equal(t, []*VisiblePeriod{{Start: 1000, End: 1500}}, periods)
+	})
+
+	t.Run("int values", func(t *testing.T) {
+		data := []any{
+			map[string]any{"period_start": 1000, "period_end": 1500},
+		}
+
+		periods := parser.parseLivenessPeriods(data)
+		assert.Equal(t, []*VisiblePeriod{{Start: 1000, End: 1500}}, periods)
+	})
+
+	t.Run("string values", func(t *testing.T) {
+		data := []any{
+			map[string]any{"period_start": "1000", "period_end": "1500"},
+		}
+
+		periods := parser.parseLivenessPeriods(data)
+		assert.Equal(t, []*VisiblePeriod{{Start: 1000, End: 1500}}, periods)
+	})
+}
+
+func TestSurrealResponseParser_toInt64(t *testing.T) {
+	parser := NewSurrealResponseParser(1000, 2000)
+
+	t.Run("float64", func(t *testing.T) {
+		result := parser.toInt64(float64(1234.56))
+		assert.Equal(t, int64(1234), result)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		result := parser.toInt64(int64(1234))
+		assert.Equal(t, int64(1234), result)
+	})
+
+	t.Run("int", func(t *testing.T) {
+		result := parser.toInt64(1234)
+		assert.Equal(t, int64(1234), result)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		result := parser.toInt64("1234")
+		assert.Equal(t, int64(1234), result)
+	})
+
+	t.Run("invalid string", func(t *testing.T) {
+		result := parser.toInt64("not_a_number")
+		assert.Equal(t, int64(0), result)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		result := parser.toInt64(nil)
+		assert.Equal(t, int64(0), result)
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		result := parser.toInt64([]int{1, 2, 3})
+		assert.Equal(t, int64(0), result)
+	})
+}
+
+func TestSurrealResponseParser_parseRelation(t *testing.T) {
+	parser := NewSurrealResponseParser(1000, 2000)
+
+	t.Run("valid relation", func(t *testing.T) {
+		data := map[string]any{
+			"relation_id":       "rel_1",
+			"relation_type":     "pod_with_service",
+			"relation_category": "static",
+			"direction":         "outbound",
+			"relation_liveness": []any{
+				map[string]any{"period_start": float64(1000), "period_end": float64(2000)},
+			},
+			"target": map[string]any{
+				"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+				"entity_type": "service",
+				"entity_data": map[string]any{},
+				"liveness":    []any{},
+			},
+		}
+
+		edge, targetNode, nestedHops, err := parser.parseRelation("from_id", "pod_with_service", data)
+		require.NoError(t, err)
+
+		assert.Equal(t, &EdgeLiveness{
+			RelationID:   "rel_1",
+			RelationType: RelationType("pod_with_service"),
+			Category:     RelationCategoryStatic,
+			Direction:    DirectionOutbound,
+			FromID:       "from_id",
+			ToID:         "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+			RawPeriods:   []*VisiblePeriod{{Start: 1000, End: 2000}},
+		}, edge)
+
+		assert.Equal(t, &NodeLiveness{
+			ResourceID:   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+			ResourceType: ResourceTypeService,
+			Labels:       map[string]string{},
+		}, targetNode)
+
+		assert.Equal(t, ([]map[string]any)(nil), nestedHops)
+	})
+
+	t.Run("missing relation_id", func(t *testing.T) {
+		data := map[string]any{
+			"relation_type": "pod_with_service",
+			"target": map[string]any{
+				"entity_id": "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+			},
+		}
+
+		_, _, _, err := parser.parseRelation("from_id", "pod_with_service", data)
+		assert.Equal(t, "missing relation_id", err.Error())
+	})
+
+	t.Run("missing target", func(t *testing.T) {
+		data := map[string]any{
+			"relation_id":   "rel_1",
+			"relation_type": "pod_with_service",
+		}
+
+		_, _, _, err := parser.parseRelation("from_id", "pod_with_service", data)
+		assert.Equal(t, "missing target", err.Error())
+	})
+
+	t.Run("with nested hops", func(t *testing.T) {
+		data := map[string]any{
+			"relation_id":       "rel_1",
+			"relation_type":     "pod_with_service",
+			"relation_category": "static",
+			"relation_liveness": []any{},
+			"target": map[string]any{
+				"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+				"entity_type": "service",
+				"entity_data": map[string]any{},
+				"liveness":    []any{},
+				"hop2": map[string]any{
+					"ingress_with_service": []any{},
+				},
+				"hop3": map[string]any{
+					"domain_with_service": []any{},
+				},
+			},
+		}
+
+		_, _, nestedHops, err := parser.parseRelation("from_id", "pod_with_service", data)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(nestedHops))
+	})
+
+	t.Run("invalid nested hop type", func(t *testing.T) {
+		data := map[string]any{
+			"relation_id":       "rel_1",
+			"relation_type":     "pod_with_service",
+			"relation_category": "static",
+			"relation_liveness": []any{},
+			"target": map[string]any{
+				"entity_id":   "service:⟨cluster=c1,namespace=ns1,service=svc1⟩",
+				"entity_type": "service",
+				"entity_data": map[string]any{},
+				"liveness":    []any{},
+				"hop2":        "invalid_string", // Should be map[string]any
+			},
+		}
+
+		_, _, nestedHops, err := parser.parseRelation("from_id", "pod_with_service", data)
+		require.NoError(t, err)
+		assert.Equal(t, ([]map[string]any)(nil), nestedHops)
+	})
+}

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
@@ -1,0 +1,198 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/curl"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+)
+
+const (
+	BKBaseSurrealDBUrlConfigPath           = "cmdb.v1beta3.surrealdb.bkbase.url"
+	BKBaseSurrealDBResultTableIDConfigPath = "cmdb.v1beta3.surrealdb.bkbase.result_table_id"
+	BKBaseSurrealDBPreferStorageConfigPath = "cmdb.v1beta3.surrealdb.bkbase.prefer_storage"
+	BKBaseSurrealDBAuthMethodConfigPath    = "cmdb.v1beta3.surrealdb.bkbase.auth_method"
+	BKBaseSurrealDBUsernameConfigPath      = "cmdb.v1beta3.surrealdb.bkbase.username"
+	BKBaseSurrealDBAppCodeConfigPath       = "cmdb.v1beta3.surrealdb.bkbase.app_code"
+	BKBaseSurrealDBAppSecretConfigPath     = "cmdb.v1beta3.surrealdb.bkbase.app_secret"
+	BKBaseSurrealDBTimeoutConfigPath       = "cmdb.v1beta3.surrealdb.bkbase.timeout"
+)
+
+var (
+	DefaultBKBaseSurrealDBUrl           = "path-to-surrealDB"
+	DefaultBKBaseSurrealDBResultTableID = ""
+	DefaultBKBaseSurrealDBPreferStorage = "surrealdb"
+	DefaultBKBaseSurrealDBAuthMethod    = "user"
+	DefaultBKBaseSurrealDBUsername      = ""
+	DefaultBKBaseSurrealDBAppCode       = ""
+	DefaultBKBaseSurrealDBAppSecret     = ""
+	DefaultBKBaseSurrealDBTimeout       = 30 * time.Second
+)
+
+var (
+	BKBaseSurrealDBUrl           string
+	BKBaseSurrealDBResultTableID string
+	BKBaseSurrealDBPreferStorage string
+	BKBaseSurrealDBAuthMethod    string
+	BKBaseSurrealDBUsername      string
+	BKBaseSurrealDBAppCode       string
+	BKBaseSurrealDBAppSecret     string
+	BKBaseSurrealDBTimeout       time.Duration
+)
+
+type BKBaseSurrealDBConfig struct {
+	Url           string
+	ResultTableID string
+	PreferStorage string
+	AuthMethod    string
+	Username      string
+	AppCode       string
+	AppSecret     string
+	Timeout       time.Duration
+}
+
+type BKBaseSurrealDBClient struct {
+	config BKBaseSurrealDBConfig
+	curl   curl.Curl
+}
+
+type BKBaseRequest struct {
+	SQL                        string `json:"sql"`
+	BKDataAuthenticationMethod string `json:"bkdata_authentication_method"`
+	PreferStorage              string `json:"prefer_storage"`
+	BKUsername                 string `json:"bk_username"`
+	BKAppCode                  string `json:"bk_app_code"`
+	BKAppSecret                string `json:"bk_app_secret"`
+}
+
+type BKBaseSQLPayload struct {
+	DSL           string `json:"dsl"`
+	ResultTableID string `json:"result_table_id"`
+}
+
+type BKBaseResponse struct {
+	Result  bool        `json:"result"`
+	Code    string      `json:"code"`
+	Data    *BKBaseData `json:"data"`
+	Message string      `json:"message"`
+	Errors  any         `json:"errors"`
+	TraceID string      `json:"trace_id"`
+}
+
+type BKBaseData struct {
+	TotalRecords      int              `json:"total_records"`
+	Device            string           `json:"device"`
+	Cluster           string           `json:"cluster"`
+	ResultTableIDs    []string         `json:"result_table_ids"`
+	List              []map[string]any `json:"list"`
+	SelectFieldsOrder []string         `json:"select_fields_order"`
+	Timetaken         float64          `json:"timetaken"`
+}
+
+func NewBKBaseSurrealDBClient() *BKBaseSurrealDBClient {
+	return NewBKBaseSurrealDBClientWithConfig(BKBaseSurrealDBConfig{
+		Url:           BKBaseSurrealDBUrl,
+		ResultTableID: BKBaseSurrealDBResultTableID,
+		PreferStorage: BKBaseSurrealDBPreferStorage,
+		AuthMethod:    BKBaseSurrealDBAuthMethod,
+		Username:      BKBaseSurrealDBUsername,
+		AppCode:       BKBaseSurrealDBAppCode,
+		AppSecret:     BKBaseSurrealDBAppSecret,
+		Timeout:       BKBaseSurrealDBTimeout,
+	})
+}
+
+func NewBKBaseSurrealDBClientWithConfig(config BKBaseSurrealDBConfig) *BKBaseSurrealDBClient {
+	return &BKBaseSurrealDBClient{
+		config: config,
+		curl:   &curl.HttpCurl{},
+	}
+}
+
+func (c *BKBaseSurrealDBClient) Execute(ctx context.Context, sql string, start, end int64) ([]*LivenessGraph, error) {
+	var err error
+	ctx, span := trace.NewSpan(ctx, "bkbase-surrealdb-execute")
+	defer span.End(&err)
+
+	span.Set("sql", sql)
+	span.Set("start", start)
+	span.Set("end", end)
+	span.Set("result_table_id", c.config.ResultTableID)
+
+	sqlPayload := BKBaseSQLPayload{
+		DSL:           sql,
+		ResultTableID: c.config.ResultTableID,
+	}
+	sqlPayloadBytes, err := json.Marshal(sqlPayload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal sql payload: %w", err)
+	}
+
+	request := BKBaseRequest{
+		SQL:                        string(sqlPayloadBytes),
+		BKDataAuthenticationMethod: c.config.AuthMethod,
+		PreferStorage:              c.config.PreferStorage,
+		BKUsername:                 c.config.Username,
+		BKAppCode:                  c.config.AppCode,
+		BKAppSecret:                c.config.AppSecret,
+	}
+
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	span.Set("request_url", c.config.Url)
+
+	var resp BKBaseResponse
+	_, err = c.curl.Request(ctx, curl.Post, curl.Options{
+		UrlPath: c.config.Url,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body:    requestBody,
+		Timeout: c.config.Timeout,
+	}, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("bkbase request failed: %w", err)
+	}
+
+	if !resp.Result {
+		return nil, fmt.Errorf("bkbase response error: code=%s, message=%s", resp.Code, resp.Message)
+	}
+
+	span.Set("trace_id", resp.TraceID)
+	span.Set("total_records", resp.Data.TotalRecords)
+
+	// 转换响应格式为标准 SurrealDB 响应格式
+	// BKBase 返回格式: {"data": {"list": [...]}}
+	// 标准格式: [{"result": [...]}]
+	rawResponse := []map[string]any{
+		{
+			ResponseFieldResult: resp.Data.List,
+		},
+	}
+
+	parser := NewSurrealResponseParser(start, end)
+	return parser.Parse(rawResponse)
+}
+
+func (c *BKBaseSurrealDBClient) SetResultTableID(resultTableID string) {
+	c.config.ResultTableID = resultTableID
+}
+
+func (c *BKBaseSurrealDBClient) GetResultTableID() string {
+	return c.config.ResultTableID
+}

--- a/pkg/unify-query/cmdb/v1beta3/types.go
+++ b/pkg/unify-query/cmdb/v1beta3/types.go
@@ -1,0 +1,233 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type ResourceType string
+
+const (
+	ResourceTypePod         ResourceType = "pod"
+	ResourceTypeNode        ResourceType = "node"
+	ResourceTypeContainer   ResourceType = "container"
+	ResourceTypeDeployment  ResourceType = "deployment"
+	ResourceTypeReplicaSet  ResourceType = "replicaset"
+	ResourceTypeStatefulSet ResourceType = "statefulset"
+	ResourceTypeDaemonSet   ResourceType = "daemonset"
+	ResourceTypeJob         ResourceType = "job"
+	ResourceTypeService     ResourceType = "service"
+	ResourceTypeIngress     ResourceType = "ingress"
+	ResourceTypeCluster     ResourceType = "cluster"
+	ResourceTypeNamespace   ResourceType = "namespace"
+
+	ResourceTypeSystem     ResourceType = "system"
+	ResourceTypeK8sAddress ResourceType = "k8s_address"
+	ResourceTypeDomain     ResourceType = "domain"
+
+	ResourceTypeAPMService         ResourceType = "apm_service"
+	ResourceTypeAPMServiceInstance ResourceType = "apm_service_instance"
+
+	ResourceTypeDataSource  ResourceType = "datasource"
+	ResourceTypeBKLogConfig ResourceType = "bklogconfig"
+
+	ResourceTypeBiz    ResourceType = "biz"
+	ResourceTypeSet    ResourceType = "set"
+	ResourceTypeModule ResourceType = "module"
+	ResourceTypeHost   ResourceType = "host"
+
+	ResourceTypeAppVersion  ResourceType = "app_version"
+	ResourceTypeGitCommit   ResourceType = "git_commit"
+	ResourceTypeEnvironment ResourceType = "environment"
+)
+
+type RelationType string
+
+const (
+	RelationNodeWithSystem           RelationType = "node_with_system"
+	RelationNodeWithPod              RelationType = "node_with_pod"
+	RelationJobWithPod               RelationType = "job_with_pod"
+	RelationPodWithReplicaSet        RelationType = "pod_with_replicaset"
+	RelationPodWithStatefulSet       RelationType = "pod_with_statefulset"
+	RelationDaemonSetWithPod         RelationType = "daemonset_with_pod"
+	RelationDeploymentWithReplicaSet RelationType = "deployment_with_replicaset"
+	RelationPodWithService           RelationType = "pod_with_service"
+	RelationIngressWithService       RelationType = "ingress_with_service"
+
+	RelationK8sAddressWithService RelationType = "k8s_address_with_service"
+	RelationDomainWithService     RelationType = "domain_with_service"
+
+	RelationAPMServiceInstanceWithPod        RelationType = "apm_service_instance_with_pod"
+	RelationAPMServiceInstanceWithSystem     RelationType = "apm_service_instance_with_system"
+	RelationAPMServiceWithAPMServiceInstance RelationType = "apm_service_with_apm_service_instance"
+
+	RelationContainerWithPod RelationType = "container_with_pod"
+
+	RelationDataSourceWithPod         RelationType = "datasource_with_pod"
+	RelationDataSourceWithNode        RelationType = "datasource_with_node"
+	RelationBKLogConfigWithDataSource RelationType = "bklogconfig_with_datasource"
+
+	RelationBizWithSet     RelationType = "biz_with_set"
+	RelationModuleWithSet  RelationType = "module_with_set"
+	RelationHostWithModule RelationType = "host_with_module"
+	RelationHostWithSystem RelationType = "host_with_system"
+
+	RelationAppVersionWithContainer  RelationType = "app_version_with_container"
+	RelationAppVersionWithSystem     RelationType = "app_version_with_system"
+	RelationContainerWithEnvironment RelationType = "container_with_environment"
+	RelationEnvironmentWithSystem    RelationType = "environment_with_system"
+	RelationAppVersionWithGitCommit  RelationType = "app_version_with_git_commit"
+
+	RelationPodToPod         RelationType = "pod_to_pod"
+	RelationPodToSystem      RelationType = "pod_to_system"
+	RelationSystemToPod      RelationType = "system_to_pod"
+	RelationSystemToSystem   RelationType = "system_to_system"
+	RelationServiceToService RelationType = "service_to_service"
+)
+
+type RelationCategory string
+
+const (
+	RelationCategoryStatic  RelationCategory = "static"
+	RelationCategoryDynamic RelationCategory = "dynamic"
+)
+
+type TraversalDirection string
+
+const (
+	DirectionOutbound TraversalDirection = "outbound"
+	DirectionInbound  TraversalDirection = "inbound"
+	DirectionBoth     TraversalDirection = "both"
+)
+
+const (
+	FieldPeriodStart = "period_start"
+	FieldPeriodEnd   = "period_end"
+)
+
+const (
+	ResponseFieldResult = "result"
+	ResponseFieldRoot   = "root"
+	ResponseFieldTarget = "target"
+
+	ResponseFieldHopPrefix = "hop"
+
+	ResponseFieldEntityID   = "entity_id"
+	ResponseFieldEntityType = "entity_type"
+	ResponseFieldEntityData = "entity_data"
+	ResponseFieldLiveness   = "liveness"
+
+	ResponseFieldRelationID       = "relation_id"
+	ResponseFieldRelationType     = "relation_type"
+	ResponseFieldRelationCategory = "relation_category"
+	ResponseFieldRelationLiveness = "relation_liveness"
+	ResponseFieldDirection        = "direction"
+)
+
+// LivenessRecord 资源存活记录
+type LivenessRecord struct {
+	ID          string `json:"id"`
+	ResourceID  string `json:"resource_id"`
+	PeriodStart int64  `json:"period_start"`
+	PeriodEnd   int64  `json:"period_end"`
+	IsActive    bool   `json:"is_active"`
+	CreatedAt   int64  `json:"created_at"`
+	UpdatedAt   int64  `json:"updated_at"`
+}
+
+// VisiblePeriod 可见时间段
+type VisiblePeriod struct {
+	Start int64 `json:"start"`
+	End   int64 `json:"end"`
+}
+
+// Overlap 计算两个 VisiblePeriod 的交集
+func (p *VisiblePeriod) Overlap(other *VisiblePeriod) *VisiblePeriod {
+	start := p.Start
+	if other.Start > start {
+		start = other.Start
+	}
+	end := p.End
+	if other.End < end {
+		end = other.End
+	}
+	if start > end {
+		return nil
+	}
+	return &VisiblePeriod{Start: start, End: end}
+}
+
+// GenerateResourceID 生成资源ID，格式: {resource_type}:⟨key1=value1,key2=value2,...⟩
+func GenerateResourceID(resourceType ResourceType, labels map[string]string) string {
+	if len(labels) == 0 {
+		return string(resourceType) + ":⟨⟩"
+	}
+
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(labels))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, labels[k]))
+	}
+
+	return fmt.Sprintf("%s:⟨%s⟩", resourceType, strings.Join(pairs, ","))
+}
+
+func GetLivenessRecordTableName(resourceType ResourceType) string {
+	return string(resourceType) + "_liveness_record"
+}
+
+func GetRelationLivenessRecordTableName(relationType RelationType) string {
+	return string(relationType) + "_liveness_record"
+}
+
+func GetLivenessIDField(resourceType ResourceType) string {
+	return string(resourceType) + "_id"
+}
+
+var resourcePrimaryKeys = map[ResourceType][]string{
+	ResourceTypePod:                {"bcs_cluster_id", "namespace", "pod"},
+	ResourceTypeNode:               {"bcs_cluster_id", "node"},
+	ResourceTypeContainer:          {"bcs_cluster_id", "namespace", "pod", "container"},
+	ResourceTypeDeployment:         {"bcs_cluster_id", "namespace", "deployment"},
+	ResourceTypeReplicaSet:         {"bcs_cluster_id", "namespace", "replicaset"},
+	ResourceTypeStatefulSet:        {"bcs_cluster_id", "namespace", "statefulset"},
+	ResourceTypeDaemonSet:          {"bcs_cluster_id", "namespace", "daemonset"},
+	ResourceTypeJob:                {"bcs_cluster_id", "namespace", "job"},
+	ResourceTypeService:            {"bcs_cluster_id", "namespace", "service"},
+	ResourceTypeIngress:            {"bcs_cluster_id", "namespace", "ingress"},
+	ResourceTypeCluster:            {"bcs_cluster_id"},
+	ResourceTypeNamespace:          {"bcs_cluster_id", "namespace"},
+	ResourceTypeSystem:             {"bk_cloud_id", "bk_target_ip"},
+	ResourceTypeK8sAddress:         {"address"},
+	ResourceTypeDomain:             {"domain"},
+	ResourceTypeAPMService:         {"bk_biz_id", "app_name", "apm_service_name"},
+	ResourceTypeAPMServiceInstance: {"bk_biz_id", "app_name", "apm_service_name", "apm_service_instance_id"},
+	ResourceTypeDataSource:         {"bk_data_id"},
+	ResourceTypeBKLogConfig:        {"bklogconfig_namespace", "bklogconfig_name"},
+	ResourceTypeBiz:                {"bk_biz_id"},
+	ResourceTypeSet:                {"bk_set_id"},
+	ResourceTypeModule:             {"bk_module_id"},
+	ResourceTypeHost:               {"bk_host_id"},
+	ResourceTypeAppVersion:         {"bcs_cluster_id", "namespace", "app_version"},
+	ResourceTypeGitCommit:          {"git_repo", "commit_id"},
+	ResourceTypeEnvironment:        {"bcs_cluster_id", "namespace", "pod", "env_name"},
+}
+
+func GetResourcePrimaryKeys(resourceType ResourceType) []string {
+	return resourcePrimaryKeys[resourceType]
+}

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3.go
@@ -1,0 +1,517 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+)
+
+var (
+	defaultModel *Model
+	modelMutex   sync.Mutex
+)
+
+func GetModel(ctx context.Context) (cmdb.CMDB, error) {
+	if defaultModel == nil {
+		modelMutex.Lock()
+		defer modelMutex.Unlock()
+		if defaultModel == nil {
+			client := NewBKBaseSurrealDBClient()
+			model, err := NewModel(ctx, client)
+			if err != nil {
+				return nil, err
+			}
+			defaultModel = model
+		}
+	}
+	return defaultModel, nil
+}
+
+type GraphQueryExecutor interface {
+	Execute(ctx context.Context, sql string, start, end int64) ([]*LivenessGraph, error)
+}
+
+// Model v2 CMDB 实现，基于 SurrealDB 图查询
+type Model struct {
+	executor GraphQueryExecutor
+}
+
+// NewModel 创建 Model 实例
+func NewModel(ctx context.Context, executor GraphQueryExecutor) (*Model, error) {
+	return &Model{executor: executor}, nil
+}
+
+// SetExecutor 设置查询执行器（用于测试）
+func (m *Model) SetExecutor(executor GraphQueryExecutor) {
+	m.executor = executor
+}
+
+func (m *Model) QueryResourceMatcher(
+	ctx context.Context,
+	lookBackDelta, spaceUid string,
+	ts string,
+	target, source cmdb.Resource,
+	indexMatcher, expandMatcher cmdb.Matcher,
+	expandShow bool,
+	pathResource []cmdb.Resource,
+) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []string, resTarget cmdb.Resource, resMatchers cmdb.Matchers, err error) {
+	ctx, span := trace.NewSpan(ctx, "cmdb-query-resource-matcher")
+	defer span.End(&err)
+
+	span.Set("space-uid", spaceUid)
+	span.Set("timestamp", ts)
+	span.Set("look-back-delta", lookBackDelta)
+	span.Set("source", source)
+	span.Set("target", target)
+	span.Set("index-matcher", indexMatcher)
+	span.Set("path-resource", pathResource)
+
+	timestamp, err := parseTimestamp(ts)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	lbd, err := parseLookBackDelta(lookBackDelta)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	req := &QueryRequest{
+		Timestamp:     timestamp,
+		SourceType:    FromCMDBResource(source),
+		SourceInfo:    matcherToMap(indexMatcher),
+		TargetType:    FromCMDBResource(target),
+		PathResource:  toResourceTypes(pathResource),
+		MaxHops:       computeMaxHops(pathResource),
+		LookBackDelta: lbd,
+	}
+	req.Normalize()
+
+	_, pathsV2, matchers, err := m.QueryLivenessGraph(ctx, req)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	paths := convertPathsV2ToStrings(pathsV2)
+
+	span.Set("paths-count", len(paths))
+	span.Set("matchers-count", len(matchers))
+
+	return source, indexMatcher, paths, target, matchers, nil
+}
+
+// QueryDynamicPaths 实现 cmdb.CMDB 接口（instant 查询），返回 []PathV2
+func (m *Model) QueryDynamicPaths(
+	ctx context.Context,
+	lookBackDelta, spaceUid string,
+	ts string,
+	target, source cmdb.Resource,
+	indexMatcher, expandMatcher cmdb.Matcher,
+	expandShow bool,
+	pathResource []cmdb.Resource,
+) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []cmdb.PathV2, resTarget cmdb.Resource, resMatchers cmdb.Matchers, err error) {
+	ctx, span := trace.NewSpan(ctx, "cmdb-v2-query-dynamic-paths")
+	defer span.End(&err)
+
+	span.Set("space-uid", spaceUid)
+	span.Set("timestamp", ts)
+	span.Set("look-back-delta", lookBackDelta)
+	span.Set("source", source)
+	span.Set("target", target)
+	span.Set("index-matcher", indexMatcher)
+	span.Set("path-resource", pathResource)
+
+	timestamp, err := parseTimestamp(ts)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	lbd, err := parseLookBackDelta(lookBackDelta)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	req := &QueryRequest{
+		Timestamp:     timestamp,
+		SourceType:    FromCMDBResource(source),
+		SourceInfo:    matcherToMap(indexMatcher),
+		TargetType:    FromCMDBResource(target),
+		PathResource:  toResourceTypes(pathResource),
+		MaxHops:       computeMaxHops(pathResource),
+		LookBackDelta: lbd,
+	}
+	req.Normalize()
+
+	_, paths, matchers, err := m.QueryLivenessGraph(ctx, req)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	span.Set("paths-count", len(paths))
+	span.Set("matchers-count", len(matchers))
+
+	return source, indexMatcher, paths, target, matchers, nil
+}
+
+// QueryResourceMatcherRange 实现 cmdb.CMDB 接口（range 查询）
+func (m *Model) QueryResourceMatcherRange(
+	ctx context.Context,
+	lookBackDelta, spaceUid string,
+	step string,
+	startTs, endTs string,
+	target, source cmdb.Resource,
+	indexMatcher, expandMatcher cmdb.Matcher,
+	expandShow bool,
+	pathResource []cmdb.Resource,
+) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []string, resTarget cmdb.Resource, result []cmdb.MatchersWithTimestamp, err error) {
+	ctx, span := trace.NewSpan(ctx, "cmdb-query-resource-matcher-range")
+	defer span.End(&err)
+
+	span.Set("space-uid", spaceUid)
+	span.Set("start-ts", startTs)
+	span.Set("end-ts", endTs)
+	span.Set("step", step)
+	span.Set("look-back-delta", lookBackDelta)
+	span.Set("source", source)
+	span.Set("target", target)
+	span.Set("index-matcher", indexMatcher)
+	span.Set("path-resource", pathResource)
+
+	start, err := parseTimestamp(startTs)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+	end, err := parseTimestamp(endTs)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	lbd, err := parseLookBackDelta(lookBackDelta)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	stepMs, err := parseStep(step)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	req := &QueryRequest{
+		Timestamp:     end,
+		SourceType:    FromCMDBResource(source),
+		SourceInfo:    matcherToMap(indexMatcher),
+		TargetType:    FromCMDBResource(target),
+		PathResource:  toResourceTypes(pathResource),
+		MaxHops:       computeMaxHops(pathResource),
+		LookBackDelta: lbd,
+	}
+	req.Normalize()
+
+	graphs, pathsV2, _, err := m.QueryLivenessGraph(ctx, req)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	result = buildTargetMatchersTimeSeries(graphs, req.TargetType, start, end, stepMs)
+
+	paths := convertPathsV2ToStrings(pathsV2)
+
+	span.Set("paths-count", len(paths))
+	span.Set("result-count", len(result))
+
+	return source, indexMatcher, paths, target, result, nil
+}
+
+// QueryDynamicPathsRange 实现 cmdb.CMDB 接口（range 查询），返回 []PathV2
+func (m *Model) QueryDynamicPathsRange(
+	ctx context.Context,
+	lookBackDelta, spaceUid string,
+	step string,
+	startTs, endTs string,
+	target, source cmdb.Resource,
+	indexMatcher, expandMatcher cmdb.Matcher,
+	expandShow bool,
+	pathResource []cmdb.Resource,
+) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []cmdb.PathV2, resTarget cmdb.Resource, result []cmdb.MatchersWithTimestamp, err error) {
+	ctx, span := trace.NewSpan(ctx, "cmdb-v2-query-dynamic-paths-range")
+	defer span.End(&err)
+
+	span.Set("space-uid", spaceUid)
+	span.Set("start-ts", startTs)
+	span.Set("end-ts", endTs)
+	span.Set("step", step)
+	span.Set("look-back-delta", lookBackDelta)
+	span.Set("source", source)
+	span.Set("target", target)
+	span.Set("index-matcher", indexMatcher)
+	span.Set("path-resource", pathResource)
+
+	start, err := parseTimestamp(startTs)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+	end, err := parseTimestamp(endTs)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	lbd, err := parseLookBackDelta(lookBackDelta)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	stepMs, err := parseStep(step)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	req := &QueryRequest{
+		Timestamp:     end,
+		SourceType:    FromCMDBResource(source),
+		SourceInfo:    matcherToMap(indexMatcher),
+		TargetType:    FromCMDBResource(target),
+		PathResource:  toResourceTypes(pathResource),
+		MaxHops:       computeMaxHops(pathResource),
+		LookBackDelta: lbd,
+	}
+	req.Normalize()
+
+	graphs, paths, _, err := m.QueryLivenessGraph(ctx, req)
+	if err != nil {
+		return "", nil, nil, "", nil, err
+	}
+
+	result = buildTargetMatchersTimeSeries(graphs, req.TargetType, start, end, stepMs)
+
+	span.Set("paths-count", len(paths))
+	span.Set("result-count", len(result))
+
+	return source, indexMatcher, paths, target, result, nil
+}
+
+// QueryLivenessGraph 执行图查询，返回图数据、路径和目标 Matchers
+func (m *Model) QueryLivenessGraph(ctx context.Context, req *QueryRequest) (graphs []*LivenessGraph, paths []cmdb.PathV2, matchers cmdb.Matchers, err error) {
+	ctx, span := trace.NewSpan(ctx, "cmdb-v2-query-liveness-graph")
+	defer span.End(&err)
+
+	span.Set("source-type", req.SourceType)
+	span.Set("target-type", req.TargetType)
+	span.Set("source-info", req.SourceInfo)
+	span.Set("max-hops", req.MaxHops)
+	span.Set("look-back-delta", req.LookBackDelta)
+
+	builder := NewSurrealQueryBuilder(req)
+	sql := builder.Build()
+	queryStart, queryEnd := req.GetQueryRange()
+
+	span.Set("query-sql", sql)
+	span.Set("query-start", queryStart)
+	span.Set("query-end", queryEnd)
+
+	pf := NewPathFinder(
+		WithAllowedCategories(req.AllowedRelationTypes...),
+		WithDynamicDirection(req.DynamicRelationDirection),
+		WithMaxHops(req.MaxHops),
+	)
+	paths, err = pf.FindAllPaths(req.SourceType, req.TargetType, req.PathResource)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if m.executor != nil {
+		graphs, err = m.executor.Execute(ctx, sql, queryStart, queryEnd)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	matchers = extractMatchersFromGraphs(graphs, req.TargetType)
+
+	span.Set("graphs-count", len(graphs))
+	span.Set("paths-count", len(paths))
+	span.Set("matchers-count", len(matchers))
+
+	return graphs, paths, matchers, nil
+}
+
+// toResourceTypes 将 []cmdb.Resource 转换为 []ResourceType
+func toResourceTypes(resources []cmdb.Resource) []ResourceType {
+	if len(resources) == 0 {
+		return nil
+	}
+	result := make([]ResourceType, len(resources))
+	for i, r := range resources {
+		result[i] = ResourceType(r)
+	}
+	return result
+}
+
+func parseTimestamp(ts string) (int64, error) {
+	if ts == "" {
+		return time.Now().UnixMilli(), nil
+	}
+	sec, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if sec < 1e12 {
+		return sec * 1000, nil
+	}
+	return sec, nil
+}
+
+func parseLookBackDelta(lbd string) (int64, error) {
+	if lbd == "" {
+		return DefaultLookBackDelta, nil
+	}
+	d, err := time.ParseDuration(lbd)
+	if err != nil {
+		return 0, err
+	}
+	return d.Milliseconds(), nil
+}
+
+func parseStep(step string) (int64, error) {
+	if step == "" {
+		return 60000, nil
+	}
+	d, err := time.ParseDuration(step)
+	if err != nil {
+		return 0, err
+	}
+	return d.Milliseconds(), nil
+}
+
+func matcherToMap(m cmdb.Matcher) map[string]string {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+func computeMaxHops(pathResource []cmdb.Resource) int {
+	if len(pathResource) == 0 {
+		return DefaultMaxHops
+	}
+	return len(pathResource) + 1
+}
+
+func extractMatchersFromGraphs(graphs []*LivenessGraph, targetType ResourceType) cmdb.Matchers {
+	if len(graphs) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var result cmdb.Matchers
+
+	for _, g := range graphs {
+		for resourceID, matcher := range g.ExtractTargetMatchersWithID(targetType) {
+			if !seen[resourceID] {
+				seen[resourceID] = true
+				result = append(result, matcher)
+			}
+		}
+	}
+
+	return result
+}
+
+type targetNodeInfo struct {
+	Labels     map[string]string
+	RawPeriods []*VisiblePeriod
+}
+
+func buildTargetMatchersTimeSeries(graphs []*LivenessGraph, targetType ResourceType, start, end, stepMs int64) []cmdb.MatchersWithTimestamp {
+	if len(graphs) == 0 {
+		return nil
+	}
+
+	targetNodes := make(map[string]*targetNodeInfo)
+	for _, g := range graphs {
+		for _, node := range g.Nodes {
+			if node.ResourceType == targetType {
+				if _, exists := targetNodes[node.ResourceID]; !exists {
+					targetNodes[node.ResourceID] = &targetNodeInfo{
+						Labels:     node.Labels,
+						RawPeriods: node.RawPeriods,
+					}
+				} else {
+					targetNodes[node.ResourceID].RawPeriods = append(
+						targetNodes[node.ResourceID].RawPeriods,
+						node.RawPeriods...,
+					)
+				}
+			}
+		}
+	}
+
+	if len(targetNodes) == 0 {
+		return nil
+	}
+
+	var result []cmdb.MatchersWithTimestamp
+
+	for ts := start; ts <= end; ts += stepMs {
+		var activeMatchers cmdb.Matchers
+
+		for _, info := range targetNodes {
+			if isActiveAt(info.RawPeriods, ts) {
+				matcher := make(cmdb.Matcher, len(info.Labels))
+				for k, v := range info.Labels {
+					matcher[k] = v
+				}
+				activeMatchers = append(activeMatchers, matcher)
+			}
+		}
+
+		if len(activeMatchers) > 0 {
+			result = append(result, cmdb.MatchersWithTimestamp{
+				Timestamp: ts,
+				Matchers:  activeMatchers,
+			})
+		}
+	}
+
+	return result
+}
+
+func isActiveAt(periods []*VisiblePeriod, ts int64) bool {
+	for _, p := range periods {
+		if ts >= p.Start && ts <= p.End {
+			return true
+		}
+	}
+	return false
+}
+
+func FromCMDBResource(r cmdb.Resource) ResourceType {
+	return ResourceType(r)
+}
+
+func convertPathsV2ToStrings(pathsV2 []cmdb.PathV2) []string {
+	if len(pathsV2) == 0 {
+		return nil
+	}
+	result := make([]string, len(pathsV2))
+	for i, path := range pathsV2 {
+		result[i] = path.String()
+	}
+	return result
+}

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
@@ -1,0 +1,1034 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+)
+
+type mockGraphQueryExecutor struct {
+	graphs []*LivenessGraph
+	err    error
+}
+
+func (m *mockGraphQueryExecutor) Execute(ctx context.Context, sql string, start, end int64) ([]*LivenessGraph, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	for _, g := range m.graphs {
+		g.QueryStart = start
+		g.QueryEnd = end
+	}
+	return m.graphs, nil
+}
+
+type CMDBHandlerTestCase struct {
+	Name          string
+	LookBackDelta string
+	SpaceUid      string
+	Ts            string
+	StartTs       string
+	EndTs         string
+	Step          string
+	Target        cmdb.Resource
+	Source        cmdb.Resource
+	IndexMatcher  cmdb.Matcher
+	ExpandMatcher cmdb.Matcher
+	ExpandShow    bool
+	PathResource  []cmdb.Resource
+
+	MockGraphs []*LivenessGraph
+	MockError  error
+
+	ExpectedSource     cmdb.Resource
+	ExpectedMatcher    cmdb.Matcher
+	ExpectedPath       []cmdb.PathV2
+	ExpectedTarget     cmdb.Resource
+	ExpectedMatchers   cmdb.Matchers                // instant 查询用
+	ExpectedTimeSeries []cmdb.MatchersWithTimestamp // range 查询用：完整时间序列
+	ExpectedError      bool
+}
+
+func TestQueryResourceMatcher(t *testing.T) {
+	testCases := []CMDBHandlerTestCase{
+		{
+			Name:          "Node_To_Pod_SingleHop",
+			LookBackDelta: "10m",
+			SpaceUid:      "test-space",
+			Ts:            "600",
+			Target:        "pod",
+			Source:        "node",
+			IndexMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"node":           "node-1",
+			},
+			ExpandMatcher: nil,
+			ExpandShow:    false,
+			PathResource:  nil,
+			MockGraphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {
+							ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+							ResourceType: ResourceTypeNode,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"node":           "node-1",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+						},
+						"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {
+							ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+							ResourceType: ResourceTypePod,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"namespace":      "default",
+								"pod":            "nginx-1",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 100000, End: 500000}},
+						},
+						"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=kube-system,pod=coredns-1⟩": {
+							ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=kube-system,pod=coredns-1⟩",
+							ResourceType: ResourceTypePod,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"namespace":      "kube-system",
+								"pod":            "coredns-1",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 200000, End: 600000}},
+						},
+					},
+					Edges: map[string]*EdgeLiveness{
+						"node_with_pod:1": {
+							RelationID:   "node_with_pod:1",
+							RelationType: RelationNodeWithPod,
+							Category:     RelationCategoryStatic,
+							FromID:       "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+							ToID:         "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+						},
+						"node_with_pod:2": {
+							RelationID:   "node_with_pod:2",
+							RelationType: RelationNodeWithPod,
+							Category:     RelationCategoryStatic,
+							FromID:       "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+							ToID:         "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=kube-system,pod=coredns-1⟩",
+						},
+					},
+				},
+			},
+			ExpectedSource: "node",
+			ExpectedMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"node":           "node-1",
+			},
+			ExpectedPath: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "node_with_system", Category: "static", Direction: "outbound"},
+					{ResourceType: "pod", RelationType: "pod_to_system", Category: "dynamic", Direction: "inbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "node_with_system", Category: "static", Direction: "outbound"},
+					{ResourceType: "pod", RelationType: "system_to_pod", Category: "dynamic", Direction: "outbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "datasource", RelationType: "datasource_with_node", Category: "static", Direction: "inbound"},
+					{ResourceType: "pod", RelationType: "datasource_with_pod", Category: "static", Direction: "outbound"},
+				}},
+			},
+			ExpectedTarget: "pod",
+			ExpectedMatchers: cmdb.Matchers{
+				{
+					"bcs_cluster_id": "BCS-K8S-00001",
+					"namespace":      "default",
+					"pod":            "nginx-1",
+				},
+				{
+					"bcs_cluster_id": "BCS-K8S-00001",
+					"namespace":      "kube-system",
+					"pod":            "coredns-1",
+				},
+			},
+			ExpectedError: false,
+		},
+		{
+			Name:          "Pod_To_Node_WithPath",
+			LookBackDelta: "5m",
+			SpaceUid:      "test-space",
+			Ts:            "1000",
+			Target:        "node",
+			Source:        "pod",
+			IndexMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"namespace":      "default",
+				"pod":            "nginx-1",
+			},
+			ExpandMatcher: nil,
+			ExpandShow:    false,
+			PathResource:  []cmdb.Resource{"node"},
+			MockGraphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {
+							ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+							ResourceType: ResourceTypePod,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"namespace":      "default",
+								"pod":            "nginx-1",
+							},
+						},
+						"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {
+							ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+							ResourceType: ResourceTypeNode,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"node":           "node-1",
+							},
+						},
+					},
+				},
+			},
+			ExpectedSource: "pod",
+			ExpectedMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"namespace":      "default",
+				"pod":            "nginx-1",
+			},
+			ExpectedPath: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "pod", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "node", RelationType: "node_with_pod", Category: "static", Direction: "inbound"},
+				}},
+			},
+			ExpectedTarget: "node",
+			ExpectedMatchers: cmdb.Matchers{
+				{
+					"bcs_cluster_id": "BCS-K8S-00001",
+					"node":           "node-1",
+				},
+			},
+			ExpectedError: false,
+		},
+		{
+			Name:          "Empty_Result",
+			LookBackDelta: "10m",
+			SpaceUid:      "test-space",
+			Ts:            "600",
+			Target:        "pod",
+			Source:        "node",
+			IndexMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"node":           "non-existent",
+			},
+			MockGraphs:      nil,
+			ExpectedSource:  "node",
+			ExpectedMatcher: cmdb.Matcher{"bcs_cluster_id": "BCS-K8S-00001", "node": "non-existent"},
+			ExpectedPath: []cmdb.PathV2{
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "node_with_system", Category: "static", Direction: "outbound"},
+					{ResourceType: "pod", RelationType: "pod_to_system", Category: "dynamic", Direction: "inbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "system", RelationType: "node_with_system", Category: "static", Direction: "outbound"},
+					{ResourceType: "pod", RelationType: "system_to_pod", Category: "dynamic", Direction: "outbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
+				}},
+				{Steps: []cmdb.PathStepV2{
+					{ResourceType: "node", RelationType: "", Category: "", Direction: ""},
+					{ResourceType: "datasource", RelationType: "datasource_with_node", Category: "static", Direction: "inbound"},
+					{ResourceType: "pod", RelationType: "datasource_with_pod", Category: "static", Direction: "outbound"},
+				}},
+			},
+			ExpectedTarget:   "pod",
+			ExpectedMatchers: nil,
+			ExpectedError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+			model, err := NewModel(ctx, &mockGraphQueryExecutor{
+				graphs: tc.MockGraphs,
+				err:    tc.MockError,
+			})
+			require.NoError(t, err)
+
+			source, matcher, path, target, matchers, err := model.QueryDynamicPaths(
+				ctx,
+				tc.LookBackDelta,
+				tc.SpaceUid,
+				tc.Ts,
+				tc.Target,
+				tc.Source,
+				tc.IndexMatcher,
+				tc.ExpandMatcher,
+				tc.ExpandShow,
+				tc.PathResource,
+			)
+
+			if tc.ExpectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedSource, source, "source mismatch")
+			assert.Equal(t, tc.ExpectedMatcher, matcher, "matcher mismatch")
+			assert.Equal(t, tc.ExpectedPath, path, "path mismatch")
+			assert.Equal(t, tc.ExpectedTarget, target, "target mismatch")
+
+			if tc.ExpectedMatchers == nil {
+				assert.Nil(t, matchers)
+			} else {
+				assert.Equal(t, len(tc.ExpectedMatchers), len(matchers), "matchers count mismatch")
+				for _, expected := range tc.ExpectedMatchers {
+					found := false
+					for _, actual := range matchers {
+						if matchersEqual(expected, actual) {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "expected matcher not found: %v", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestQueryResourceMatcherRange(t *testing.T) {
+	nginx1Matcher := cmdb.Matcher{
+		"bcs_cluster_id": "BCS-K8S-00001",
+		"namespace":      "default",
+		"pod":            "nginx-1",
+	}
+	nginx2Matcher := cmdb.Matcher{
+		"bcs_cluster_id": "BCS-K8S-00001",
+		"namespace":      "default",
+		"pod":            "nginx-2",
+	}
+
+	testCases := []CMDBHandlerTestCase{
+		{
+			Name:          "Node_To_Pod_Range_AllActive",
+			LookBackDelta: "10m",
+			SpaceUid:      "test-space",
+			StartTs:       "0",
+			EndTs:         "300",
+			Step:          "100s",
+			Target:        "pod",
+			Source:        "node",
+			IndexMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"node":           "node-1",
+			},
+			MockGraphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {
+							ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+							ResourceType: ResourceTypeNode,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"node":           "node-1",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 0, End: 400000}},
+						},
+						"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {
+							ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+							ResourceType: ResourceTypePod,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"namespace":      "default",
+								"pod":            "nginx-1",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 0, End: 400000}},
+						},
+					},
+				},
+			},
+			ExpectedSource: "node",
+			ExpectedMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"node":           "node-1",
+			},
+			ExpectedTarget: "pod",
+			// start=0, end=300s=300000ms, step=100s=100000ms
+			// 时间点: 0, 100000, 200000, 300000
+			ExpectedTimeSeries: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{nginx1Matcher}},
+				{Timestamp: 100000, Matchers: cmdb.Matchers{nginx1Matcher}},
+				{Timestamp: 200000, Matchers: cmdb.Matchers{nginx1Matcher}},
+				{Timestamp: 300000, Matchers: cmdb.Matchers{nginx1Matcher}},
+			},
+			ExpectedError: false,
+		},
+		{
+			Name:          "Node_To_Pod_Range_PartialActive",
+			LookBackDelta: "10m",
+			SpaceUid:      "test-space",
+			StartTs:       "0",
+			EndTs:         "500",
+			Step:          "100s",
+			Target:        "pod",
+			Source:        "node",
+			IndexMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"node":           "node-1",
+			},
+			MockGraphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩": {
+							ResourceID:   "node:⟨bcs_cluster_id=BCS-K8S-00001,node=node-1⟩",
+							ResourceType: ResourceTypeNode,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"node":           "node-1",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 0, End: 600000}},
+						},
+						// nginx-1: 活跃时间段 [100000, 300000]
+						"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩": {
+							ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-1⟩",
+							ResourceType: ResourceTypePod,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"namespace":      "default",
+								"pod":            "nginx-1",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 100000, End: 300000}},
+						},
+						// nginx-2: 活跃时间段 [250000, 500000]
+						"pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-2⟩": {
+							ResourceID:   "pod:⟨bcs_cluster_id=BCS-K8S-00001,namespace=default,pod=nginx-2⟩",
+							ResourceType: ResourceTypePod,
+							Labels: map[string]string{
+								"bcs_cluster_id": "BCS-K8S-00001",
+								"namespace":      "default",
+								"pod":            "nginx-2",
+							},
+							RawPeriods: []*VisiblePeriod{{Start: 250000, End: 500000}},
+						},
+					},
+				},
+			},
+			ExpectedSource: "node",
+			ExpectedMatcher: cmdb.Matcher{
+				"bcs_cluster_id": "BCS-K8S-00001",
+				"node":           "node-1",
+			},
+			ExpectedTarget: "pod",
+			// start=0, end=500s=500000ms, step=100s=100000ms
+			// 时间点: 0, 100000, 200000, 300000, 400000, 500000
+			// nginx-1 活跃: [100000, 300000]
+			// nginx-2 活跃: [250000, 500000]
+			ExpectedTimeSeries: []cmdb.MatchersWithTimestamp{
+				// ts=0: 无活跃 pod (不在结果中)
+				{Timestamp: 100000, Matchers: cmdb.Matchers{nginx1Matcher}},
+				{Timestamp: 200000, Matchers: cmdb.Matchers{nginx1Matcher}},
+				{Timestamp: 300000, Matchers: cmdb.Matchers{nginx1Matcher, nginx2Matcher}}, // 两个都活跃
+				{Timestamp: 400000, Matchers: cmdb.Matchers{nginx2Matcher}},
+				{Timestamp: 500000, Matchers: cmdb.Matchers{nginx2Matcher}},
+			},
+			ExpectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+			model, err := NewModel(ctx, &mockGraphQueryExecutor{
+				graphs: tc.MockGraphs,
+				err:    tc.MockError,
+			})
+			require.NoError(t, err)
+
+			source, matcher, _, target, result, err := model.QueryResourceMatcherRange(
+				ctx,
+				tc.LookBackDelta,
+				tc.SpaceUid,
+				tc.Step,
+				tc.StartTs,
+				tc.EndTs,
+				tc.Target,
+				tc.Source,
+				tc.IndexMatcher,
+				tc.ExpandMatcher,
+				tc.ExpandShow,
+				tc.PathResource,
+			)
+
+			if tc.ExpectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedSource, source, "source mismatch")
+			assert.Equal(t, tc.ExpectedMatcher, matcher, "matcher mismatch")
+			assert.Equal(t, tc.ExpectedTarget, target, "target mismatch")
+
+			if tc.ExpectedTimeSeries == nil {
+				assert.Nil(t, result, "expected nil result")
+			} else {
+				require.NotNil(t, result, "result should not be nil")
+				require.Equal(t, len(tc.ExpectedTimeSeries), len(result), "time series length mismatch")
+
+				for i, expected := range tc.ExpectedTimeSeries {
+					actual := result[i]
+					assert.Equal(t, expected.Timestamp, actual.Timestamp, "timestamp mismatch at index %d", i)
+					require.Equal(t, len(expected.Matchers), len(actual.Matchers),
+						"matchers count mismatch at timestamp %d", expected.Timestamp)
+
+					for _, expectedMatcher := range expected.Matchers {
+						found := false
+						for _, actualMatcher := range actual.Matchers {
+							if matchersEqual(expectedMatcher, actualMatcher) {
+								found = true
+								break
+							}
+						}
+						assert.True(t, found, "expected matcher not found at timestamp %d: %v",
+							expected.Timestamp, expectedMatcher)
+					}
+				}
+			}
+		})
+	}
+}
+
+func matchersEqual(a, b cmdb.Matcher) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestBuildTargetMatchersTimeSeries(t *testing.T) {
+	testCases := []struct {
+		Name       string
+		Graphs     []*LivenessGraph
+		TargetType ResourceType
+		Start      int64
+		End        int64
+		StepMs     int64
+		Expected   []cmdb.MatchersWithTimestamp
+	}{
+		{
+			Name:       "EmptyGraphs",
+			Graphs:     nil,
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        100000,
+			StepMs:     50000,
+			Expected:   nil,
+		},
+		{
+			Name:       "EmptyGraphsList",
+			Graphs:     []*LivenessGraph{},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        100000,
+			StepMs:     50000,
+			Expected:   nil,
+		},
+		{
+			Name: "NoTargetTypeNodes",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"node:node-1": {
+							ResourceID:   "node:node-1",
+							ResourceType: ResourceTypeNode,
+							Labels:       map[string]string{"node": "node-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 200000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        100000,
+			StepMs:     50000,
+			Expected:   nil,
+		},
+		{
+			Name: "SingleNodeAlwaysActive",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1", "namespace": "default"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 300000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        200000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{"pod": "nginx-1", "namespace": "default"}}},
+				{Timestamp: 100000, Matchers: cmdb.Matchers{{"pod": "nginx-1", "namespace": "default"}}},
+				{Timestamp: 200000, Matchers: cmdb.Matchers{{"pod": "nginx-1", "namespace": "default"}}},
+			},
+		},
+		{
+			Name: "SingleNodeNeverActive",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 500000, End: 600000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        200000,
+			StepMs:     100000,
+			Expected:   nil,
+		},
+		{
+			Name: "SingleNodePartialActive_StartOnly",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 50000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        200000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+		{
+			Name: "SingleNodePartialActive_EndOnly",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 150000, End: 250000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        200000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 200000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+		{
+			Name: "MultiplePeriods_SameNode",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods: []*VisiblePeriod{
+								{Start: 0, End: 50000},
+								{Start: 150000, End: 250000},
+							},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        200000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+				{Timestamp: 200000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+		{
+			Name: "MultipleNodes_DifferentActiveRanges",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 100000}},
+						},
+						"pod:nginx-2": {
+							ResourceID:   "pod:nginx-2",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-2"},
+							RawPeriods:   []*VisiblePeriod{{Start: 100000, End: 200000}},
+						},
+						"pod:nginx-3": {
+							ResourceID:   "pod:nginx-3",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-3"},
+							RawPeriods:   []*VisiblePeriod{{Start: 200000, End: 300000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        300000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+				{Timestamp: 100000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}, {"pod": "nginx-2"}}},
+				{Timestamp: 200000, Matchers: cmdb.Matchers{{"pod": "nginx-2"}, {"pod": "nginx-3"}}},
+				{Timestamp: 300000, Matchers: cmdb.Matchers{{"pod": "nginx-3"}}},
+			},
+		},
+		{
+			Name: "MultipleGraphs_SameNode",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 100000}},
+						},
+					},
+				},
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 200000, End: 300000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        300000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+				{Timestamp: 100000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+				{Timestamp: 200000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+				{Timestamp: 300000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+		{
+			Name: "BoundaryCondition_ExactMatch",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 100000, End: 100000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        200000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 100000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+		{
+			Name: "SingleTimestamp",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 100000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      50000,
+			End:        50000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 50000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+		{
+			Name: "MixedResourceTypes",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 200000}},
+						},
+						"node:node-1": {
+							ResourceID:   "node:node-1",
+							ResourceType: ResourceTypeNode,
+							Labels:       map[string]string{"node": "node-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 200000}},
+						},
+						"service:svc-1": {
+							ResourceID:   "service:svc-1",
+							ResourceType: ResourceTypeService,
+							Labels:       map[string]string{"service": "svc-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 200000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        100000,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+				{Timestamp: 100000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+		{
+			Name: "EmptyLabels",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 100000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        0,
+			StepMs:     100000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{}}},
+			},
+		},
+		{
+			Name: "EmptyRawPeriods",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   nil,
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        100000,
+			StepMs:     100000,
+			Expected:   nil,
+		},
+		{
+			Name: "LargeStep_SkipTimestamps",
+			Graphs: []*LivenessGraph{
+				{
+					Nodes: map[string]*NodeLiveness{
+						"pod:nginx-1": {
+							ResourceID:   "pod:nginx-1",
+							ResourceType: ResourceTypePod,
+							Labels:       map[string]string{"pod": "nginx-1"},
+							RawPeriods:   []*VisiblePeriod{{Start: 0, End: 1000000}},
+						},
+					},
+				},
+			},
+			TargetType: ResourceTypePod,
+			Start:      0,
+			End:        500000,
+			StepMs:     500000,
+			Expected: []cmdb.MatchersWithTimestamp{
+				{Timestamp: 0, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+				{Timestamp: 500000, Matchers: cmdb.Matchers{{"pod": "nginx-1"}}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := buildTargetMatchersTimeSeries(tc.Graphs, tc.TargetType, tc.Start, tc.End, tc.StepMs)
+
+			if tc.Expected == nil {
+				assert.Nil(t, result, "expected nil result")
+				return
+			}
+
+			require.NotNil(t, result, "result should not be nil")
+			require.Equal(t, len(tc.Expected), len(result), "time series length mismatch")
+
+			for i, expected := range tc.Expected {
+				actual := result[i]
+				assert.Equal(t, expected.Timestamp, actual.Timestamp, "timestamp mismatch at index %d", i)
+				require.Equal(t, len(expected.Matchers), len(actual.Matchers),
+					"matchers count mismatch at timestamp %d", expected.Timestamp)
+
+				for _, expectedMatcher := range expected.Matchers {
+					found := false
+					for _, actualMatcher := range actual.Matchers {
+						if matchersEqual(expectedMatcher, actualMatcher) {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "expected matcher not found at timestamp %d: %v",
+						expected.Timestamp, expectedMatcher)
+				}
+			}
+		})
+	}
+}
+
+func TestIsActiveAt(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Periods  []*VisiblePeriod
+		Ts       int64
+		Expected bool
+	}{
+		{
+			Name:     "NilPeriods",
+			Periods:  nil,
+			Ts:       100,
+			Expected: false,
+		},
+		{
+			Name:     "EmptyPeriods",
+			Periods:  []*VisiblePeriod{},
+			Ts:       100,
+			Expected: false,
+		},
+		{
+			Name:     "WithinSinglePeriod",
+			Periods:  []*VisiblePeriod{{Start: 0, End: 200}},
+			Ts:       100,
+			Expected: true,
+		},
+		{
+			Name:     "AtPeriodStart",
+			Periods:  []*VisiblePeriod{{Start: 100, End: 200}},
+			Ts:       100,
+			Expected: true,
+		},
+		{
+			Name:     "AtPeriodEnd",
+			Periods:  []*VisiblePeriod{{Start: 100, End: 200}},
+			Ts:       200,
+			Expected: true,
+		},
+		{
+			Name:     "BeforePeriod",
+			Periods:  []*VisiblePeriod{{Start: 100, End: 200}},
+			Ts:       50,
+			Expected: false,
+		},
+		{
+			Name:     "AfterPeriod",
+			Periods:  []*VisiblePeriod{{Start: 100, End: 200}},
+			Ts:       250,
+			Expected: false,
+		},
+		{
+			Name: "WithinSecondPeriod",
+			Periods: []*VisiblePeriod{
+				{Start: 0, End: 100},
+				{Start: 200, End: 300},
+			},
+			Ts:       250,
+			Expected: true,
+		},
+		{
+			Name: "BetweenPeriods",
+			Periods: []*VisiblePeriod{
+				{Start: 0, End: 100},
+				{Start: 200, End: 300},
+			},
+			Ts:       150,
+			Expected: false,
+		},
+		{
+			Name:     "ExactPointPeriod",
+			Periods:  []*VisiblePeriod{{Start: 100, End: 100}},
+			Ts:       100,
+			Expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := isActiveAt(tc.Periods, tc.Ts)
+			assert.Equal(t, tc.Expected, result)
+		})
+	}
+}

--- a/pkg/unify-query/redis/redis.go
+++ b/pkg/unify-query/redis/redis.go
@@ -134,3 +134,20 @@ var Subscribe = func(ctx context.Context, channels ...string) <-chan *goRedis.Me
 	p := globalInstance.client.Subscribe(ctx, channels...)
 	return p.Channel()
 }
+
+// Scan 迭代式扫描 key，避免阻塞 Redis
+// cursor: 游标位置，首次调用传 0
+// match: 匹配模式
+// count: 建议返回的 key 数量（实际可能更多或更少）
+var Scan = func(ctx context.Context, cursor uint64, match string, count int64) (keys []string, nextCursor uint64, err error) {
+	log.Debugf(ctx, "[redis] scan cursor=%d match=%s count=%d", cursor, match, count)
+	res := globalInstance.client.Scan(ctx, cursor, match, count)
+	return res.Result()
+}
+
+// Publish 发布消息到指定通道
+var Publish = func(ctx context.Context, channel string, message interface{}) (int64, error) {
+	log.Debugf(ctx, "[redis] publish %s", channel)
+	res := globalInstance.client.Publish(ctx, channel, message)
+	return res.Result()
+}

--- a/pkg/unify-query/service/cmdb/service.go
+++ b/pkg/unify-query/service/cmdb/service.go
@@ -1,0 +1,120 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package cmdb
+
+import (
+	"context"
+	"sync"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb/v1beta1"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb/v1beta3"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+)
+
+// Service CMDB SchemaProvider 初始化服务
+// 负责在 Redis 就绪后创建 CompositeSchemaProvider（Redis → Static 级联）
+// 并注入到 v1beta1，使其能从 Redis 动态获取资源/关联配置
+type Service struct {
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+
+	redisProvider *v1beta3.RedisSchemaProvider
+	mu            sync.Mutex
+}
+
+func (s *Service) Type() string {
+	return "cmdb"
+}
+
+func (s *Service) Start(ctx context.Context) {
+	s.Reload(ctx)
+}
+
+func (s *Service) Reload(ctx context.Context) {
+	var err error
+	ctx, span := trace.NewSpan(ctx, "cmdb-service-reload")
+	defer span.End(&err)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// 关闭旧的 RedisSchemaProvider（如有）
+	if s.redisProvider != nil {
+		if closeErr := s.redisProvider.Close(); closeErr != nil {
+			log.Warnf(ctx, "failed to close old RedisSchemaProvider: %v", closeErr)
+		}
+		s.redisProvider = nil
+	}
+
+	s.ctx, s.cancelFunc = context.WithCancel(ctx)
+
+	// 检查 Redis 客户端是否就绪
+	client := redis.Client()
+	if client == nil {
+		log.Warnf(ctx, "redis client not ready, v1beta1 will use hardcoded config as fallback")
+		span.Set("schema_provider.status", "redis_not_ready")
+		return
+	}
+
+	// 创建 RedisSchemaProvider
+	redisProvider, redisErr := v1beta3.NewRedisSchemaProvider(client)
+	if redisErr != nil {
+		log.Warnf(ctx, "failed to create RedisSchemaProvider: %v, v1beta1 will use hardcoded config as fallback", redisErr)
+		span.Set("schema_provider.status", "redis_provider_failed")
+		span.Set("schema_provider.error", redisErr.Error())
+		return
+	}
+	s.redisProvider = redisProvider
+
+	// 创建 StaticSchemaProvider 作为兜底
+	staticProvider := v1beta3.NewStaticSchemaProvider()
+
+	// 创建 CompositeSchemaProvider: Redis(高优先级) → Static(兜底)
+	compositeProvider := v1beta3.NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 注入到 v1beta1 并触发 model 初始化
+	v1beta1.InitSchemaProvider(compositeProvider)
+
+	// 主动触发 v1beta1 model 构建，启动时即可确认配置加载结果
+	if _, initErr := v1beta1.GetModel(ctx); initErr != nil {
+		log.Errorf(ctx, "failed to initialize v1beta1 model: %v", initErr)
+		span.Set("v1beta1.model.status", "failed")
+		span.Set("v1beta1.model.error", initErr.Error())
+	} else {
+		log.Infof(ctx, "v1beta1 model initialized successfully")
+		span.Set("v1beta1.model.status", "initialized")
+	}
+
+	log.Infof(ctx, "CMDB SchemaProvider initialized: CompositeSchemaProvider(Redis → Static) injected into v1beta1")
+	span.Set("schema_provider.status", "initialized")
+	span.Set("schema_provider.type", "composite(redis→static)")
+}
+
+func (s *Service) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.redisProvider != nil {
+		if err := s.redisProvider.Close(); err != nil {
+			log.Warnf(context.TODO(), "failed to close RedisSchemaProvider: %v", err)
+		}
+		s.redisProvider = nil
+	}
+
+	if s.cancelFunc != nil {
+		s.cancelFunc()
+	}
+}
+
+func (s *Service) Wait() {
+	// RedisSchemaProvider 的 goroutine 由其自身的 wg 管理，Close() 时会等待
+}


### PR DESCRIPTION
## Summary
- 新增 `cmdb.SchemaProvider` 抽象接口（cmdb 根包），供 v1beta1/v1beta3 共用，支持从 Redis 或静态配置获取资源和关联定义
- 新增 `v1beta3.RedisSchemaProvider`：从 Redis Hash (`bkmonitorv3:entity:ResourceDefinition` / `RelationDefinition`) 全量加载 + Pub/Sub 热更新
- 新增 `v1beta3.StaticSchemaProvider`：从硬编码的 `resourcePrimaryKeys` / `schemaRegistry` 初始化，作为兜底
- 新增 `v1beta3.CompositeSchemaProvider`：级联查找 Redis → Static，高优先级优先
- 新增 `v1beta1.ConfigAdapter`：将 `cmdb.ResourceDefinition`/`RelationDefinition` 转换为 v1beta1 `Config` 格式（Required→Index, !Required→Info, FromResource→Resources[0], ToResource→Resources[1]）
- 新增 `service/cmdb` 服务：在 Redis 就绪后创建 CompositeSchemaProvider 并注入 v1beta1，启动顺序 `Consul → Redis → CMDB → Trace → ...`
- v1beta1 `newModel()` 增加 trace span，记录 `config_source`（schema_provider/hardcoded）、资源/关联数量和名称，便于在 tracing UI 验证配置来源
- v1beta3 完整核心实现：SurrealDB 图查询、路径查找、响应解析、API handler 注册
