### PR TITLE
feat: (unify-query)增加raw_with_scroll接口关键链路观测 --story=133789021

### DIFF
--- a/pkg/unify-query/service/http/query.go
+++ b/pkg/unify-query/service/http/query.go
@@ -527,6 +527,20 @@ func queryRawWithScroll(ctx context.Context, queryTs *structured.QueryTs, sessio
 
 				if size == 0 {
 					slice.Status = redisUtil.StatusCompleted
+
+					// 可疑完成：slice 已经累计过 offset（即至少拿到过一轮数据或已尝试续拉）却在当前轮拿到 0 条，
+					// 这通常意味着底层网关沉默失败（典型场景：bkdata _search/scroll 返回 HTTP 200 但 hits 缺失）。
+					// 只在 Offset>0 时告警，避免把"首轮本就无数据"的正常空查询污染为 WARN。
+					if slice.Offset > 0 {
+						span.Set("scroll-suspicious-done-slice", newQry.TableUUID())
+						span.Set("scroll-suspicious-done-offset", slice.Offset)
+						span.Set("scroll-suspicious-done-scroll-id", slice.ScrollID)
+						metadata.NewMessage(
+							metadata.MsgQueryRawScroll,
+							"scroll 续拉命中 0 条被判完成：slice=%s, offset=%d, scroll_id=%s",
+							newQry.TableUUID(), slice.Offset, slice.ScrollID,
+						).Warn(ctx)
+					}
 				}
 
 				resultTableOptions.SetOption(newQry.TableUUID(), option)
@@ -546,6 +560,15 @@ func queryRawWithScroll(ctx context.Context, queryTs *structured.QueryTs, sessio
 	close(errCh)
 
 	receiveWg.Wait()
+
+	// Session 终态快照：只在本轮判定 Done 时写入，一次 trace 就能直接看到"为什么这次就结束了"。
+	// 与信号 1/2 形成闭环：若 session 所有 slice 都以 completed+Offset==Limit 在单轮终结、同时
+	// 能看到 es-result-hits-nil / scroll-suspicious-done-* 信号，即可锁定底层网关沉默失败。
+	if session.Done() {
+		finalSession, _ := json.Marshal(session)
+		span.Set("session-final", string(finalSession))
+		span.Set("session-final-total", total)
+	}
 
 	return total, list, resultTableOptions, session.Done(), err
 }

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -383,26 +383,24 @@ func (i *Instance) esQuery(ctx context.Context, qo *queryOption, fact *FormatFac
 	if err = handleESError(ctx, qo.conn.Address, err, res); err != nil {
 		return nil, err
 	}
-	// 异常分支专用 span：用于诊断 bkdata 等网关返回 HTTP 200、但响应体里 hits 缺失或内嵌 error 的场景。
-	// 这类响应不会触发 handleESError，导致 scroll 续拉被误判为完成；这里只在异常路径 set，正常路径零开销，
-	// 与下方 res.Hits != nil 时记录的 total_hits / hits_length 形成互补。
+	// handleESError 对 (res=nil, err=io.EOF) 会返回 nil，所以后续读取 res 的 span 统一放在 res != nil 内。
 	if res != nil {
+		// 诊断网关返回 200 但 hits 缺失 / 内嵌 error 的场景（会让 scroll 续拉被误判为完成）。
 		if res.Hits == nil {
 			span.Set("es-result-hits-nil", true)
-			// 同步记录 scroll_id，便于在 trace 里直接定位是哪一轮 scroll 续拉拿到了空 hits。
 			span.Set("es-result-scroll-id", res.ScrollId)
 		}
 		if res.Error != nil {
 			span.Set("es-result-error-type", res.Error.Type)
 			span.Set("es-result-error-reason", res.Error.Reason)
 		}
-	}
-	if res.Hits != nil {
-		span.Set("total_hits", res.Hits.TotalHits)
-		span.Set("hits_length", len(res.Hits.Hits))
-	}
-	if res.Aggregations != nil {
-		span.Set("aggregations_length", len(res.Aggregations))
+		if res.Hits != nil {
+			span.Set("total_hits", res.Hits.TotalHits)
+			span.Set("hits_length", len(res.Hits.Hits))
+		}
+		if res.Aggregations != nil {
+			span.Set("aggregations_length", len(res.Aggregations))
+		}
 	}
 	queryCost := time.Since(startAnalyze)
 	span.Set("query-cost", queryCost.String())

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -383,6 +383,20 @@ func (i *Instance) esQuery(ctx context.Context, qo *queryOption, fact *FormatFac
 	if err = handleESError(ctx, qo.conn.Address, err, res); err != nil {
 		return nil, err
 	}
+	// 异常分支专用 span：用于诊断 bkdata 等网关返回 HTTP 200、但响应体里 hits 缺失或内嵌 error 的场景。
+	// 这类响应不会触发 handleESError，导致 scroll 续拉被误判为完成；这里只在异常路径 set，正常路径零开销，
+	// 与下方 res.Hits != nil 时记录的 total_hits / hits_length 形成互补。
+	if res != nil {
+		if res.Hits == nil {
+			span.Set("es-result-hits-nil", true)
+			// 同步记录 scroll_id，便于在 trace 里直接定位是哪一轮 scroll 续拉拿到了空 hits。
+			span.Set("es-result-scroll-id", res.ScrollId)
+		}
+		if res.Error != nil {
+			span.Set("es-result-error-type", res.Error.Type)
+			span.Set("es-result-error-reason", res.Error.Reason)
+		}
+	}
 	if res.Hits != nil {
 		span.Set("total_hits", res.Hits.TotalHits)
 		span.Set("hits_length", len(res.Hits.Hits))


### PR DESCRIPTION
## 背景
bkdata `_search/scroll` 续拉返回 HTTP 200 但 body 无 `hits`（`status:1532001 "结果表 236_tqos5 不存在"`），被 unify-query 误判为 slice 完成，scroll 下载仅拿到首轮 1w / 应 5w。根因在 bkdata 侧，本 PR 仅补关键观测。

## 变更（3 处，异常路径触发）
- `esQuery`：`res.Hits==nil` / `res.Error!=nil` 时补 `es-result-hits-nil` / `es-result-error-*` span
- `queryRawWithScroll` size==0 分支：`slice.Offset>0` 时补 WARN + `scroll-suspicious-done-*` span
- `queryRawWithScroll` return 前：`session.Done()` 时写入 `session-final` / `session-final-total` span