### PR TITLE
fix: (unify-query) 改由显式 table_id_conditions 绕过容器默认过滤 --bug=157273417

### DIFF
--- a/pkg/unify-query/influxdb/router_mock.go
+++ b/pkg/unify-query/influxdb/router_mock.go
@@ -358,6 +358,7 @@ func MockSpaceRouter(ctx context.Context) {
 					FieldAlias: map[string]string{
 						"alias_ns": "__ext.host.bk_set_name",
 					},
+					Labels: map[string]string{"scene": "k8s", "stream": "file"},
 				},
 				ResultTableEs1: &ir.ResultTableDetail{
 					StorageId:   3,

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -701,11 +701,6 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 	if metricName == "" || q.DataSource == BkLog || q.DataSource == BkApm {
 		isSkipField = true
 	}
-	// bklog非指标数据源，跳过容器指标专用分支（isK8s=true 时仅允许 bk_split_measurement）
-	isSkipK8s := metadata.GetQueryParams(ctx).IsSkipK8s
-	if q.DataSource == BkLog {
-		isSkipK8s = true
-	}
 	if len(tsDBs) == 0 {
 		tsDBs, err = GetTsDBList(ctx, &TsDBOption{
 			SpaceUid:          spaceUid,
@@ -714,7 +709,7 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 			IsRegexp:          q.IsRegexp,
 			AllConditions:     allConditions,
 			IsSkipSpace:       metadata.GetUser(ctx).IsSkipSpace(),
-			IsSkipK8s:         isSkipK8s,
+			IsSkipK8s:         metadata.GetQueryParams(ctx).IsSkipK8s,
 			IsSkipField:       isSkipField,
 			TableIDConditions: q.TableIDConditions,
 		})

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -701,6 +701,11 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 	if metricName == "" || q.DataSource == BkLog || q.DataSource == BkApm {
 		isSkipField = true
 	}
+	// bklog非指标数据源，跳过容器指标专用分支（isK8s=true 时仅允许 bk_split_measurement）
+	isSkipK8s := metadata.GetQueryParams(ctx).IsSkipK8s
+	if q.DataSource == BkLog {
+		isSkipK8s = true
+	}
 	if len(tsDBs) == 0 {
 		tsDBs, err = GetTsDBList(ctx, &TsDBOption{
 			SpaceUid:          spaceUid,
@@ -709,7 +714,7 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 			IsRegexp:          q.IsRegexp,
 			AllConditions:     allConditions,
 			IsSkipSpace:       metadata.GetUser(ctx).IsSkipSpace(),
-			IsSkipK8s:         metadata.GetQueryParams(ctx).IsSkipK8s,
+			IsSkipK8s:         isSkipK8s,
 			IsSkipField:       isSkipField,
 			TableIDConditions: q.TableIDConditions,
 		})

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -406,7 +406,7 @@ func TestE2E_Query_TableIDConditions_ToQueryMetric_GetTsDBList(t *testing.T) {
 
 // TestE2E_Query_BkLog_TableIDConditions_ToQueryMetric_GetTsDBList 端到端：
 // DataSource=bklog 且 table_id 为空、仅靠 TableIDConditions 选表时，应能命中非 split-measurement 的日志类 RT；
-// 锁住 query_ts.go 里为 bklog/bkapm 自动置 IsSkipK8s=true 的修复。
+// 锁住 space.NewTsDBs 中"显式 table_id_conditions 时绕过容器默认过滤"的修复语义。
 func TestE2E_Query_BkLog_TableIDConditions_ToQueryMetric_GetTsDBList(t *testing.T) {
 	mock.Init()
 	ctx := md.InitHashID(context.Background())
@@ -426,7 +426,7 @@ func TestE2E_Query_BkLog_TableIDConditions_ToQueryMetric_GetTsDBList(t *testing.
 	assert.NoError(t, err)
 	assert.NotNil(t, metric)
 	// mock 中 ResultTableEs 为 ES 存储、无 MeasurementType、Labels scene=k8s；
-	// 修复前会被 isK8s 分支过滤；修复后 bklog 路径自动置 IsSkipK8s=true，可命中。
+	// 修复前会被 isK8s 分支误过滤；修复后 space.NewTsDBs 在 table_id_conditions 非空时跳过容器默认过滤，可命中。
 	assert.NotEmpty(t, metric.QueryList, "bklog + table_id_conditions(scene=k8s) 应命中非 split-measurement 的 RT")
 }
 

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -404,6 +404,32 @@ func TestE2E_Query_TableIDConditions_ToQueryMetric_GetTsDBList(t *testing.T) {
 	assert.NotEmpty(t, metric.QueryList, "表标签 scene=log 应匹配到带 Labels 的 RT")
 }
 
+// TestE2E_Query_BkLog_TableIDConditions_ToQueryMetric_GetTsDBList 端到端：
+// DataSource=bklog 且 table_id 为空、仅靠 TableIDConditions 选表时，应能命中非 split-measurement 的日志类 RT；
+// 锁住 query_ts.go 里为 bklog/bkapm 自动置 IsSkipK8s=true 的修复。
+func TestE2E_Query_BkLog_TableIDConditions_ToQueryMetric_GetTsDBList(t *testing.T) {
+	mock.Init()
+	ctx := md.InitHashID(context.Background())
+	influxdb.MockSpaceRouter(ctx)
+
+	query := &Query{
+		DataSource:    BkLog,
+		TableID:       "",
+		FieldName:     "dtEventTimeStamp",
+		ReferenceName: "a",
+		TableIDConditions: AllConditions{
+			{{DimensionName: "scene", Value: []string{"k8s"}, Operator: ConditionEqual}},
+		},
+	}
+
+	metric, err := query.ToQueryMetric(ctx, influxdb.SpaceUid, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, metric)
+	// mock 中 ResultTableEs 为 ES 存储、无 MeasurementType、Labels scene=k8s；
+	// 修复前会被 isK8s 分支过滤；修复后 bklog 路径自动置 IsSkipK8s=true，可命中。
+	assert.NotEmpty(t, metric.QueryList, "bklog + table_id_conditions(scene=k8s) 应命中非 split-measurement 的 RT")
+}
+
 // TestQueryTs_StructToPromQL_WithTableIDConditions 独立方向：从 QueryTs 结构体（带 TableIDConditions）转为 PromQL，
 // 单组 AND 输出 __bk_query_label_selector_<维度>；多组 OR 无法写进单条 PromQL，应报错。
 func TestQueryTs_StructToPromQL_WithTableIDConditions(t *testing.T) {

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -126,8 +126,10 @@ func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fiel
 		}
 	}
 
-	// 只有在容器场景下的特殊逻辑
-	if isK8s {
+	// 容器场景下的特殊过滤逻辑：仅在未显式提供 table_id_conditions 时生效。
+	// 若调用方已通过 table_id_conditions 按 Labels 显式路由，则信任该选择，不再叠加"仅 bk_split_measurement / BcsClusterID 匹配"的容器默认规则，
+	// 避免把 bklog/bkapm 等非 split-measurement 的 RT 误过滤掉。
+	if isK8s && len(tableIDConditions) == 0 {
 		// 增加在非单指标单表下，判断如果强行指定了单指标单表则对其进行修改以支持 vm 查询
 		isSplitMeasurement := rtDetail.MeasurementType == redis.BkSplitMeasurement
 

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -336,11 +336,20 @@ func (s *SpaceFilter) DataList(opt *TsDBOption) ([]*query.TsDBV2, error) {
 
 	isK8sFeatureFlag := featureFlag.GetIsK8sFeatureFlag(s.ctx)
 
+	// 仅在启用了 table_id_conditions 时跟踪是否有候选 RT 的 Labels 命中，避免后续失败原因不在 Labels 时追加误导文案
+	anyLabelMatched := len(tableIDCondsForFilter) == 0
 	for _, tID := range tableIDs.ToArray() {
 		spaceRt := s.GetSpaceRtInfo(tID)
 		// 如果不跳过空间，则取 space 和 tableIDs 的交集
 		if !opt.IsSkipSpace && spaceRt == nil {
 			continue
+		}
+		if !anyLabelMatched {
+			if rt := s.router.GetResultTable(s.ctx, tID, false); rt != nil {
+				if tableIDCondsForFilter.MatchesResultTableLabels(rt.Labels) {
+					anyLabelMatched = true
+				}
+			}
 		}
 		// 指标模糊匹配，可能命中多个私有指标 RT
 		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, tableIDCondsForFilter)
@@ -354,8 +363,8 @@ func (s *SpaceFilter) DataList(opt *TsDBOption) ([]*query.TsDBV2, error) {
 
 	if len(tsDBs) == 0 {
 		routerMessage = fmt.Sprintf("tableID with field is empty with tableID: %s, field: %s, isSkipField: %v", opt.TableID, opt.FieldName, opt.IsSkipField)
-		if len(tableIDCondsForFilter) > 0 {
-			routerMessage += "；已启用 table_id_conditions，无命中时请核对 Labels 与条件是否一致"
+		if len(tableIDCondsForFilter) > 0 && !anyLabelMatched {
+			routerMessage += "；已启用 table_id_conditions，无 RT 的 Labels 命中条件"
 		}
 		return nil, nil
 	}

--- a/pkg/unify-query/query/structured/space_test.go
+++ b/pkg/unify-query/query/structured/space_test.go
@@ -336,4 +336,42 @@ func TestE2E_DataList_FilterResultTableByLabel(t *testing.T) {
 		assert.Contains(t, tableIDs, influxdb.ResultTableInfluxDB)
 		assert.Contains(t, tableIDs, influxdb.ResultTableVM)
 	})
+
+	// 非 split-measurement 的 RT（如 bklog 日志表 ResultTableEs，Labels scene=k8s）：
+	// IsSkipK8s=false 时会被容器指标分支误杀；IsSkipK8s=true（bklog/bkapm 路径）时 Labels 命中即可通过。
+	t.Run("non_split_rt_with_is_skip_k8s_false_is_filtered", func(t *testing.T) {
+		opt := *optBase
+		opt.FieldName = "dtEventTimeStamp"
+		opt.IsRegexp = false
+		opt.IsSkipField = true
+		opt.IsSkipK8s = false
+		opt.TableIDConditions = AllConditions{
+			{{DimensionName: "scene", Value: []string{"k8s"}, Operator: ConditionEqual}},
+		}
+		tsdb, err := sf.DataList(&opt)
+		require.NoError(t, err)
+		tableIDs := make([]string, 0, len(tsdb))
+		for _, d := range tsdb {
+			tableIDs = append(tableIDs, d.TableID)
+		}
+		assert.NotContains(t, tableIDs, influxdb.ResultTableEs, "IsSkipK8s=false 时容器分支会把非 split-measurement 的 RT 过滤掉")
+	})
+
+	t.Run("non_split_rt_with_is_skip_k8s_true_passes", func(t *testing.T) {
+		opt := *optBase
+		opt.FieldName = "dtEventTimeStamp"
+		opt.IsRegexp = false
+		opt.IsSkipField = true
+		opt.IsSkipK8s = true
+		opt.TableIDConditions = AllConditions{
+			{{DimensionName: "scene", Value: []string{"k8s"}, Operator: ConditionEqual}},
+		}
+		tsdb, err := sf.DataList(&opt)
+		require.NoError(t, err)
+		tableIDs := make([]string, 0, len(tsdb))
+		for _, d := range tsdb {
+			tableIDs = append(tableIDs, d.TableID)
+		}
+		assert.Contains(t, tableIDs, influxdb.ResultTableEs, "IsSkipK8s=true 时非 split-measurement 的 RT 在 Labels 命中后应被选中（bklog/bkapm 路径）")
+	})
 }

--- a/pkg/unify-query/query/structured/space_test.go
+++ b/pkg/unify-query/query/structured/space_test.go
@@ -337,9 +337,9 @@ func TestE2E_DataList_FilterResultTableByLabel(t *testing.T) {
 		assert.Contains(t, tableIDs, influxdb.ResultTableVM)
 	})
 
-	// 非 split-measurement 的 RT（如 bklog 日志表 ResultTableEs，Labels scene=k8s）：
-	// IsSkipK8s=false 时会被容器指标分支误杀；IsSkipK8s=true（bklog/bkapm 路径）时 Labels 命中即可通过。
-	t.Run("non_split_rt_with_is_skip_k8s_false_is_filtered", func(t *testing.T) {
+	// 非 split-measurement 的 RT（如 bklog 日志表 ResultTableEs，Labels scene=k8s）在容器默认过滤下会被误杀；
+	// 显式传 table_id_conditions 时应绕过容器默认规则，按 Labels 选表，不再要求 bk_split_measurement。
+	t.Run("non_split_rt_with_conditions_bypasses_k8s_filter", func(t *testing.T) {
 		opt := *optBase
 		opt.FieldName = "dtEventTimeStamp"
 		opt.IsRegexp = false
@@ -354,24 +354,22 @@ func TestE2E_DataList_FilterResultTableByLabel(t *testing.T) {
 		for _, d := range tsdb {
 			tableIDs = append(tableIDs, d.TableID)
 		}
-		assert.NotContains(t, tableIDs, influxdb.ResultTableEs, "IsSkipK8s=false 时容器分支会把非 split-measurement 的 RT 过滤掉")
+		assert.Contains(t, tableIDs, influxdb.ResultTableEs, "显式 table_id_conditions 下，非 split-measurement 的 RT 在 Labels 命中后应被选中（不叠加容器默认过滤）")
 	})
 
-	t.Run("non_split_rt_with_is_skip_k8s_true_passes", func(t *testing.T) {
+	t.Run("non_split_rt_without_conditions_is_filtered_by_k8s_default", func(t *testing.T) {
 		opt := *optBase
 		opt.FieldName = "dtEventTimeStamp"
 		opt.IsRegexp = false
 		opt.IsSkipField = true
-		opt.IsSkipK8s = true
-		opt.TableIDConditions = AllConditions{
-			{{DimensionName: "scene", Value: []string{"k8s"}, Operator: ConditionEqual}},
-		}
+		opt.IsSkipK8s = false
+		opt.TableIDConditions = nil
 		tsdb, err := sf.DataList(&opt)
 		require.NoError(t, err)
 		tableIDs := make([]string, 0, len(tsdb))
 		for _, d := range tsdb {
 			tableIDs = append(tableIDs, d.TableID)
 		}
-		assert.Contains(t, tableIDs, influxdb.ResultTableEs, "IsSkipK8s=true 时非 split-measurement 的 RT 在 Labels 命中后应被选中（bklog/bkapm 路径）")
+		assert.NotContains(t, tableIDs, influxdb.ResultTableEs, "无 table_id_conditions 时维持容器默认规则，非 split-measurement 的 RT 应被过滤")
 	})
 }


### PR DESCRIPTION
## 背景
`bkcc__100605` 空间下调用 `/query/ts/raw`，`data_source=bklog` + `table_id=""` + `table_id_conditions=[[scene=eq=k8s]]`，目标 RT Labels 实际能命中 `scene=k8s`，却一直返回error

## 根因

`space.NewTsDBs` 中的 `isK8s` 分支对候选 RT 硬校验"只认 `bk_split_measurement`"。bklog/bkapm 走 ES/Doris 链路，`MeasurementType` 为空串，不等于 `bk_split_measurement`，Labels 已命中的 RT 仍被直接 `return nil, nil` 刷掉；外层的兜底文案又无差别追加"请核对 Labels"，把失败原因指向错误方向。

该容器默认过滤本意服务 Prom/VM 指标查询。问题是它作用在"全空间扫表 + 有 `table_id_conditions`"这条显式路由路径上 —— 调用方明确按 Labels 选表了，默认规则仍在隐式兜底，二者叠加导致误杀。

## 方案

让显式路由优先于默认路由：`space.NewTsDBs` 里 `isK8s` 分支收紧激活条件，**仅在未提供 `table_id_conditions` 时生效**。

```go
// 容器场景下的特殊过滤逻辑：仅在未显式提供 table_id_conditions 时生效。
if isK8s && len(tableIDConditions) == 0 {
    // 原容器指标过滤（不变）
    ...
}