### PR TITLE
fix(bkmonitorbeat): 修复 diskro 挂载点上报状态串用问题

### DIFF
--- a/pkg/bkmonitorbeat/tasks/exceptionbeat/collector/diskro/collector.go
+++ b/pkg/bkmonitorbeat/tasks/exceptionbeat/collector/diskro/collector.go
@@ -130,7 +130,6 @@ func (c *DiskROCollector) getRODisk() []beat.MapStr {
 	var (
 		retList            []beat.MapStr
 		MountPointInfoList []*MountPointInfo
-		shouldReport       bool
 	)
 
 	// 此处只关心物理设备的分区，其他系统生成的分区不必关注
@@ -144,6 +143,7 @@ func (c *DiskROCollector) getRODisk() []beat.MapStr {
 	}
 	MountPointInfoList = NewBatchMountPointInfo(partitions)
 	for _, mp := range MountPointInfoList {
+		shouldReport := false
 		c.deviceMap[mp.Device] = true
 		// 判断是否满足白名单，如果是直接返回告警
 		if mp.IsReadOnly() && mp.IsMatchRule(c.whiteList) {

--- a/pkg/bkmonitorbeat/tasks/exceptionbeat/collector/diskro/collector_test.go
+++ b/pkg/bkmonitorbeat/tasks/exceptionbeat/collector/diskro/collector_test.go
@@ -1,0 +1,104 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+
+package diskro
+
+import (
+	"os"
+	"testing"
+
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRODiskDoesNotLeakStatusAcrossMountPoints(t *testing.T) {
+	f := initStorage()
+	defer os.Remove(f)
+
+	firstHistory := NewMountPointInfo(disk.PartitionStat{
+		Device:     "/dev/sdm",
+		Mountpoint: "/hadoop12",
+		Fstype:     "ext4",
+		Opts:       []string{"rw"},
+	})
+	secondHistory := NewMountPointInfo(disk.PartitionStat{
+		Device:     "/dev/sdb",
+		Mountpoint: "/hadoop01",
+		Fstype:     "ext4",
+		Opts:       []string{"rw"},
+	})
+
+	require.NoError(t, firstHistory.SaveStatus())
+	require.NoError(t, secondHistory.SaveStatus())
+	defer cleanStorage(t, firstHistory)
+	defer cleanStorage(t, secondHistory)
+
+	originalPartitionFunc := partitionFunc
+	partitionFunc = func(all bool) ([]disk.PartitionStat, error) {
+		return []disk.PartitionStat{
+			{
+				Device:     "/dev/sdm",
+				Mountpoint: "/hadoop12",
+				Fstype:     "ext4",
+				Opts:       []string{"ro"},
+			},
+			{
+				Device:     "/dev/sdb",
+				Mountpoint: "/hadoop01",
+				Fstype:     "ext4",
+				Opts:       []string{"rw"},
+			},
+		}, nil
+	}
+	defer func() {
+		partitionFunc = originalPartitionFunc
+	}()
+
+	collector := &DiskROCollector{
+		deviceMap: make(map[string]bool),
+	}
+
+	ret := collector.getRODisk()
+	require.Len(t, ret, 1)
+	assert.EqualValues(t, beatMapStr("/dev/sdm", "/hadoop12", "ext4"), ret[0])
+}
+
+func TestGetRODiskDoesNotLeakWhitelistReportAcrossMountPoints(t *testing.T) {
+	originalPartitionFunc := partitionFunc
+	partitionFunc = func(all bool) ([]disk.PartitionStat, error) {
+		return []disk.PartitionStat{
+			{
+				Device:     "/dev/sdm",
+				Mountpoint: "/hadoop12",
+				Fstype:     "ext4",
+				Opts:       []string{"ro"},
+			},
+			{
+				Device:     "/dev/sdb",
+				Mountpoint: "/hadoop01",
+				Fstype:     "ext4",
+				Opts:       []string{"rw"},
+			},
+		}, nil
+	}
+	defer func() {
+		partitionFunc = originalPartitionFunc
+	}()
+
+	collector := &DiskROCollector{
+		whiteList: []string{"hadoop12"},
+		deviceMap: make(map[string]bool),
+	}
+
+	ret := collector.getRODisk()
+	require.Len(t, ret, 1)
+	assert.EqualValues(t, beatMapStr("/dev/sdm", "/hadoop12", "ext4"), ret[0])
+}
+
+func beatMapStr(fs, position, fileSystem string) map[string]interface{} {
+	return map[string]interface{}{
+		"fs":       fs,
+		"position": position,
+		"type":     fileSystem,
+	}
+}


### PR DESCRIPTION
## 背景

diskro 采集器会遍历当前主机的多个挂载点，并分别判断每个挂载点是否需要上报只读异常。
预期行为是：命中的挂载点单独上报，未命中的挂载点不应被连带带出。

但在实际逻辑中，如果前一个挂载点已经命中了“白名单只读”或“RW -> RO 状态变化”，
后一个本身不满足上报条件的挂载点，仍可能被一并加入返回结果，造成误报。

## 根因

DiskROCollector.getRODisk 中用于控制是否上报的 shouldReport 定义在挂载点遍历循环外层。

这使得它不再是“当前挂载点的一次性判定状态”，而变成了多个挂载点之间共享的临时变量。
一旦前一个挂载点把 shouldReport 置为 true，后续挂载点如果没有重新清零，即使自身既不命中白名单、
也没有发生只读状态变化，最终仍可能进入上报列表。

问题本质上不是只读判断规则本身错误，而是跨挂载点复用了上报状态，导致判定结果串用。

## 方案

将 shouldReport 收敛到每个挂载点的循环体内部，使每次遍历都从 false 开始，
只根据当前挂载点的白名单匹配结果和只读状态变化结果决定是否上报。

同时补充回归测试，覆盖以下场景：

1. 前一个挂载点发生 RW -> RO 变化后，不应污染后一个仍为 RW 的挂载点；
2. 前一个挂载点命中白名单只读后，不应导致后一个未命中的挂载点被连带上报。

这样可以保证 diskro 的只读异常按挂载点独立判定，修复跨挂载点误报问题。