### PR TITLE
feat: 复用进程状态快照统计僵尸进程数

### DIFF
--- a/pkg/bkmonitorbeat/tasks/basereport/collector/system.go
+++ b/pkg/bkmonitorbeat/tasks/basereport/collector/system.go
@@ -10,11 +10,25 @@
 package collector
 
 import (
+	"time"
+
 	"github.com/shirou/gopsutil/v3/host"
-	"github.com/shirou/gopsutil/v3/process"
+	gopsutilprocess "github.com/shirou/gopsutil/v3/process"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tasks"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tasks/processsnapshot"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
+)
+
+const (
+	sharedProcSnapshotMaxAge = 1 * time.Minute
+)
+
+var (
+	getSharedProcStates = func() (map[int32]string, bool) {
+		return processsnapshot.SharedProcStates(sharedProcSnapshotMaxAge)
+	}
+	countZombieProcs = numZombieProcsByGopsutil
 )
 
 // add systemtype info
@@ -54,7 +68,21 @@ func GetSystemInfo() (*SystemReport, error) {
 }
 
 func numZombieProcs() (int, error) {
-	procs, err := process.Processes()
+	if states, ok := getSharedProcStates(); ok {
+		var total int
+		for _, state := range states {
+			if state == "zombie" {
+				total++
+			}
+		}
+		return total, nil
+	}
+
+	return countZombieProcs()
+}
+
+func numZombieProcsByGopsutil() (int, error) {
+	procs, err := gopsutilprocess.Processes()
 	if err != nil {
 		return 0, err
 	}
@@ -65,7 +93,7 @@ func numZombieProcs() (int, error) {
 		if err != nil {
 			continue
 		}
-		if len(status) > 0 && status[0] == process.Zombie {
+		if len(status) > 0 && status[0] == gopsutilprocess.Zombie {
 			total++
 		}
 	}

--- a/pkg/bkmonitorbeat/tasks/basereport/collector/system_test.go
+++ b/pkg/bkmonitorbeat/tasks/basereport/collector/system_test.go
@@ -1,0 +1,48 @@
+package collector
+
+import (
+	"testing"
+)
+
+func TestNumZombieProcsUsesSnapshot(t *testing.T) {
+	originalGetSharedProcStates := getSharedProcStates
+	defer func() {
+		getSharedProcStates = originalGetSharedProcStates
+	}()
+
+	getSharedProcStates = func() (map[int32]string, bool) {
+		return map[int32]string{1: "zombie", 2: "running", 3: "zombie"}, true
+	}
+
+	total, err := numZombieProcs()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected zombie count 2, got %d", total)
+	}
+}
+
+func TestNumZombieProcsFallsBackToGopsutil(t *testing.T) {
+	originalGetSharedProcStates := getSharedProcStates
+	originalCountZombieProcs := countZombieProcs
+	defer func() {
+		getSharedProcStates = originalGetSharedProcStates
+		countZombieProcs = originalCountZombieProcs
+	}()
+
+	getSharedProcStates = func() (map[int32]string, bool) {
+		return nil, false
+	}
+	countZombieProcs = func() (int, error) {
+		return 2, nil
+	}
+
+	total, err := numZombieProcs()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected zombie count 2, got %d", total)
+	}
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf.go
@@ -82,15 +82,15 @@ func (p *procPerfMgr) MergeMetaDataPerfStat(meta, perf define.ProcStat) define.P
 
 func (p *procPerfMgr) getProcState(s string) string {
 	switch s {
-	case "S":
+	case "S", "sleep", "sleeping":
 		return "sleeping"
-	case "R":
+	case "R", "running":
 		return "running"
-	case "D", "I":
+	case "D", "I", "idle":
 		return "idle"
-	case "T":
+	case "T", "t", "stop", "stopped":
 		return "stopped"
-	case "Z":
+	case "Z", "zombie":
 		return "zombie"
 	}
 	return "unknown"

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
@@ -1,0 +1,33 @@
+package process
+
+import "testing"
+
+func TestGetProcState(t *testing.T) {
+	mgr := &procPerfMgr{}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "single letter sleep", input: "S", want: "sleeping"},
+		{name: "single letter running", input: "R", want: "running"},
+		{name: "single letter blocked", input: "D", want: "idle"},
+		{name: "single letter idle", input: "I", want: "idle"},
+		{name: "single letter stopped", input: "T", want: "stopped"},
+		{name: "single letter traced stop", input: "t", want: "stopped"},
+		{name: "single letter zombie", input: "Z", want: "zombie"},
+		{name: "semantic sleep", input: "sleep", want: "sleeping"},
+		{name: "semantic stop", input: "stop", want: "stopped"},
+		{name: "semantic zombie", input: "zombie", want: "zombie"},
+		{name: "unknown", input: "x", want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mgr.getProcState(tt.input); got != tt.want {
+				t.Fatalf("getProcState(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_unix.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_unix.go
@@ -17,6 +17,7 @@ import (
 	shiroups "github.com/shirou/gopsutil/v3/process"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tasks/processsnapshot"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -39,6 +40,8 @@ func (p *procPerfMgr) AllMetaData() ([]define.ProcStat, error) {
 		}
 		ret = append(ret, stat)
 	}
+
+	processsnapshot.UpdateSharedProcStateSnapshot(ret)
 
 	return ret, nil
 }

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_windows.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_windows.go
@@ -20,6 +20,7 @@ import (
 	shiroups "github.com/shirou/gopsutil/v3/process"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tasks/processsnapshot"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -86,6 +87,8 @@ func (p *procPerfMgr) AllMetaData() ([]define.ProcStat, error) {
 	for _, proc := range procs {
 		ret = append(ret, *proc)
 	}
+
+	processsnapshot.UpdateSharedProcStateSnapshot(ret)
 
 	return ret, nil
 }

--- a/pkg/bkmonitorbeat/tasks/processsnapshot/snapshot.go
+++ b/pkg/bkmonitorbeat/tasks/processsnapshot/snapshot.go
@@ -1,0 +1,55 @@
+package processsnapshot
+
+import (
+	"sync"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+)
+
+type procStateSnapshot struct {
+	updatedAt time.Time
+	states    map[int32]string
+}
+
+var sharedProcStateSnapshot struct {
+	mut      sync.RWMutex
+	snapshot procStateSnapshot
+}
+
+func UpdateSharedProcStateSnapshot(stats []define.ProcStat) {
+	states := make(map[int32]string, len(stats))
+	for _, stat := range stats {
+		if stat.Status == "" {
+			continue
+		}
+		states[stat.Pid] = stat.Status
+	}
+
+	sharedProcStateSnapshot.mut.Lock()
+	sharedProcStateSnapshot.snapshot = procStateSnapshot{
+		updatedAt: time.Now(),
+		states:    states,
+	}
+	sharedProcStateSnapshot.mut.Unlock()
+}
+
+func SharedProcStates(maxAge time.Duration) (map[int32]string, bool) {
+	sharedProcStateSnapshot.mut.RLock()
+	defer sharedProcStateSnapshot.mut.RUnlock()
+
+	snapshot := sharedProcStateSnapshot.snapshot
+	if snapshot.updatedAt.IsZero() || len(snapshot.states) == 0 {
+		return nil, false
+	}
+	if maxAge > 0 && time.Since(snapshot.updatedAt) > maxAge {
+		return nil, false
+	}
+
+	states := make(map[int32]string, len(snapshot.states))
+	for pid, state := range snapshot.states {
+		states[pid] = state
+	}
+
+	return states, true
+}

--- a/pkg/bkmonitorbeat/tasks/processsnapshot/snapshot_test.go
+++ b/pkg/bkmonitorbeat/tasks/processsnapshot/snapshot_test.go
@@ -1,0 +1,39 @@
+package processsnapshot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+)
+
+func TestSharedProcStates(t *testing.T) {
+	sharedProcStateSnapshot.mut.Lock()
+	sharedProcStateSnapshot.snapshot = procStateSnapshot{}
+	sharedProcStateSnapshot.mut.Unlock()
+
+	UpdateSharedProcStateSnapshot([]define.ProcStat{
+		{Pid: 1, Status: "running"},
+		{Pid: 2, Status: "zombie"},
+		{Pid: 3, Status: "zombie"},
+	})
+
+	snapshot, ok := SharedProcStates(time.Minute)
+	if !ok {
+		t.Fatal("expected shared snapshot to be available")
+	}
+	if len(snapshot) != 3 {
+		t.Fatalf("expected 3 process states, got %d", len(snapshot))
+	}
+	if snapshot[2] != "zombie" {
+		t.Fatalf("expected pid 2 state zombie, got %s", snapshot[2])
+	}
+
+	sharedProcStateSnapshot.mut.Lock()
+	sharedProcStateSnapshot.snapshot.updatedAt = time.Now().Add(-2 * time.Minute)
+	sharedProcStateSnapshot.mut.Unlock()
+
+	if _, ok := SharedProcStates(time.Minute); ok {
+		t.Fatal("expected stale shared snapshot to be rejected")
+	}
+}


### PR DESCRIPTION
## 背景
`basereport` 中的 `numZombieProcs` 会单独全量遍历进程并统计僵尸进程数，而 `processbeat` 同时也会全量采集进程元数据。  
在高进程数场景下，这两条链路会重复读取进程状态，带来额外开销。

## 改动
- 新增 processsnapshot 公共模块，缓存最近一次进程状态快照
- processbeat 在全量采集进程元数据后，同步刷新共享进程状态快照
- basereport 的 numZombieProcs 优先复用共享快照统计僵尸进程数
- 当共享快照不存在或超过 1 分钟未更新时，回退到原有 gopsutil 统计链路
- 补充 processsnapshot、processbeat 状态映射、basereport snapshot/fallback 相关单测
- 修正 processbeat 状态映射，兼容 gopsutil 返回的 "zombie" 状态，避免僵尸进程被错误识别为 unknown
- 待更新gopsutil版本，避免proc文件重复解析

优化前
File: bkmonitorbeat
Type: cpu
Time: Apr 7, 2026 at 7:26pm (CST)
Duration: 120.01s, Total samples = 22.10s (18.42%)
Showing nodes accounting for 18.70s, 84.62% of 22.10s total

优化后
File: bkmonitorbeat
Type: cpu
Time: Apr 13, 2026 at 5:36pm (CST)
Duration: 120.13s, Total samples = 12.06s (10.04%)
Showing nodes accounting for 10s, 82.92% of 12.06s total