### PR TITLE
feat: (unify-query)精简 unify-query trace 埋点 --story=133836854

### DIFF
--- a/pkg/unify-query/featureFlag/feature_flag.go
+++ b/pkg/unify-query/featureFlag/feature_flag.go
@@ -51,8 +51,6 @@ func GetMustVmQueryFeatureFlag(ctx context.Context, tableID string) bool {
 		"tableID":  tableID,
 	})
 
-	span.Set("ff-user-custom", ffUser.GetCustom())
-
 	// 如果匹配不到，则默认查询 vm
 	status := BoolVariation(ctx, ffUser, "must-vm-query", true)
 

--- a/pkg/unify-query/featureFlag/feature_flag.go
+++ b/pkg/unify-query/featureFlag/feature_flag.go
@@ -19,12 +19,7 @@ import (
 func GetBkDataTableIDCheck(ctx context.Context, tableID string) bool {
 	var (
 		user = metadata.GetUser(ctx)
-		err  error
-		span *trace.Span
 	)
-
-	ctx, span = trace.NewSpan(ctx, "get-bk-data-table-id-auth-feature-flag")
-	defer span.End(&err)
 
 	u := FFUser(user.HashID, map[string]any{
 		"name":     user.Name,
@@ -32,10 +27,7 @@ func GetBkDataTableIDCheck(ctx context.Context, tableID string) bool {
 		"spaceUid": user.SpaceUID,
 		"tableID":  tableID,
 	})
-
-	span.Set("ff-user-custom", u.GetCustom())
 	status := BoolVariation(ctx, u, "bk-data-table-id-auth", false)
-	span.Set("ff-status", status)
 
 	return status
 }

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -869,8 +869,6 @@ func (q *Query) BuildMetadataQuery(
 	if measurement != "" {
 		measurements = []string{measurement}
 	}
-	jsonString, _ := json.Marshal(tsDB)
-	span.Set("tsdb-json", jsonString)
 
 	if q.Offset != "" {
 		dTmp, err := model.ParseDuration(q.Offset)
@@ -1032,7 +1030,7 @@ func (q *Query) BuildMetadataQuery(
 		query.Orders = q.OrderBy.Orders()
 	}
 
-	jsonString, _ = json.Marshal(query)
+	jsonString, _ := json.Marshal(query)
 	span.Set("query-json", jsonString)
 
 	return query

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -724,6 +724,7 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 
 	// 构建 query map 使得相同的 storage 可以进行合并查询
 	queryMap := make(map[string]*metadata.Query)
+	var queryMergePairs []string
 
 	// 查询路由匹配中的 tsDB 列表
 	for _, tsDB := range tsDBs {
@@ -815,13 +816,17 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 
 			storageUUID := query.StorageUUID()
 			if oq, ok := queryMap[storageUUID]; ok {
-				span.Set(fmt.Sprintf("query_merge_%s", oq.TableID), query.TableID)
+				queryMergePairs = append(queryMergePairs, fmt.Sprintf("%s->%s", oq.TableID, query.TableID))
 				oq.DBs = append(oq.DBs, query.DB)
 			} else {
 				query.DBs = []string{query.DB}
 				queryMap[storageUUID] = query
 			}
 		}
+	}
+
+	if len(queryMergePairs) > 0 {
+		span.Set("query_merge_pairs", queryMergePairs)
 	}
 
 	span.Set("query_map_length", len(queryMap))

--- a/pkg/unify-query/service/http/api.go
+++ b/pkg/unify-query/service/http/api.go
@@ -670,8 +670,6 @@ func HandlerFieldMap(c *gin.Context) {
 				return
 			}
 
-			span.Set(fmt.Sprintf("field-map-length-%s", qry.TableUUID()), len(res))
-
 			for k, v := range res {
 				lock.Lock()
 				if _, ok := dataMap[k]; !ok {

--- a/pkg/unify-query/service/http/api.go
+++ b/pkg/unify-query/service/http/api.go
@@ -514,12 +514,10 @@ func HandlerLabelValues(c *gin.Context) {
 
 	ctx, span := trace.NewSpan(ctx, "label-values-handler")
 	defer func() {
+		span.End(&err)
 		if err != nil {
 			resp.failed(ctx, err)
-			return
 		}
-
-		span.End(&err)
 	}()
 
 	labelName := c.Param("label_name")

--- a/pkg/unify-query/service/http/response.go
+++ b/pkg/unify-query/service/http/response.go
@@ -34,9 +34,8 @@ func (r *response) failed(ctx context.Context, err error) {
 		return
 	}
 
-	_, span := trace.NewSpan(ctx, "response-failed")
 	r.c.JSON(http.StatusBadRequest, ErrResponse{
-		TraceID: span.TraceID(),
+		TraceID: trace.TraceIDFromContext(ctx),
 		Err:     err.Error(),
 	})
 }

--- a/pkg/unify-query/trace/trace.go
+++ b/pkg/unify-query/trace/trace.go
@@ -56,6 +56,15 @@ func (s *Span) TraceID() string {
 	return traceID.String()
 }
 
+// TraceIDFromContext 从 ctx 提取 trace id，无有效链路时返回空字符串
+func TraceIDFromContext(ctx context.Context) string {
+	traceID := oteltrace.SpanFromContext(ctx).SpanContext().TraceID()
+	if !traceID.IsValid() {
+		return ""
+	}
+	return traceID.String()
+}
+
 // Set attribute 打点
 func (s *Span) Set(key string, value any) {
 	if s.span == nil {

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -215,11 +215,6 @@ func needFieldMap(query *metadata.Query) bool {
 }
 
 func (i *Instance) InitQueryFactory(ctx context.Context, query *metadata.Query, start, end time.Time) (*QueryFactory, error) {
-	var err error
-
-	ctx, span := trace.NewSpan(ctx, "instance-init-query-factory")
-	defer span.End(&err)
-
 	f := NewQueryFactory(ctx, query).
 		WithRangeTime(start, end)
 
@@ -238,10 +233,6 @@ func (i *Instance) InitQueryFactory(ctx context.Context, query *metadata.Query, 
 				keepColumns = append(keepColumns, k)
 			}
 		}
-		out, _ := json.Marshal(fieldsMap)
-		span.Set("table_fields_map", string(out))
-
-		span.Set("keep-columns", keepColumns)
 		f.WithFieldsMap(fieldsMap).WithKeepColumns(keepColumns)
 	}
 

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -430,15 +430,11 @@ func (i *Instance) queryWithAgg(ctx context.Context, qo *queryOption, fact *Form
 }
 
 func (i *Instance) getAlias(ctx context.Context, query *metadata.Query, start, end time.Time) ([]string, error) {
-	_, span := trace.NewSpan(ctx, "get-alias")
-
 	allAlias := make([]string, 0)
 	dbs := query.DBs
 	if len(dbs) == 0 {
 		dbs = []string{query.DB}
 	}
-
-	span.Set("dbs", dbs)
 
 	// 多表的字段进行合并查询，进行倒序遍历
 	for idx := len(dbs) - 1; idx >= 0; idx-- {
@@ -450,8 +446,6 @@ func (i *Instance) getAlias(ctx context.Context, query *metadata.Query, start, e
 		alias := i.explainDB(ctx, db, query.NeedAddTime, start, end, query.SourceType)
 		allAlias = append(allAlias, alias...)
 	}
-
-	span.Set("alias", allAlias)
 
 	if len(allAlias) == 0 {
 		return nil, metadata.NewMessage(

--- a/pkg/unify-query/tsdb/influxdb/instance.go
+++ b/pkg/unify-query/tsdb/influxdb/instance.go
@@ -333,10 +333,7 @@ func (i *Instance) makeSQL(
 		groupList  = make([]string, 0)
 
 		sqlBuilder strings.Builder
-		err        error
 	)
-	ctx, span := trace.NewSpan(ctx, "influxdb-make-sqlBuilder")
-	defer span.End(&err)
 
 	if len(query.Aggregates) > 1 {
 		return "", fmt.Errorf("influxdb 不支持多函数聚合查询, %+v", query.Aggregates)


### PR DESCRIPTION
1.修复 get-alias、response-failed 等创建后未 End 的 span 泄漏；去掉仅为取 TraceID 或重复包一层的冗余 span，错误响应的 trace_id 改为从请求上下文读取当前链路 TraceID
2.GetBkDataTableIDCheck 移除 span
3.HandlerFieldMap 删除动态键，避免属性键基数随 UUID 爆炸的问题
4.`build-metadata-query` 里原有 `attributes.tsdb-json` 会把 `TsDBV2` 序列化写入 span，信息量大且与路由排障信息存在重叠，移除"tsdb-json", 结果表元数据改由 `space_key_print?type_key=result_table_detail` 统一查看
5.`bksql.Instance.InitQueryFactory` 中移除` instance-init-query-factory` 这一层 span，字段元数据请求已通过 QueryFieldMap → sqlQuery → QuerySync 下发，每条语句在 sql-query span 的 query-sql 中已有完整 SQL（含 SHOW CREATE / DESCRIBE 等）
6.修复 label-values-handler 错误路径下 Span 未 End 导致泄漏
7.将 ToQueryMetric 中按 query_merge_<TableID> 动态写入 span 属性的方式，改为在合并结束后统一写入 query_merge_pairs，避免属性键基数过高
8.删除 influxdb-make-sqlBuilder，原因是没有任何独占的诊断属性
9. 精简 check-must-query-feature-flag 链路属性,移除了对 OpenTelemetry span 的 ff-user-custom 属性写入,表维度信息在同 trace 内相邻的 build-metadata-query 所带的 query-json（table_id）及下游 get-ts-db-instance 的 storage-type 等处也可对照