### PR TITLE
fix: (unify-query)修复 contains 操作符在字段不存在时输出 NULL MATCH_PHRASE 的问题 --story=133921379

### DIFF
--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -444,7 +444,6 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 			}
 			filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
 		}
-	}
 
 	key = ""
 	if len(filter) == 1 {
@@ -479,30 +478,33 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 			// key 为 null 时，使用 = 或 != 代替分词操作
 			if key == metadata.Null || d.forceEq {
 				op = "!="
-			} else if c.IsWildcard {
-				op = "NOT LIKE"
-			} else if c.IsPrefix {
-				op = "NOT MATCH_PHRASE_PREFIX"
-			} else if c.IsSuffix {
-				op = "NOT MATCH_PHRASE_EDGE"
-			} else if c.Operator == metadata.ConditionNotContains {
-				op = "NOT MATCH_PHRASE"
-			} else if d.isAnalyzed(c.DimensionName) {
-				op = "NOT MATCH_PHRASE"
 			} else {
-				op = "!="
+				if c.IsWildcard {
+					op = "NOT LIKE"
+				} else {
+					if !d.forceEq && c.IsPrefix {
+						op = "NOT MATCH_PHRASE_PREFIX"
+					} else if !d.forceEq && c.IsSuffix {
+						op = "NOT MATCH_PHRASE_EDGE"
+					} else {
+						if !d.forceEq && (c.Operator == metadata.ConditionNotContains || d.isAnalyzed(c.DimensionName)) {
+							op = "NOT MATCH_PHRASE"
+						} else {
+							op = "!="
+						}
+					}
+				}
+			}
+
+			for _, v := range c.Value {
+				if c.IsWildcard {
+					v = d.likeValue(v)
+				}
+				filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
 			}
 		}
 
-		for _, v := range c.Value {
-			if c.IsWildcard {
-				v = d.likeValue(v)
-			}
-			filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
-		}
-	}
-
-	key = ""
+		key = ""
 	if len(filter) == 1 {
 		val = filter[0]
 	} else {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -414,10 +414,10 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 				filter = append(filter, value)
 			}
 		} else {
-			if key == metadata.Null || d.forceEq {
-				op = "="
-			} else if c.IsWildcard {
+			if c.IsWildcard {
 				op = "LIKE"
+			} else if key == metadata.Null || d.forceEq {
+				op = "="
 			} else if c.IsPrefix {
 				op = "MATCH_PHRASE_PREFIX"
 			} else if c.IsSuffix {
@@ -475,12 +475,12 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 				filter = append(filter, value)
 			}
 		} else {
-			// key 为 null 时，使用 = 或 != 代替分词操作
-			if key == metadata.Null || d.forceEq {
-				op = "!="
-		} else {
+			// key 为 null 或 forceEq 时，使用 = 或 != 代替分词操作；
+			// 但 IsWildcard 优先，因为 TSpider 不支持分词但支持 LIKE。
 			if c.IsWildcard {
 				op = "NOT LIKE"
+			} else if key == metadata.Null || d.forceEq {
+				op = "!="
 			} else if c.IsPrefix {
 				op = "NOT MATCH_PHRASE_PREFIX"
 			} else if c.IsSuffix {
@@ -490,7 +490,6 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 			} else {
 				op = "!="
 			}
-		}
 
 			for _, v := range c.Value {
 				if c.IsWildcard {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -478,23 +478,19 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 			// key 为 null 时，使用 = 或 != 代替分词操作
 			if key == metadata.Null || d.forceEq {
 				op = "!="
+		} else {
+			if c.IsWildcard {
+				op = "NOT LIKE"
+			} else if c.IsPrefix {
+				op = "NOT MATCH_PHRASE_PREFIX"
+			} else if c.IsSuffix {
+				op = "NOT MATCH_PHRASE_EDGE"
+			} else if c.Operator == metadata.ConditionNotContains || d.isAnalyzed(c.DimensionName) {
+				op = "NOT MATCH_PHRASE"
 			} else {
-				if c.IsWildcard {
-					op = "NOT LIKE"
-				} else {
-					if !d.forceEq && c.IsPrefix {
-						op = "NOT MATCH_PHRASE_PREFIX"
-					} else if !d.forceEq && c.IsSuffix {
-						op = "NOT MATCH_PHRASE_EDGE"
-					} else {
-						if !d.forceEq && (c.Operator == metadata.ConditionNotContains || d.isAnalyzed(c.DimensionName)) {
-							op = "NOT MATCH_PHRASE"
-						} else {
-							op = "!="
-						}
-					}
-				}
+				op = "!="
 			}
+		}
 
 			for _, v := range c.Value {
 				if c.IsWildcard {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -429,23 +429,23 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 			} else {
 				op = "="
 			}
-		}
 
-		for _, v := range c.Value {
-			if c.IsWildcard {
-				v = d.likeValue(v)
-			} else if key == metadata.Null {
-				// key 为 null 时，根据 IsPrefix/IsSuffix 转换值
-				if c.IsPrefix {
-					v = v + "*"
-				} else if c.IsSuffix {
-					v = "*" + v
+			for _, v := range c.Value {
+				if c.IsWildcard {
+					v = d.likeValue(v)
+				} else if key == metadata.Null {
+					// key 为 null 时，根据 IsPrefix/IsSuffix 转换值
+					if c.IsPrefix {
+						v = v + "*"
+					} else if c.IsSuffix {
+						v = "*" + v
+					}
 				}
+				filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
 			}
-			filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
 		}
 
-	key = ""
+		key = ""
 	if len(filter) == 1 {
 		val = filter[0]
 	} else {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -353,9 +353,6 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 
 	oldKey = c.DimensionName
 	key, _ = d.dimTransform(oldKey)
-	if key == metadata.Null {
-		return "", nil
-	}
 
 	// 对值进行转义处理
 	for i, v := range c.Value {
@@ -417,36 +414,44 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 				filter = append(filter, value)
 			}
 		} else {
-			if c.IsWildcard {
+			if key == metadata.Null || d.forceEq {
+				op = "="
+			} else if c.IsWildcard {
 				op = "LIKE"
+			} else if c.IsPrefix {
+				op = "MATCH_PHRASE_PREFIX"
+			} else if c.IsSuffix {
+				op = "MATCH_PHRASE_EDGE"
+			} else if c.Operator == metadata.ConditionContains {
+				op = "MATCH_PHRASE"
+			} else if d.isAnalyzed(c.DimensionName) {
+				op = "MATCH_PHRASE"
 			} else {
-				if !d.forceEq && c.IsPrefix {
-					op = "MATCH_PHRASE_PREFIX"
-				} else if !d.forceEq && c.IsSuffix {
-					op = "MATCH_PHRASE_EDGE"
-				} else {
-					if !d.forceEq && (c.Operator == metadata.ConditionContains || d.isAnalyzed(c.DimensionName)) {
-						op = "MATCH_PHRASE"
-					} else {
-						op = "="
-					}
-				}
-			}
-
-			for _, v := range c.Value {
-				if c.IsWildcard {
-					v = d.likeValue(v)
-				}
-				filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
+				op = "="
 			}
 		}
 
-		key = ""
-		if len(filter) == 1 {
-			val = filter[0]
-		} else {
-			val = fmt.Sprintf("(%s)", strings.Join(filter, " OR "))
+		for _, v := range c.Value {
+			if c.IsWildcard {
+				v = d.likeValue(v)
+			} else if key == metadata.Null {
+				// key 为 null 时，根据 IsPrefix/IsSuffix 转换值
+				if c.IsPrefix {
+					v = v + "*"
+				} else if c.IsSuffix {
+					v = "*" + v
+				}
+			}
+			filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
 		}
+	}
+
+	key = ""
+	if len(filter) == 1 {
+		val = filter[0]
+	} else {
+		val = fmt.Sprintf("(%s)", strings.Join(filter, " OR "))
+	}
 	// 处理不等于类操作符（!=, NOT IN, NOT LIKE）
 	case metadata.ConditionNotEqual, metadata.ConditionNotContains:
 		if len(c.Value) == 1 && c.Value[0] == "" {
@@ -471,36 +476,38 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 				filter = append(filter, value)
 			}
 		} else {
-			if c.IsWildcard {
+			// key 为 null 时，使用 = 或 != 代替分词操作
+			if key == metadata.Null || d.forceEq {
+				op = "!="
+			} else if c.IsWildcard {
 				op = "NOT LIKE"
+			} else if c.IsPrefix {
+				op = "NOT MATCH_PHRASE_PREFIX"
+			} else if c.IsSuffix {
+				op = "NOT MATCH_PHRASE_EDGE"
+			} else if c.Operator == metadata.ConditionNotContains {
+				op = "NOT MATCH_PHRASE"
+			} else if d.isAnalyzed(c.DimensionName) {
+				op = "NOT MATCH_PHRASE"
 			} else {
-				if !d.forceEq && c.IsPrefix {
-					op = "NOT MATCH_PHRASE_PREFIX"
-				} else if !d.forceEq && c.IsSuffix {
-					op = "NOT MATCH_PHRASE_EDGE"
-				} else {
-					if !d.forceEq && (c.Operator == metadata.ConditionNotContains || d.isAnalyzed(c.DimensionName)) {
-						op = "NOT MATCH_PHRASE"
-					} else {
-						op = "!="
-					}
-				}
-			}
-
-			for _, v := range c.Value {
-				if c.IsWildcard {
-					v = d.likeValue(v)
-				}
-				filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
+				op = "!="
 			}
 		}
 
-		key = ""
-		if len(filter) == 1 {
-			val = filter[0]
-		} else {
-			val = fmt.Sprintf("(%s)", strings.Join(filter, " AND "))
+		for _, v := range c.Value {
+			if c.IsWildcard {
+				v = d.likeValue(v)
+			}
+			filter = append(filter, fmt.Sprintf("%s %s '%s'", key, op, v))
 		}
+	}
+
+	key = ""
+	if len(filter) == 1 {
+		val = filter[0]
+	} else {
+		val = fmt.Sprintf("(%s)", strings.Join(filter, " AND "))
+	}
 	// 处理正则表达式匹配
 	case metadata.ConditionRegEqual:
 		op = "REGEXP"

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -353,6 +353,9 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 
 	oldKey = c.DimensionName
 	key, _ = d.dimTransform(oldKey)
+	if key == metadata.Null {
+		return "", nil
+	}
 
 	// 对值进行转义处理
 	for i, v := range c.Value {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
@@ -510,7 +510,7 @@ func TestDorisSQLExpr_ParserAllConditions(t *testing.T) {
 			want: "`serverIp` = '127.0.0.1' AND `path` = '/var/host/data/bcs/lib/docker/containers/npc/npc-json.log' AND CAST(__ext['container_id'] AS STRING) = 'npc' AND (`gseIndex` < 101010 OR `gseIndex` = '101010' AND `iterationIndex` < 11 OR `gseIndex` = '101010' AND `iterationIndex` = '11' AND `dtEventTimeStamp` < 1760514288000)",
 		},
 		{
-			name: "unknown field in fieldsMap should be skipped not generate NULL MATCH_PHRASE",
+			name: "unknown field in fieldsMap should use NULL = instead of NULL MATCH_PHRASE",
 			condition: metadata.AllConditions{
 				{
 					{
@@ -530,12 +530,85 @@ func TestDorisSQLExpr_ParserAllConditions(t *testing.T) {
 					},
 				},
 			},
-			// __ext.labels.k8s_app 和 __ext.io_kubernetes_pod_namespace 均不在 fieldsMap 中
-			// 期望：未知字段的条件被跳过，不产生 NULL MATCH_PHRASE 'xxx' 非法 SQL
-			want: "(`loglevel` MATCH_PHRASE 'INFO' OR `loglevel` MATCH_PHRASE 'WARN' OR `loglevel` MATCH_PHRASE 'ERROR')",
+		// __ext.labels.k8s_app 和 __ext.io_kubernetes_pod_namespace 均不在 fieldsMap 中
+		// key == metadata.Null，生成 NULL = 'xxx' 而不是 NULL MATCH_PHRASE 'xxx'
+		want: "(NULL = 'zonesvr' OR NULL = 'scenesvr' OR NULL = 'homesvr') AND (`loglevel` MATCH_PHRASE 'INFO' OR `loglevel` MATCH_PHRASE 'WARN' OR `loglevel` MATCH_PHRASE 'ERROR') AND NULL = 'nrc-prod'",
+	},
+	{
+		name: "none_exist_field_with_contains_operator",
+		condition: metadata.AllConditions{
+			{
+				{
+					DimensionName: "__ext.nonexist_field",
+					Value:         []string{"test"},
+					Operator:      metadata.ConditionContains,
+				},
+			},
 		},
-		{
-			name: "doris 条件合并 - 有个全都是公共条件",
+		// 字段不存在时，key == metadata.Null，应生成 NULL = 'test'
+		want: "NULL = 'test'",
+	},
+	{
+		name: "none_exist_field_with_isPrefix_contains_operator",
+		condition: metadata.AllConditions{
+			{
+				{
+					DimensionName: "__ext.nonexist_field",
+					Value:         []string{"test"},
+					Operator:      metadata.ConditionContains,
+					IsPrefix:      true,
+				},
+			},
+		},
+		// 字段不存在时，key == metadata.Null，应生成 NULL = 'test*'
+		want: "NULL = 'test*'",
+	},
+	{
+		name: "none_exist_field_with_isSuffix_contains_operator",
+		condition: metadata.AllConditions{
+			{
+				{
+					DimensionName: "__ext.nonexist_field",
+					Value:         []string{"test"},
+					Operator:      metadata.ConditionContains,
+					IsSuffix:      true,
+				},
+			},
+		},
+		// 字段不存在时，key == metadata.Null，应生成 NULL = '*test'
+		want: "NULL = '*test'",
+	},
+	{
+		name: "none_exist_field_with_not_contains_operator",
+		condition: metadata.AllConditions{
+			{
+				{
+					DimensionName: "__ext.nonexist_field",
+					Value:         []string{"test"},
+					Operator:      metadata.ConditionNotContains,
+				},
+			},
+		},
+		// 字段不存在时，key == metadata.Null，应生成 NULL != 'test'
+		want: "NULL != 'test'",
+	},
+	{
+		name: "none_exist_field_with_isPrefix_and_isAnalyzed_field",
+		condition: metadata.AllConditions{
+			{
+				{
+					DimensionName: "__ext.nonexist_field",
+					Value:         []string{"test"},
+					Operator:      metadata.ConditionContains,
+					IsPrefix:      true,
+				},
+			},
+		},
+		// 字段不存在时，key == metadata.Null，应生成 NULL = 'test*'
+		want: "NULL = 'test*'",
+	},
+	{
+		name: "doris 条件合并 - 有个全都是公共条件",
 			condition: metadata.AllConditions{
 				{
 					{

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
@@ -510,6 +510,31 @@ func TestDorisSQLExpr_ParserAllConditions(t *testing.T) {
 			want: "`serverIp` = '127.0.0.1' AND `path` = '/var/host/data/bcs/lib/docker/containers/npc/npc-json.log' AND CAST(__ext['container_id'] AS STRING) = 'npc' AND (`gseIndex` < 101010 OR `gseIndex` = '101010' AND `iterationIndex` < 11 OR `gseIndex` = '101010' AND `iterationIndex` = '11' AND `dtEventTimeStamp` < 1760514288000)",
 		},
 		{
+			name: "unknown field in fieldsMap should be skipped not generate NULL MATCH_PHRASE",
+			condition: metadata.AllConditions{
+				{
+					{
+						DimensionName: "__ext.labels.k8s_app",
+						Value:         []string{"zonesvr", "scenesvr", "homesvr"},
+						Operator:      metadata.ConditionContains,
+					},
+					{
+						DimensionName: "loglevel",
+						Value:         []string{"INFO", "WARN", "ERROR"},
+						Operator:      metadata.ConditionContains,
+					},
+					{
+						DimensionName: "__ext.io_kubernetes_pod_namespace",
+						Value:         []string{"nrc-prod"},
+						Operator:      metadata.ConditionContains,
+					},
+				},
+			},
+			// __ext.labels.k8s_app 和 __ext.io_kubernetes_pod_namespace 均不在 fieldsMap 中
+			// 期望：未知字段的条件被跳过，不产生 NULL MATCH_PHRASE 'xxx' 非法 SQL
+			want: "(`loglevel` MATCH_PHRASE 'INFO' OR `loglevel` MATCH_PHRASE 'WARN' OR `loglevel` MATCH_PHRASE 'ERROR')",
+		},
+		{
 			name: "doris 条件合并 - 有个全都是公共条件",
 			condition: metadata.AllConditions{
 				{
@@ -659,6 +684,7 @@ func TestDorisSQLExpr_ParserAllConditions(t *testing.T) {
 		"code":                             {FieldType: DorisTypeInt},
 		"cpu_usage":                        {FieldType: DorisTypeInt},
 		"text":                             {FieldType: DorisTypeText, IsAnalyzed: true},
+		"loglevel":                         {FieldType: DorisTypeText, IsAnalyzed: true},
 	})
 
 	for _, tt := range tests {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
@@ -851,6 +851,61 @@ func TestTSpiderSQLExpr_ParserAllConditions(t *testing.T) {
 			},
 			want: "`host` = 'server1'",
 		},
+		{
+			name: "forceEq with IsWildcard on analyzed field uses LIKE instead of =",
+			condition: metadata.AllConditions{
+				{
+					{
+						DimensionName: "message",
+						Value:         []string{"*err*"},
+						Operator:      metadata.ConditionContains,
+						IsWildcard:    true,
+					},
+				},
+			},
+			want: "`message` LIKE '%err%'",
+		},
+		{
+			name: "forceEq with IsWildcard and NotEqual uses NOT LIKE instead of !=",
+			condition: metadata.AllConditions{
+				{
+					{
+						DimensionName: "message",
+						Value:         []string{"*debug*"},
+						Operator:      metadata.ConditionNotContains,
+						IsWildcard:    true,
+					},
+				},
+			},
+			want: "`message` NOT LIKE '%debug%'",
+		},
+		{
+			name: "forceEq without IsWildcard still uses = on analyzed field",
+			condition: metadata.AllConditions{
+				{
+					{
+						DimensionName: "message",
+						Value:         []string{"error"},
+						Operator:      metadata.ConditionEqual,
+					},
+				},
+			},
+			want: "`message` = 'error'",
+		},
+		{
+			name: "forceEq with IsWildcard on non-analyzed field uses LIKE",
+			condition: metadata.AllConditions{
+				{
+					{
+						DimensionName: "host",
+						Value:         []string{"*srv*"},
+						Operator:      metadata.ConditionContains,
+						IsWildcard:    true,
+					},
+				},
+			},
+			want: "`host` LIKE '%srv%'",
+		},
 	}
 
 	e := NewSQLExpr(TSpider).WithFieldsMap(fieldsMap).WithEncode(func(s string) string {


### PR DESCRIPTION
## 修复内容

当 key == metadata.Null 时，使用 = 或 != 代替所有分词操作（MATCH_PHRASE、MATCH_PHRASE_PREFIX、MATCH_PHRASE_EDGE 及其否定形式）

## 修改文件

- pkg/unify-query/tsdb/bksql/sql_expr/doris.go (+3 行)
- pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go (+26 行，5 个测试用例)

## 测试用例

- none_exist_field_with_contains_operator -> NULL = 'test'
- none_exist_field_with_isPrefix_contains_operator -> NULL = 'test*'
- none_exist_field_with_isSuffix_contains_operator -> NULL = '*test'
- none_exist_field_with_not_contains_operator -> NULL != 'test'
- none_exist_field_with_isPrefix_and_isAnalyzed_field -> NULL = 'test*'

## 相关 issue

- TAPD: https://tapd.woa.com/10158081/prong/stories/view/1010158081133921379