### PR TITLE
fix(libgse): fix pipeline blocking, kafka connection leak and data race in output clients

### DIFF
--- a/pkg/libgse/output/bkpipe_multi/clients.go
+++ b/pkg/libgse/output/bkpipe_multi/clients.go
@@ -52,7 +52,7 @@ func RegisterTaskOutput(taskID string, config common.ConfigNamespace) error {
 	}
 	taskRegistry[taskID] = configHash
 
-	_, ok := taskRegistry[configHash]
+	_, ok := outputRegistry[configHash]
 
 	if ok {
 		return nil
@@ -75,6 +75,31 @@ func RegisterTaskOutput(taskID string, config common.ConfigNamespace) error {
 	}
 
 	return nil
+}
+
+// DeregisterTaskOutput 按任务ID反注册发送配置，当没有任务引用该配置时关闭对应的客户端连接
+func DeregisterTaskOutput(taskID string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	configHash, ok := taskRegistry[taskID]
+	if !ok {
+		return
+	}
+	delete(taskRegistry, taskID)
+
+	for _, hash := range taskRegistry {
+		if hash == configHash {
+			return
+		}
+	}
+
+	if out, ok := outputRegistry[configHash]; ok {
+		if out.client != nil {
+			_ = out.client.Close()
+		}
+		delete(outputRegistry, configHash)
+	}
 }
 
 // LoadOutputClient 根据任务发送配置的哈希值，获取发送客户端对象
@@ -114,9 +139,23 @@ func LoadOutputClient(
 		networkClient, ok := outClient.(outputs.NetworkClient)
 
 		if ok {
-			// 如果 output 实现了 NetworkClient 则需要调用其 Connect 接口
-			if err = networkClient.Connect(); err != nil {
-				return nil, fmt.Errorf("failed to connect to %s: %v", out.config.Name(), err)
+			connectDone := make(chan error, 1)
+			go func() {
+				connectDone <- networkClient.Connect()
+			}()
+
+			select {
+			case err = <-connectDone:
+				if err != nil {
+					_ = outClient.Close()
+					return nil, fmt.Errorf("failed to connect to %s: %v", out.config.Name(), err)
+				}
+			case <-time.After(30 * time.Second):
+				go func() {
+					<-connectDone
+					_ = outClient.Close()
+				}()
+				return nil, fmt.Errorf("connect to %s timed out after 30s", out.config.Name())
 			}
 		}
 		out.client = outClient
@@ -177,8 +216,8 @@ func GroupEventsByOutput(events []beat.Event) map[string][]beat.Event {
 // CloseOutputClients 关闭所有已初始化的 Output 客户端连接
 func CloseOutputClients() {
 
-	mutex.RLock()
-	defer mutex.RUnlock()
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	for _, out := range outputRegistry {
 		if out.client == nil {


### PR DESCRIPTION
## Summary

修复 `bkpipe_multi/clients.go` 中导致采集器 pipeline 阻塞和 Kafka 连接泄漏的 4 个 bug：

- **LoadOutputClient 连接超时**：`networkClient.Connect()` 包装 30s 超时，防止 Kafka broker 不可达时 output worker 无限阻塞，级联堵死整条 pipeline
- **RegisterTaskOutput map 查询错误**：第 55 行 `taskRegistry[configHash]` 修正为 `outputRegistry[configHash]`，修复每次注册都覆盖已有 output 导致旧 client 泄漏
- **新增 DeregisterTaskOutput**：按 taskID 引用计数反注册，当无任务引用同一 configHash 时关闭 client 并清理 registry
- **CloseOutputClients 锁修复**：`RLock/RUnlock` 改为 `Lock/Unlock`，修复写操作（`out.client = nil`）使用读锁的 data race

## Test plan

- [ ] 模拟 Kafka 不可达，确认 30s 超时后 goroutine 不再堆积（`pprof/goroutine` 检查 Mutex.Lock 等待数）
- [ ] 配置 kafka output 子配置，多次触发 reload，通过 `ss -tnp | grep 9092` 确认旧连接释放、连接数不增长
- [ ] `go vet ./pkg/libgse/...` 无 data race 警告

Made with [Cursor](https://cursor.com)