### PR TITLE
feat: (unify-query)storage id未命中时重新从consul刷入及打点优化 --story=134046756

### DIFF
--- a/pkg/unify-query/metric/metric.go
+++ b/pkg/unify-query/metric/metric.go
@@ -33,6 +33,11 @@ const (
 	StatusReceived = "received"
 	StatusSuccess  = "success"
 	StatusFailed   = "failed"
+
+	// StorageResult* 用于 unify_query_tsdb_get_storage_total 的 result 标签，区分 GetStorage 三类返回路径。
+	StorageResultHit            = "hit"
+	StorageResultHitAfterReload = "hit_after_reload"
+	StorageResultMiss           = "miss"
 )
 
 const (
@@ -124,6 +129,15 @@ var (
 		},
 		[]string{"space_uid", "table_id", "is_match", "is_ff"},
 	)
+
+	tsDBGetStorageTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "unify_query",
+			Name:      "tsdb_get_storage_total",
+			Help:      "tsdb GetStorage call count by result",
+		},
+		[]string{"result"},
+	)
 )
 
 func APIRequestInc(ctx context.Context, api, status, spaceUID, sourceType string) {
@@ -169,6 +183,12 @@ func JWTRequestInc(ctx context.Context, api, jwtAppCode, jwtAppUserName, spaceUI
 
 func BkDataRequestInc(ctx context.Context, spaceUID, tableID, isMatch, isFF string) {
 	metric, _ := bkDataApiRequestTotal.GetMetricWithLabelValues(spaceUID, tableID, isMatch, isFF)
+	counterInc(ctx, metric)
+}
+
+// TsDBGetStorageInc 在 tsdb.GetStorage 的每条返回路径上递增一次，result 取 StorageResultHit / StorageResultHitAfterReload / StorageResultMiss。
+func TsDBGetStorageInc(ctx context.Context, result string) {
+	metric, _ := tsDBGetStorageTotal.GetMetricWithLabelValues(result)
 	counterInc(ctx, metric)
 }
 

--- a/pkg/unify-query/service/tsdb/hook.go
+++ b/pkg/unify-query/service/tsdb/hook.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/eventbus"
+	inner "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/tsdb"
 )
 
 // setDefaultConfig 配置初始化参数
@@ -56,6 +57,8 @@ func setDefaultConfig() {
 	viper.SetDefault(EsTimeoutConfigPath, "30s")
 	viper.SetDefault(EsMaxSizeConfigPath, 1e4)
 	viper.SetDefault(EsMaxRoutingConfigPath, 10)
+
+	viper.SetDefault(TsdbStorageMissReloadCooldownConfigPath, "10m")
 }
 
 // initConfig 加载配置
@@ -93,6 +96,8 @@ func initConfig() {
 	EsTimeout = viper.GetDuration(EsTimeoutConfigPath)
 	EsMaxRouting = viper.GetInt(EsMaxRoutingConfigPath)
 	EsMaxSize = viper.GetInt(EsMaxSizeConfigPath)
+
+	inner.SetStorageMissReloadCooldown(viper.GetDuration(TsdbStorageMissReloadCooldownConfigPath))
 }
 
 // init 初始化，通过 eventBus 加载配置读取前和读取后操作

--- a/pkg/unify-query/service/tsdb/hook.go
+++ b/pkg/unify-query/service/tsdb/hook.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/eventbus"
-	inner "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/tsdb"
 )
 
 // setDefaultConfig 配置初始化参数
@@ -97,7 +96,8 @@ func initConfig() {
 	EsMaxRouting = viper.GetInt(EsMaxRoutingConfigPath)
 	EsMaxSize = viper.GetInt(EsMaxSizeConfigPath)
 
-	inner.SetStorageMissReloadCooldown(viper.GetDuration(TsdbStorageMissReloadCooldownConfigPath))
+	// storage缺失重载冷却时间
+	StorageMissReloadCooldown = viper.GetDuration(TsdbStorageMissReloadCooldownConfigPath)
 }
 
 // init 初始化，通过 eventBus 加载配置读取前和读取后操作

--- a/pkg/unify-query/service/tsdb/service.go
+++ b/pkg/unify-query/service/tsdb/service.go
@@ -53,6 +53,10 @@ func (s *Service) Reload(ctx context.Context) {
 	s.ctx, s.cancelFunc = context.WithCancel(ctx)
 	log.Debugf(context.TODO(), "prometheus service context update success.")
 
+	inner.ReloadStorageFromConsul = func(context.Context) error {
+		return s.reloadStorage()
+	}
+
 	err = s.loopReloadStorage(s.ctx)
 	if err != nil {
 		log.Errorf(context.TODO(), "prometheus service close success")

--- a/pkg/unify-query/service/tsdb/service.go
+++ b/pkg/unify-query/service/tsdb/service.go
@@ -53,9 +53,7 @@ func (s *Service) Reload(ctx context.Context) {
 	s.ctx, s.cancelFunc = context.WithCancel(ctx)
 	log.Debugf(context.TODO(), "prometheus service context update success.")
 
-	inner.ReloadStorageFromConsul = func(context.Context) error {
-		return s.reloadStorage()
-	}
+	inner.ReloadStorageFromConsul = s.reloadStorage
 
 	err = s.loopReloadStorage(s.ctx)
 	if err != nil {

--- a/pkg/unify-query/service/tsdb/service.go
+++ b/pkg/unify-query/service/tsdb/service.go
@@ -53,7 +53,7 @@ func (s *Service) Reload(ctx context.Context) {
 	s.ctx, s.cancelFunc = context.WithCancel(ctx)
 	log.Debugf(context.TODO(), "prometheus service context update success.")
 
-	inner.SetStorageMissReloadFunc(s.reloadStorage)
+	inner.SetStorageMissReloadStrategy(inner.NewCooldownStorageMissReloadStrategy(StorageMissReloadCooldown, s.reloadStorage))
 
 	err = s.loopReloadStorage(s.ctx)
 	if err != nil {

--- a/pkg/unify-query/service/tsdb/service.go
+++ b/pkg/unify-query/service/tsdb/service.go
@@ -53,7 +53,7 @@ func (s *Service) Reload(ctx context.Context) {
 	s.ctx, s.cancelFunc = context.WithCancel(ctx)
 	log.Debugf(context.TODO(), "prometheus service context update success.")
 
-	inner.ReloadStorageFromConsul = s.reloadStorage
+	inner.SetStorageMissReloadFunc(s.reloadStorage)
 
 	err = s.loopReloadStorage(s.ctx)
 	if err != nil {

--- a/pkg/unify-query/service/tsdb/service.go
+++ b/pkg/unify-query/service/tsdb/service.go
@@ -53,7 +53,7 @@ func (s *Service) Reload(ctx context.Context) {
 	s.ctx, s.cancelFunc = context.WithCancel(ctx)
 	log.Debugf(context.TODO(), "prometheus service context update success.")
 
-	inner.SetStorageMissReloadStrategy(inner.NewCooldownStorageMissReloadStrategy(StorageMissReloadCooldown, s.reloadStorage))
+	inner.SetStorageMissReload(StorageMissReloadCooldown, s.reloadStorage)
 
 	err = s.loopReloadStorage(s.ctx)
 	if err != nil {

--- a/pkg/unify-query/service/tsdb/settings.go
+++ b/pkg/unify-query/service/tsdb/settings.go
@@ -95,4 +95,7 @@ var (
 	EsMaxSize    int
 
 	QueryRouterForceVmClusterName string
+
+	// StorageMissReloadCooldown GetStorage miss 后触发 Consul 刷新的最短间隔，由 initConfig 从 viper 读取
+	StorageMissReloadCooldown time.Duration
 )

--- a/pkg/unify-query/service/tsdb/settings.go
+++ b/pkg/unify-query/service/tsdb/settings.go
@@ -53,6 +53,9 @@ const (
 
 	// query router 配置
 	QueryRouterForceVmClusterNameConfigPath = "query_router.force_vm_cluster_name"
+
+	// TsdbStorageMissReloadCooldownConfigPath GetStorage miss 后触发 Consul 刷新的最短间隔（节流）。
+	TsdbStorageMissReloadCooldownConfigPath = "tsdb.storage_miss_reload_cooldown"
 )
 
 var (

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -56,14 +56,9 @@ func newCooldownStorageMissReloadStrategy(cooldown time.Duration, reloadFn func(
 	return s
 }
 
-// SetStorageMissReloadCooldown 由配置加载逻辑调用（如 service/tsdb hook）。d<=0 时回退为 defaultStorageMissReloadCooldown。
-func SetStorageMissReloadCooldown(d time.Duration) {
-	defaultStorageMissReloadStrategy.SetCooldown(d)
-}
-
-// SetStorageMissReloadFunc 由上层服务注入 reload 实现。
-func SetStorageMissReloadFunc(reloadFn func() error) {
-	defaultStorageMissReloadStrategy.SetReloadFunc(reloadFn)
+// NewCooldownStorageMissReloadStrategy 构造默认的 miss reload 策略：cooldown 节流 + singleflight 合并，由 service 层在启动/Reload 时通过 SetStorageMissReloadStrategy 注入。
+func NewCooldownStorageMissReloadStrategy(cooldown time.Duration, reloadFn func() error) StorageMissReloadStrategy {
+	return newCooldownStorageMissReloadStrategy(cooldown, reloadFn)
 }
 
 func (s *cooldownStorageMissReloadStrategy) cooldown() time.Duration {
@@ -169,7 +164,7 @@ var (
 	storageMapHash string
 	storageLock    = new(sync.RWMutex)
 
-	// 默认策略用于当前全局 storage map 模式下的 miss reload，可被测试或上层注入替换。
+	// 默认策略：未注入时作为 noop 占位（reloadFn 为 nil），等 service 层在 Reload 中通过 ，SetStorageMissReloadStrategy 注入真实的 cooldown + reloadFn 实现。
 	defaultStorageMissReloadStrategy = newCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, nil)
 	storageMissReloadStrategyLock    sync.RWMutex
 	storageMissReloadStrategy        StorageMissReloadStrategy = defaultStorageMissReloadStrategy

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -33,95 +33,48 @@ const defaultStorageMissReloadCooldown = 10 * time.Minute
 // missReloadSingleflightKey：所有 miss 刷新共享同一 singleflight key，用于合并并发请求
 const storageMissReloadSingleflightKey = "tsdb-storage-miss-reload"
 
-// StorageMissReloadStrategy 负责在 GetStorage miss 后按策略触发 reload
-type StorageMissReloadStrategy interface {
-	ReloadAfterMiss(ctx context.Context, storageID string)
+// ReloadStrategyWithCooldown 通用的"按 cooldown 节流 + singleflight 合并执行 reloadFn"策略。
+type ReloadStrategyWithCooldown interface {
+	Reload(ctx context.Context, cooldown time.Duration, reloadFn func() error)
 }
 
-// cooldownStorageMissReloadStrategy 将 miss 后的 reload 合并为单次执行，并限制最小触发间隔。
-type cooldownStorageMissReloadStrategy struct {
-	cooldownNanos atomic.Int64
-	lastAttempt   atomic.Int64
-	group         singleflight.Group
-
-	// reloadFn 运行时可被 service 层替换，因此通过读写锁保护热路径读取。
-	reloadFnLock sync.RWMutex
-	reloadFn     func() error
+// cooldownReloadStrategy 用 cooldown 节流 + singleflight 合并并发请求： 每次 Reload 的 cooldown / reloadFn 由调用方传入，strategy 自身只持有运行时态
+type cooldownReloadStrategy struct {
+	lastAttempt atomic.Int64
+	group       singleflight.Group
 }
 
-func newCooldownStorageMissReloadStrategy(cooldown time.Duration, reloadFn func() error) *cooldownStorageMissReloadStrategy {
-	s := &cooldownStorageMissReloadStrategy{}
-	s.SetCooldown(cooldown)
-	s.SetReloadFunc(reloadFn)
-	return s
+func newCooldownReloadStrategy() *cooldownReloadStrategy {
+	return &cooldownReloadStrategy{}
 }
 
-// NewCooldownStorageMissReloadStrategy 构造默认的 miss reload 策略：cooldown 节流 + singleflight 合并，由 service 层在启动/Reload 时通过 SetStorageMissReloadStrategy 注入。
-func NewCooldownStorageMissReloadStrategy(cooldown time.Duration, reloadFn func() error) StorageMissReloadStrategy {
-	return newCooldownStorageMissReloadStrategy(cooldown, reloadFn)
-}
-
-func (s *cooldownStorageMissReloadStrategy) cooldown() time.Duration {
-	n := s.cooldownNanos.Load()
-	if n <= 0 {
-		return defaultStorageMissReloadCooldown
-	}
-	return time.Duration(n)
-}
-
-func (s *cooldownStorageMissReloadStrategy) SetCooldown(d time.Duration) {
-	if d <= 0 {
-		d = defaultStorageMissReloadCooldown
-	}
-	s.cooldownNanos.Store(int64(d))
-}
-
-func (s *cooldownStorageMissReloadStrategy) SetReloadFunc(reloadFn func() error) {
-	s.reloadFnLock.Lock()
-	defer s.reloadFnLock.Unlock()
-	s.reloadFn = reloadFn
-}
-
-func (s *cooldownStorageMissReloadStrategy) getReloadFunc() func() error {
-	s.reloadFnLock.RLock()
-	defer s.reloadFnLock.RUnlock()
-	return s.reloadFn
-}
-
-func (s *cooldownStorageMissReloadStrategy) ReloadAfterMiss(logCtx context.Context, storageID string) {
-	reloadFn := s.getReloadFunc()
+func (s *cooldownReloadStrategy) Reload(ctx context.Context, cooldown time.Duration, reloadFn func() error) {
 	if reloadFn == nil {
-		log.Errorf(logCtx, "tsdb storage miss reload func not set")
+		log.Errorf(ctx, "tsdb storage miss reload func not set")
 		return
+	}
+	if cooldown <= 0 {
+		cooldown = defaultStorageMissReloadCooldown
 	}
 
 	_, _, _ = s.group.Do(storageMissReloadSingleflightKey, func() (interface{}, error) {
 		now := time.Now()
 		lastNano := s.lastAttempt.Load()
 		// 先判断冷却窗口；只有真正允许发起 reload 时才更新时间戳。
-		if lastNano != 0 && now.Sub(time.Unix(0, lastNano)) < s.cooldown() {
-			log.Infof(logCtx, "tsdb storage miss reload cooldown: %v", s.cooldown())
+		if lastNano != 0 && now.Sub(time.Unix(0, lastNano)) < cooldown {
+			log.Infof(ctx, "tsdb storage miss reload cooldown: %v", cooldown)
 			return nil, nil
 		}
 
 		s.lastAttempt.Store(now.UnixNano())
-		// 只有真正进入 reload 执行窗口时才读取并打印当前 Consul 里的 storage id 列表,cooldown 跳过和并发不会重复打这条日志
-		logReloadStorageMissWithConsulIDs(logCtx, storageID)
-
-		// singleflight 保证并发 miss 只会有一个 goroutine 实际执行 reloadFn。
-		if err := reloadFn(); err != nil {
-			log.Infof(logCtx, "tsdb storage miss reload from consul failed: requested_storage_id=%s reload_err=%v", storageID, err)
-			return nil, err
-		}
-		return nil, nil
+		// singleflight 保证并发场景下只有一个 goroutine 实际执行 reloadFn。
+		return nil, reloadFn()
 	})
 }
 
 // resetForTest 用于测试重置状态
-func (s *cooldownStorageMissReloadStrategy) resetForTest() {
+func (s *cooldownReloadStrategy) resetForTest() {
 	s.lastAttempt.Store(0)
-	s.SetCooldown(defaultStorageMissReloadCooldown)
-	s.SetReloadFunc(nil)
 	s.group.Forget(storageMissReloadSingleflightKey)
 }
 
@@ -149,12 +102,9 @@ func loadConsulStorageIDs() (ids []string, err error) {
 func logReloadStorageMissWithConsulIDs(ctx context.Context, storageID string) {
 	ids, err := loadConsulStorageIDs()
 	if err != nil {
-		// 记录“本次 reload 触发时无法读取 Consul 列表”，但不影响后续 reload 尝试本身。
-		log.Infof(ctx, "tsdb storage miss reload trigger: requested_storage_id=%s consul_storage_ids_err=%v",
-			storageID, err)
+		log.Errorf(ctx, "load consul storage ids failed: %v", err)
 		return
 	}
-
 	log.Infof(ctx, "tsdb storage miss reload trigger: requested_storage_id=%s consul_storage_ids=%v",
 		storageID, ids)
 }
@@ -164,15 +114,22 @@ var (
 	storageMapHash string
 	storageLock    = new(sync.RWMutex)
 
-	// 默认策略：未注入时作为 noop 占位（reloadFn 为 nil），等 service 层在 Reload 中通过 ，SetStorageMissReloadStrategy 注入真实的 cooldown + reloadFn 实现。
-	defaultStorageMissReloadStrategy = newCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, nil)
+	// 默认策略：通用 cooldown + singleflight 实现；service 层未注入 cooldown / reloadFn 之前，Reload 内会因 reloadFn==nil 走 noop 分支。
+	defaultStorageMissReloadStrategy = newCooldownReloadStrategy()
 	storageMissReloadStrategyLock    sync.RWMutex
-	storageMissReloadStrategy        StorageMissReloadStrategy = defaultStorageMissReloadStrategy
-	getTsDBStorageInfo                                         = consul.GetTsDBStorageInfo
+	storageMissReloadStrategy        ReloadStrategyWithCooldown = defaultStorageMissReloadStrategy
+	getTsDBStorageInfo                                          = consul.GetTsDBStorageInfo
+
+	// 包级配置：cooldown + reloadFn，由 service 层在启动 / Reload 时通过 SetStorageMissReload 注入。
+	storageMissReloadCfgLock sync.RWMutex
+	storageMissReloadCfg     struct {
+		cooldown time.Duration
+		reloadFn func() error
+	}
 )
 
 // SetStorageMissReloadStrategy 设置 GetStorage miss 时使用的 reload 策略；nil 时回退默认实现。
-func SetStorageMissReloadStrategy(strategy StorageMissReloadStrategy) {
+func SetStorageMissReloadStrategy(strategy ReloadStrategyWithCooldown) {
 	if strategy == nil {
 		strategy = defaultStorageMissReloadStrategy
 	}
@@ -181,10 +138,24 @@ func SetStorageMissReloadStrategy(strategy StorageMissReloadStrategy) {
 	storageMissReloadStrategy = strategy
 }
 
-func getStorageMissReloadStrategy() StorageMissReloadStrategy {
+func getStorageMissReloadStrategy() ReloadStrategyWithCooldown {
 	storageMissReloadStrategyLock.RLock()
 	defer storageMissReloadStrategyLock.RUnlock()
 	return storageMissReloadStrategy
+}
+
+// SetStorageMissReload 由 service 层调用，决定 GetStorage miss 时使用的 cooldown 与 reloadFn。
+func SetStorageMissReload(cooldown time.Duration, reloadFn func() error) {
+	storageMissReloadCfgLock.Lock()
+	defer storageMissReloadCfgLock.Unlock()
+	storageMissReloadCfg.cooldown = cooldown
+	storageMissReloadCfg.reloadFn = reloadFn
+}
+
+func getStorageMissReloadConfig() (time.Duration, func() error) {
+	storageMissReloadCfgLock.RLock()
+	defer storageMissReloadCfgLock.RUnlock()
+	return storageMissReloadCfg.cooldown, storageMissReloadCfg.reloadFn
 }
 
 // StorageMapHash 返回最近一次 ReloadTsDBStorage 写入的配置哈希（与 Consul 侧 hash 比对用于短路 reload）
@@ -286,10 +257,22 @@ func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 		return storage, nil
 	}
 	// 3.如果获取失败，从 Consul 中获取 Storage
-	// miss 后交给策略对象处理 reload；默认实现会做 singleflight 合并、cooldown 节流并在真正触发 reload 时打印当前 Consul 中实际存在的 storage id 列表。
+	// miss 后交给策略对象处理 reload；默认实现会做 singleflight 合并、cooldown 节流。
 	var err error
 
-	getStorageMissReloadStrategy().ReloadAfterMiss(ctx, storageID)
+	cooldown, baseReloadFn := getStorageMissReloadConfig()
+	var reloadFn func() error
+	if baseReloadFn != nil {
+		reloadFn = func() error {
+			logReloadStorageMissWithConsulIDs(ctx, storageID)
+			err := baseReloadFn()
+			if err != nil {
+				log.Errorf(ctx, "tsdb storage miss reload from consul failed: requested_storage_id=%s reload_err=%v", storageID, err)
+			}
+			return err
+		}
+	}
+	getStorageMissReloadStrategy().Reload(ctx, cooldown, reloadFn)
 
 	// 4.如果第二次获取成功，则返回 Storage
 	storageLock.RLock()

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -100,7 +100,7 @@ func (s *cooldownStorageMissReloadStrategy) ReloadAfterMiss(logCtx context.Conte
 		lastNano := s.lastAttempt.Load()
 		// 先判断冷却窗口；只有真正允许发起 reload 时才更新时间戳。
 		if lastNano != 0 && now.Sub(time.Unix(0, lastNano)) < s.cooldown() {
-			log.Errorf(logCtx, "tsdb storage miss reload cooldown: %v", s.cooldown())
+			log.Infof(logCtx, "tsdb storage miss reload cooldown: %v", s.cooldown())
 			return nil, nil
 		}
 

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/consul"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metric"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
 )
 
@@ -164,6 +165,7 @@ func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 	storageLock.RUnlock()
 	// 2.如果获取成功，则返回 Storage
 	if ok {
+		metric.TsDBGetStorageInc(ctx, metric.StorageResultHit)
 		return storage, nil
 	}
 	// 3.如果获取失败，从 Consul 中获取 Storage
@@ -184,9 +186,11 @@ func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 	storageLock.RUnlock()
 
 	if ok {
+		metric.TsDBGetStorageInc(ctx, metric.StorageResultHitAfterReload)
 		return storage, nil
 	}
 	// 5.如果第二次获取失败，则返回错误 span中打印storage_id、storage_hash、storage_hash_after_reload
+	metric.TsDBGetStorageInc(ctx, metric.StorageResultMiss)
 	span.Set("storage_id", storageID)
 	span.Set("storage_hash", hashBeforeMiss)
 	span.Set("storage_hash_after_reload", hashAfterReload)

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -16,6 +16,9 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/consul"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
@@ -23,14 +26,44 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
 )
 
+// defaultStorageMissReloadCooldown：配置未加载或未设置时的默认最短刷新间隔。
+const defaultStorageMissReloadCooldown = 10 * time.Minute
+
+// storageMissReloadCooldownNanos：GetStorage miss 触发 Consul 刷新的最短间隔（纳秒），运行时由 SetStorageMissReloadCooldown 写入。
+var storageMissReloadCooldownNanos atomic.Int64
+
+func init() {
+	storageMissReloadCooldownNanos.Store(int64(defaultStorageMissReloadCooldown))
+}
+
+// SetStorageMissReloadCooldown 由配置加载逻辑调用（如 service/tsdb hook）。d<=0 时回退为 defaultStorageMissReloadCooldown。
+func SetStorageMissReloadCooldown(d time.Duration) {
+	if d <= 0 {
+		d = defaultStorageMissReloadCooldown
+	}
+	storageMissReloadCooldownNanos.Store(int64(d))
+}
+
+func storageMissReloadCooldown() time.Duration {
+	n := storageMissReloadCooldownNanos.Load()
+	if n <= 0 {
+		return defaultStorageMissReloadCooldown
+	}
+	return time.Duration(n)
+}
+
 var (
 	storageMap     = make(map[string]*Storage)
 	storageMapHash string
 	storageLock    = new(sync.RWMutex)
 
-	// getStorageKeysLogPending：本次 Reload 之后是否还需要打「首次命中」的全量 keys 诊断日志。
-	// Reload 成功替换 storageMap 后置为 true；任意一次成功 GetStorage 通过 CAS 消费掉该标记，或 miss 时直接置 false。
-	getStorageKeysLogPending atomic.Bool
+	storageMissReloadGroup singleflight.Group
+
+	// lastMissReloadAttemptUnixNano：上一次 miss 路径实际发起 ReloadStorageFromConsul 尝试的时间（Unix 纳秒）。
+	lastMissReloadAttemptUnixNano atomic.Int64
+
+	// ReloadStorageFromConsul 由上层（如 prometheus tsdb Service）注入；miss 时在释放读锁后按需调用
+	ReloadStorageFromConsul func(context.Context) error
 )
 
 // StorageMapHash 返回最近一次 ReloadTsDBStorage 写入的配置哈希（与 Consul 侧 hash 比对用于短路 reload）
@@ -83,7 +116,7 @@ func ReloadTsDBStorage(ctx context.Context, hash string, tsDBs map[string]*consu
 	for k := range newStorageMap {
 		newKeys = append(newKeys, k)
 	}
-	// 与 storageMapKeysLocked 一致：按 storage ID 数值升序，便于日志对照。
+	// 与 storage map key 排序一致：按 storage ID 数值升序，便于日志对照
 	sortStorageIDKeysAsc(newKeys)
 
 	span.Set("old_hash", oldHash)
@@ -96,8 +129,6 @@ func ReloadTsDBStorage(ctx context.Context, hash string, tsDBs map[string]*consu
 
 	storageMap = newStorageMap
 	storageMapHash = hash
-	// 新 map 生效后允许再一次「首次成功 GetStorage」附带全量 map_keys，便于对照重载后的内存视图。
-	getStorageKeysLogPending.Store(true)
 
 	// oldHash 为空表示进程内首次写入，会打初始化日志；否则视为配置变更后的重载。
 	if oldHash == "" {
@@ -123,43 +154,40 @@ func Print() string {
 }
 
 // GetStorage 从内存 map 按 storageID 取 Storage。
-// 诊断日志（遍历全表 keys、metadata.Info）仅在两类场景打出，避免热路径每条请求扫 map：
-//   - miss：便于核对请求的 ID 与当前内存中的 ID 列表；
-//   - 本次 Reload 之后第一次成功命中：CompareAndSwap 保证全进程仅一次。
-//
-// 其余成功命中只写 span 的 storage_id、storage_hash。
+// 命中不写 span 属性。miss 时在释放读锁后通过 ReloadStorageAfterMiss（singleflight + 可配置冷却，键 tsdb.storage_miss_reload_cooldown）尝试触发上层 Consul 刷新，再二次查找；
+// 仍失败则 span/metadata 携带首次 miss 时内存 hash（storage_hash，兼容旧语义）与二次查找时刻内存 hash（storage_hash_after_reload），以及 storage_id；不带 map_keys。
 func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 	var err error
 	ctx, span := trace.NewSpan(ctx, "get-tsdb-storage")
 	defer span.End(&err)
 
 	storageLock.RLock()
-	defer storageLock.RUnlock()
+	storage, ok := storageMap[storageID]
+	hashBeforeMiss := storageMapHash
+	storageLock.RUnlock()
+
+	if ok {
+		return storage, nil
+	}
+
+	ReloadStorageAfterMiss(ctx)
+
+	storageLock.RLock()
+	storage, ok = storageMap[storageID]
+	hashAfterReload := storageMapHash
+	storageLock.RUnlock()
+
+	if ok {
+		return storage, nil
+	}
 
 	span.Set("storage_id", storageID)
-	span.Set("storage_hash", storageMapHash)
-
-	storage, ok := storageMap[storageID]
-	if !ok {
-		// miss：始终打全量 keys；并取消「首次命中」待打标记，避免紧接着的成功请求再打一份全量 keys。
-		keys := storageMapKeysLocked()
-		span.Set("storage_keys", fmt.Sprintf("%v", keys))
-		getStorageKeysLogPending.Store(false)
-		metadata.NewMessage("tsdb_storage", "get storage miss: id=%s hash=%s map_keys=%v",
-			storageID, storageMapHash, keys).Info(ctx)
-		err = fmt.Errorf("%s: storageID: %s", ErrStorageNotFound, storageID)
-		return nil, err
-	}
-
-	// 仅当 pending 仍为 true 时进入：原子地从 true 翻成 false，保证多 goroutine 下只有一次会打「重载后首次命中」全量 keys。
-	if getStorageKeysLogPending.CompareAndSwap(true, false) {
-		keys := storageMapKeysLocked()
-		span.Set("storage_keys", fmt.Sprintf("%v", keys))
-		metadata.NewMessage("tsdb_storage", "get storage: id=%s hash=%s map_keys=%v",
-			storageID, storageMapHash, keys).Info(ctx)
-	}
-
-	return storage, nil
+	span.Set("storage_hash", hashBeforeMiss)
+	span.Set("storage_hash_after_reload", hashAfterReload)
+	metadata.NewMessage("tsdb_storage", "get storage miss: id=%s hash_before=%s hash_after=%s",
+		storageID, hashBeforeMiss, hashAfterReload).Info(ctx)
+	err = fmt.Errorf("%s: storageID: %s", ErrStorageNotFound, storageID)
+	return nil, err
 }
 
 // SetStorage 写入实例到内存去
@@ -168,16 +196,6 @@ func SetStorage(storageID string, storage *Storage) {
 	defer storageLock.Unlock()
 
 	storageMap[storageID] = storage
-}
-
-// storageMapKeysLocked 复制当前 storageMap 的全部 key，调用方须已持有 storageLock 读锁或写锁。
-func storageMapKeysLocked() []string {
-	keys := make([]string, 0, len(storageMap))
-	for k := range storageMap {
-		keys = append(keys, k)
-	}
-	sortStorageIDKeysAsc(keys)
-	return keys
 }
 
 // sortStorageIDKeysAsc 按 storage ID 的数值升序排列（ID 为十进制整数字符串时）。
@@ -190,5 +208,25 @@ func sortStorageIDKeysAsc(keys []string) {
 			return ai < aj
 		}
 		return keys[i] < keys[j]
+	})
+}
+
+// ReloadStorageAfterMiss 在 GetStorage miss 路径调用：合并并发（singleflight）、并按 storageMissReloadCooldown() 节流对 Consul 的刷新尝试。
+func ReloadStorageAfterMiss(ctx context.Context) {
+	reloadFn := ReloadStorageFromConsul
+	if reloadFn == nil {
+		return
+	}
+	_, _, _ = storageMissReloadGroup.Do("tsdb-storage-miss-reload", func() (interface{}, error) {
+		now := time.Now()
+		lastNano := lastMissReloadAttemptUnixNano.Load()
+		if lastNano != 0 {
+			if now.Sub(time.Unix(0, lastNano)) < storageMissReloadCooldown() {
+				return nil, nil
+			}
+		}
+		lastMissReloadAttemptUnixNano.Store(now.UnixNano())
+		_ = reloadFn(ctx)
+		return nil, nil
 	})
 }

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -96,7 +96,7 @@ func (s *cooldownStorageMissReloadStrategy) getReloadFunc() func() error {
 func (s *cooldownStorageMissReloadStrategy) ReloadAfterMiss(logCtx context.Context, storageID string) {
 	reloadFn := s.getReloadFunc()
 	if reloadFn == nil {
-		log.Infof(logCtx, "tsdb storage miss reload func not set")
+		log.Errorf(logCtx, "tsdb storage miss reload func not set")
 		return
 	}
 
@@ -105,7 +105,7 @@ func (s *cooldownStorageMissReloadStrategy) ReloadAfterMiss(logCtx context.Conte
 		lastNano := s.lastAttempt.Load()
 		// 先判断冷却窗口；只有真正允许发起 reload 时才更新时间戳。
 		if lastNano != 0 && now.Sub(time.Unix(0, lastNano)) < s.cooldown() {
-			log.Infof(logCtx, "tsdb storage miss reload cooldown: %v", s.cooldown())
+			log.Errorf(logCtx, "tsdb storage miss reload cooldown: %v", s.cooldown())
 			return nil, nil
 		}
 

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -27,32 +27,141 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
 )
 
-// defaultStorageMissReloadCooldown：配置未加载或未设置时的默认最短刷新间隔。
+// defaultStorageMissReloadCooldown：配置未加载或未设置时的默认最短刷新间隔
 const defaultStorageMissReloadCooldown = 10 * time.Minute
 
+// missReloadSingleflightKey：所有 miss 刷新共享同一 singleflight key，用于合并并发请求
 const storageMissReloadSingleflightKey = "tsdb-storage-miss-reload"
 
-// storageMissReloadCooldownNanos：GetStorage miss 触发 Consul 刷新的最短间隔（纳秒），运行时由 SetStorageMissReloadCooldown 写入。
-var storageMissReloadCooldownNanos atomic.Int64
+// StorageMissReloadStrategy 负责在 GetStorage miss 后按策略触发 reload
+type StorageMissReloadStrategy interface {
+	ReloadAfterMiss(ctx context.Context, storageID string)
+}
 
-func init() {
-	storageMissReloadCooldownNanos.Store(int64(defaultStorageMissReloadCooldown))
+// cooldownStorageMissReloadStrategy 将 miss 后的 reload 合并为单次执行，并限制最小触发间隔。
+type cooldownStorageMissReloadStrategy struct {
+	cooldownNanos atomic.Int64
+	lastAttempt   atomic.Int64
+	group         singleflight.Group
+
+	// reloadFn 运行时可被 service 层替换，因此通过读写锁保护热路径读取。
+	reloadFnLock sync.RWMutex
+	reloadFn     func() error
+}
+
+func newCooldownStorageMissReloadStrategy(cooldown time.Duration, reloadFn func() error) *cooldownStorageMissReloadStrategy {
+	s := &cooldownStorageMissReloadStrategy{}
+	s.SetCooldown(cooldown)
+	s.SetReloadFunc(reloadFn)
+	return s
 }
 
 // SetStorageMissReloadCooldown 由配置加载逻辑调用（如 service/tsdb hook）。d<=0 时回退为 defaultStorageMissReloadCooldown。
 func SetStorageMissReloadCooldown(d time.Duration) {
-	if d <= 0 {
-		d = defaultStorageMissReloadCooldown
-	}
-	storageMissReloadCooldownNanos.Store(int64(d))
+	defaultStorageMissReloadStrategy.SetCooldown(d)
 }
 
-func storageMissReloadCooldown() time.Duration {
-	n := storageMissReloadCooldownNanos.Load()
+// SetStorageMissReloadFunc 由上层服务注入 reload 实现。
+func SetStorageMissReloadFunc(reloadFn func() error) {
+	defaultStorageMissReloadStrategy.SetReloadFunc(reloadFn)
+}
+
+func (s *cooldownStorageMissReloadStrategy) cooldown() time.Duration {
+	n := s.cooldownNanos.Load()
 	if n <= 0 {
 		return defaultStorageMissReloadCooldown
 	}
 	return time.Duration(n)
+}
+
+func (s *cooldownStorageMissReloadStrategy) SetCooldown(d time.Duration) {
+	if d <= 0 {
+		d = defaultStorageMissReloadCooldown
+	}
+	s.cooldownNanos.Store(int64(d))
+}
+
+func (s *cooldownStorageMissReloadStrategy) SetReloadFunc(reloadFn func() error) {
+	s.reloadFnLock.Lock()
+	defer s.reloadFnLock.Unlock()
+	s.reloadFn = reloadFn
+}
+
+func (s *cooldownStorageMissReloadStrategy) getReloadFunc() func() error {
+	s.reloadFnLock.RLock()
+	defer s.reloadFnLock.RUnlock()
+	return s.reloadFn
+}
+
+func (s *cooldownStorageMissReloadStrategy) ReloadAfterMiss(logCtx context.Context, storageID string) {
+	reloadFn := s.getReloadFunc()
+	if reloadFn == nil {
+		log.Infof(logCtx, "tsdb storage miss reload func not set")
+		return
+	}
+
+	_, _, _ = s.group.Do(storageMissReloadSingleflightKey, func() (interface{}, error) {
+		now := time.Now()
+		lastNano := s.lastAttempt.Load()
+		// 先判断冷却窗口；只有真正允许发起 reload 时才更新时间戳。
+		if lastNano != 0 && now.Sub(time.Unix(0, lastNano)) < s.cooldown() {
+			log.Infof(logCtx, "tsdb storage miss reload cooldown: %v", s.cooldown())
+			return nil, nil
+		}
+
+		s.lastAttempt.Store(now.UnixNano())
+		// 只有真正进入 reload 执行窗口时才读取并打印当前 Consul 里的 storage id 列表,cooldown 跳过和并发不会重复打这条日志
+		logReloadStorageMissWithConsulIDs(logCtx, storageID)
+
+		// singleflight 保证并发 miss 只会有一个 goroutine 实际执行 reloadFn。
+		if err := reloadFn(); err != nil {
+			log.Infof(logCtx, "tsdb storage miss reload from consul failed: requested_storage_id=%s reload_err=%v", storageID, err)
+			return nil, err
+		}
+		return nil, nil
+	})
+}
+
+// resetForTest 用于测试重置状态
+func (s *cooldownStorageMissReloadStrategy) resetForTest() {
+	s.lastAttempt.Store(0)
+	s.SetCooldown(defaultStorageMissReloadCooldown)
+	s.SetReloadFunc(nil)
+	s.group.Forget(storageMissReloadSingleflightKey)
+}
+
+func loadConsulStorageIDs() (ids []string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Consul 实例未初始化等异常场景下，失败日志不能再因为取 ids 而 panic。
+			err = fmt.Errorf("load consul storage ids panic: %v", r)
+		}
+	}()
+
+	storages, err := getTsDBStorageInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	ids = make([]string, 0, len(storages))
+	for storageID := range storages {
+		ids = append(ids, storageID)
+	}
+	sortStorageIDKeysAsc(ids)
+	return ids, nil
+}
+
+func logReloadStorageMissWithConsulIDs(ctx context.Context, storageID string) {
+	ids, err := loadConsulStorageIDs()
+	if err != nil {
+		// 记录“本次 reload 触发时无法读取 Consul 列表”，但不影响后续 reload 尝试本身。
+		log.Infof(ctx, "tsdb storage miss reload trigger: requested_storage_id=%s consul_storage_ids_err=%v",
+			storageID, err)
+		return
+	}
+
+	log.Infof(ctx, "tsdb storage miss reload trigger: requested_storage_id=%s consul_storage_ids=%v",
+		storageID, ids)
 }
 
 var (
@@ -60,14 +169,28 @@ var (
 	storageMapHash string
 	storageLock    = new(sync.RWMutex)
 
-	storageMissReloadGroup singleflight.Group
-
-	// lastMissReloadAttemptUnixNano：上一次 miss 路径实际发起 ReloadStorageFromConsul 尝试的时间（Unix 纳秒）。
-	lastMissReloadAttemptUnixNano atomic.Int64
-
-	// ReloadStorageFromConsul 由上层（如 prometheus tsdb Service）注入；miss 时在释放读锁后按需调用
-	ReloadStorageFromConsul func() error
+	// 默认策略用于当前全局 storage map 模式下的 miss reload，可被测试或上层注入替换。
+	defaultStorageMissReloadStrategy = newCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, nil)
+	storageMissReloadStrategyLock    sync.RWMutex
+	storageMissReloadStrategy        StorageMissReloadStrategy = defaultStorageMissReloadStrategy
+	getTsDBStorageInfo                                         = consul.GetTsDBStorageInfo
 )
+
+// SetStorageMissReloadStrategy 设置 GetStorage miss 时使用的 reload 策略；nil 时回退默认实现。
+func SetStorageMissReloadStrategy(strategy StorageMissReloadStrategy) {
+	if strategy == nil {
+		strategy = defaultStorageMissReloadStrategy
+	}
+	storageMissReloadStrategyLock.Lock()
+	defer storageMissReloadStrategyLock.Unlock()
+	storageMissReloadStrategy = strategy
+}
+
+func getStorageMissReloadStrategy() StorageMissReloadStrategy {
+	storageMissReloadStrategyLock.RLock()
+	defer storageMissReloadStrategyLock.RUnlock()
+	return storageMissReloadStrategy
+}
 
 // StorageMapHash 返回最近一次 ReloadTsDBStorage 写入的配置哈希（与 Consul 侧 hash 比对用于短路 reload）
 func StorageMapHash() string {
@@ -161,7 +284,6 @@ func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 	// 1.尝试从内存 map 中获取 Storage
 	storageLock.RLock()
 	storage, ok := storageMap[storageID]
-	hashBeforeMiss := storageMapHash
 	storageLock.RUnlock()
 	// 2.如果获取成功，则返回 Storage
 	if ok {
@@ -169,33 +291,22 @@ func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 		return storage, nil
 	}
 	// 3.如果获取失败，从 Consul 中获取 Storage
-	//   3.1 全局 singleflight 合并并发刷新，singleflight.Group，并发时只请求一次；
-	//   3.2 设置storageMissReloadCooldown 冷却间隔 10min ,避免频繁请求consul, 配置文件写入
-	//   3.3 - 当前时间-上次刷新时间 < storageMissReloadCooldown 则跳过本次 Consul 调用；
-	//       - 当前时间-上次刷新时间 >= storageMissReloadCooldown ,发起从consul刷入内存的尝试 使用 reloadStorage 函数刷新
+	// miss 后交给策略对象处理 reload；默认实现会做 singleflight 合并、cooldown 节流并在真正触发 reload 时打印当前 Consul 中实际存在的 storage id 列表。
 	var err error
-	ctx, span := trace.NewSpan(ctx, "get-tsdb-storage")
-	defer span.End(&err)
 
-	ReloadStorageAfterMiss(ctx)
+	getStorageMissReloadStrategy().ReloadAfterMiss(ctx, storageID)
 
 	// 4.如果第二次获取成功，则返回 Storage
 	storageLock.RLock()
 	storage, ok = storageMap[storageID]
-	hashAfterReload := storageMapHash
 	storageLock.RUnlock()
 
 	if ok {
 		metric.TsDBGetStorageInc(ctx, metric.StorageResultHitAfterReload)
 		return storage, nil
 	}
-	// 5.如果第二次获取失败，则返回错误 span中打印storage_id、storage_hash、storage_hash_after_reload
+	// 5.如果第二次获取失败，则返回错误
 	metric.TsDBGetStorageInc(ctx, metric.StorageResultMiss)
-	span.Set("storage_id", storageID)
-	span.Set("storage_hash", hashBeforeMiss)
-	span.Set("storage_hash_after_reload", hashAfterReload)
-	metadata.NewMessage("tsdb_storage", "get storage miss: id=%s hash_before=%s hash_after=%s",
-		storageID, hashBeforeMiss, hashAfterReload).Info(ctx)
 	err = fmt.Errorf("%s: storageID: %s", ErrStorageNotFound, storageID)
 	return nil, err
 }
@@ -218,29 +329,5 @@ func sortStorageIDKeysAsc(keys []string) {
 			return ai < aj
 		}
 		return keys[i] < keys[j]
-	})
-}
-
-// ReloadStorageAfterMiss 在 GetStorage miss 路径调用：合并并发（singleflight）、并按 storageMissReloadCooldown() 节流对 Consul 的刷新尝试
-func ReloadStorageAfterMiss(logCtx context.Context) {
-	if ReloadStorageFromConsul == nil {
-		return
-	}
-	// 全局 singleflight 合并并发刷新，singleflight.Group，并发时只请求一次
-	_, _, _ = storageMissReloadGroup.Do(storageMissReloadSingleflightKey, func() (interface{}, error) {
-		now := time.Now()
-		lastNano := lastMissReloadAttemptUnixNano.Load()
-		if lastNano != 0 {
-			if now.Sub(time.Unix(0, lastNano)) < storageMissReloadCooldown() {
-				return nil, nil
-			}
-		}
-		lastMissReloadAttemptUnixNano.Store(now.UnixNano())
-		//超过storageMissReloadCooldown ,发起从consul刷入内存
-		if rerr := ReloadStorageFromConsul(); rerr != nil {
-			// logCtx 仅用于刷新失败时的日志
-			log.Warnf(logCtx, "tsdb storage miss reload from consul failed: %v", rerr)
-		}
-		return nil, nil
 	})
 }

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -29,6 +29,8 @@ import (
 // defaultStorageMissReloadCooldown：配置未加载或未设置时的默认最短刷新间隔。
 const defaultStorageMissReloadCooldown = 10 * time.Minute
 
+const storageMissReloadSingleflightKey = "tsdb-storage-miss-reload"
+
 // storageMissReloadCooldownNanos：GetStorage miss 触发 Consul 刷新的最短间隔（纳秒），运行时由 SetStorageMissReloadCooldown 写入。
 var storageMissReloadCooldownNanos atomic.Int64
 
@@ -63,7 +65,7 @@ var (
 	lastMissReloadAttemptUnixNano atomic.Int64
 
 	// ReloadStorageFromConsul 由上层（如 prometheus tsdb Service）注入；miss 时在释放读锁后按需调用
-	ReloadStorageFromConsul func(context.Context) error
+	ReloadStorageFromConsul func() error
 )
 
 // StorageMapHash 返回最近一次 ReloadTsDBStorage 写入的配置哈希（与 Consul 侧 hash 比对用于短路 reload）
@@ -153,25 +155,29 @@ func Print() string {
 	return str
 }
 
-// GetStorage 从内存 map 按 storageID 取 Storage。
-// 命中不写 span 属性。miss 时在释放读锁后通过 ReloadStorageAfterMiss（singleflight + 可配置冷却，键 tsdb.storage_miss_reload_cooldown）尝试触发上层 Consul 刷新，再二次查找；
-// 仍失败则 span/metadata 携带首次 miss 时内存 hash（storage_hash，兼容旧语义）与二次查找时刻内存 hash（storage_hash_after_reload），以及 storage_id；不带 map_keys。
+// GetStorage 从内存 map 按 storageID 取 Storage
 func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
-	var err error
-	ctx, span := trace.NewSpan(ctx, "get-tsdb-storage")
-	defer span.End(&err)
-
+	// 1.尝试从内存 map 中获取 Storage
 	storageLock.RLock()
 	storage, ok := storageMap[storageID]
 	hashBeforeMiss := storageMapHash
 	storageLock.RUnlock()
-
+	// 2.如果获取成功，则返回 Storage
 	if ok {
 		return storage, nil
 	}
+	// 3.如果获取失败，从 Consul 中获取 Storage
+	//   3.1 全局 singleflight 合并并发刷新，singleflight.Group，并发时只请求一次；
+	//   3.2 设置storageMissReloadCooldown 冷却间隔 10min ,避免频繁请求consul, 配置文件写入
+	//   3.3 - 当前时间-上次刷新时间 < storageMissReloadCooldown 则跳过本次 Consul 调用；
+	//       - 当前时间-上次刷新时间 >= storageMissReloadCooldown ,发起从consul刷入内存的尝试 使用 reloadStorage 函数刷新
+	var err error
+	ctx, span := trace.NewSpan(ctx, "get-tsdb-storage")
+	defer span.End(&err)
 
 	ReloadStorageAfterMiss(ctx)
 
+	// 4.如果第二次获取成功，则返回 Storage
 	storageLock.RLock()
 	storage, ok = storageMap[storageID]
 	hashAfterReload := storageMapHash
@@ -180,7 +186,7 @@ func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 	if ok {
 		return storage, nil
 	}
-
+	// 5.如果第二次获取失败，则返回错误 span中打印storage_id、storage_hash、storage_hash_after_reload
 	span.Set("storage_id", storageID)
 	span.Set("storage_hash", hashBeforeMiss)
 	span.Set("storage_hash_after_reload", hashAfterReload)
@@ -211,13 +217,13 @@ func sortStorageIDKeysAsc(keys []string) {
 	})
 }
 
-// ReloadStorageAfterMiss 在 GetStorage miss 路径调用：合并并发（singleflight）、并按 storageMissReloadCooldown() 节流对 Consul 的刷新尝试。
-func ReloadStorageAfterMiss(ctx context.Context) {
-	reloadFn := ReloadStorageFromConsul
-	if reloadFn == nil {
+// ReloadStorageAfterMiss 在 GetStorage miss 路径调用：合并并发（singleflight）、并按 storageMissReloadCooldown() 节流对 Consul 的刷新尝试
+func ReloadStorageAfterMiss(logCtx context.Context) {
+	if ReloadStorageFromConsul == nil {
 		return
 	}
-	_, _, _ = storageMissReloadGroup.Do("tsdb-storage-miss-reload", func() (interface{}, error) {
+	// 全局 singleflight 合并并发刷新，singleflight.Group，并发时只请求一次
+	_, _, _ = storageMissReloadGroup.Do(storageMissReloadSingleflightKey, func() (interface{}, error) {
 		now := time.Now()
 		lastNano := lastMissReloadAttemptUnixNano.Load()
 		if lastNano != 0 {
@@ -226,7 +232,11 @@ func ReloadStorageAfterMiss(ctx context.Context) {
 			}
 		}
 		lastMissReloadAttemptUnixNano.Store(now.UnixNano())
-		_ = reloadFn(ctx)
+		//超过storageMissReloadCooldown ,发起从consul刷入内存
+		if rerr := ReloadStorageFromConsul(); rerr != nil {
+			// logCtx 仅用于刷新失败时的日志
+			log.Warnf(logCtx, "tsdb storage miss reload from consul failed: %v", rerr)
+		}
 		return nil, nil
 	})
 }

--- a/pkg/unify-query/tsdb/storage_test.go
+++ b/pkg/unify-query/tsdb/storage_test.go
@@ -62,10 +62,10 @@ func TestGetStorage_hit_doesNotTriggerReload(t *testing.T) {
 func TestGetStorage_miss_reloadSecondHit(t *testing.T) {
 	resetStorageTestState(t)
 
-	SetStorageMissReloadFunc(func() error {
+	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
 		SetStorage("99", &Storage{Address: "from-reload"})
 		return nil
-	})
+	}))
 	st, err := GetStorage(context.Background(), "99")
 	require.NoError(t, err)
 	require.Equal(t, "from-reload", st.Address)
@@ -76,11 +76,11 @@ func TestGetStorage_missReload_singleflight(t *testing.T) {
 	resetStorageTestState(t)
 	var calls atomic.Int32
 	var wg sync.WaitGroup
-	SetStorageMissReloadFunc(func() error {
+	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
 		calls.Add(1)
 		time.Sleep(20 * time.Millisecond)
 		return nil
-	})
+	}))
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
 		go func() {
@@ -95,12 +95,11 @@ func TestGetStorage_missReload_singleflight(t *testing.T) {
 // TestGetStorage_missReload_cooldown：首次 miss 会触发一次 reload；冷却期内第二次 miss 不再调用 ReloadStorageFromConsul。
 func TestGetStorage_missReload_cooldown(t *testing.T) {
 	resetStorageTestState(t)
-	SetStorageMissReloadCooldown(time.Hour)
 	var calls atomic.Int32
-	SetStorageMissReloadFunc(func() error {
+	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(time.Hour, func() error {
 		calls.Add(1)
 		return nil
-	})
+	}))
 
 	ctx := context.Background()
 	_, err := GetStorage(ctx, "nope")
@@ -115,9 +114,9 @@ func TestGetStorage_missReload_cooldown(t *testing.T) {
 // TestGetStorage_missReload_returnsErrorStillFails：reload 回调返回错误时 GetStorage 仍为 ErrStorageNotFound，且不 panic。
 func TestGetStorage_missReload_returnsErrorStillFails(t *testing.T) {
 	resetStorageTestState(t)
-	SetStorageMissReloadFunc(func() error {
+	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
 		return errors.New("consul down")
-	})
+	}))
 	_, err := GetStorage(context.Background(), "id")
 	require.Error(t, err)
 }
@@ -134,9 +133,9 @@ func TestGetStorage_missReloadFetchesConsulStorageIDs(t *testing.T) {
 			"11": {},
 		}, nil
 	}
-	SetStorageMissReloadFunc(func() error {
+	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
 		return nil
-	})
+	}))
 
 	_, err := GetStorage(context.Background(), "404")
 	require.Error(t, err)
@@ -155,9 +154,9 @@ func TestGetStorage_missReloadFailureStillFetchesConsulStorageIDs(t *testing.T) 
 			"11": {},
 		}, nil
 	}
-	SetStorageMissReloadFunc(func() error {
+	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
 		return errors.New("consul down")
-	})
+	}))
 
 	_, err := GetStorage(context.Background(), "404")
 	require.Error(t, err)

--- a/pkg/unify-query/tsdb/storage_test.go
+++ b/pkg/unify-query/tsdb/storage_test.go
@@ -1,0 +1,157 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package tsdb
+
+// 本文件测试 GetStorage miss 路径：ReloadStorageAfterMiss 的 singleflight、冷却、二次查找及 span 行为。
+// 使用 package tsdb 以便重置包级 storageMap / ReloadStorageFromConsul 等状态。
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// resetStorageTestState 清空内存 map、reload 回调与节流状态，并 Forget singleflight key，避免用例间串扰。
+func resetStorageTestState(t *testing.T) {
+	t.Helper()
+	storageLock.Lock()
+	storageMap = make(map[string]*Storage)
+	storageMapHash = ""
+	storageLock.Unlock()
+	lastMissReloadAttemptUnixNano.Store(0)
+	ReloadStorageFromConsul = nil
+	SetStorageMissReloadCooldown(defaultStorageMissReloadCooldown)
+	storageMissReloadGroup.Forget(storageMissReloadSingleflightKey)
+}
+
+// installTestTracer 注册 TracerProvider + SpanRecorder，用于断言是否创建 get-tsdb-storage span。
+func installTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return rec
+}
+
+// endedSpanNames 返回已结束 span 的名称列表。
+func endedSpanNames(rec *tracetest.SpanRecorder) []string {
+	spans := rec.Ended()
+	names := make([]string, 0, len(spans))
+	for _, s := range spans {
+		names = append(names, s.Name())
+	}
+	return names
+}
+
+// TestGetStorage_hit_doesNotStartSpan：命中热路径不创建 get-tsdb-storage span。
+func TestGetStorage_hit_doesNotStartSpan(t *testing.T) {
+	resetStorageTestState(t)
+	rec := installTestTracer(t)
+
+	SetStorage("1", &Storage{Address: "addr-a"})
+	st, err := GetStorage(context.Background(), "1")
+	require.NoError(t, err)
+	require.Equal(t, "addr-a", st.Address)
+
+	assert.NotContains(t, endedSpanNames(rec), "get-tsdb-storage")
+}
+
+// TestGetStorage_miss_createsSpan：内存 miss 且注入 reload 空操作后仍不存在时，应产生 get-tsdb-storage span。
+func TestGetStorage_miss_createsSpan(t *testing.T) {
+	resetStorageTestState(t)
+	rec := installTestTracer(t)
+
+	ReloadStorageFromConsul = func() error { return nil }
+	_, err := GetStorage(context.Background(), "missing")
+	require.Error(t, err)
+
+	assert.Contains(t, endedSpanNames(rec), "get-tsdb-storage")
+}
+
+// TestGetStorage_miss_reloadSecondHit：miss 触发 ReloadStorageFromConsul 写入 map 后，二次查找应命中。
+func TestGetStorage_miss_reloadSecondHit(t *testing.T) {
+	resetStorageTestState(t)
+	rec := installTestTracer(t)
+
+	ReloadStorageFromConsul = func() error {
+		SetStorage("99", &Storage{Address: "from-reload"})
+		return nil
+	}
+	st, err := GetStorage(context.Background(), "99")
+	require.NoError(t, err)
+	require.Equal(t, "from-reload", st.Address)
+
+	assert.Contains(t, endedSpanNames(rec), "get-tsdb-storage")
+}
+
+// TestGetStorage_missReload_singleflight：并发多次 miss，ReloadStorageFromConsul 在同一刷新窗口内只执行一次。
+func TestGetStorage_missReload_singleflight(t *testing.T) {
+	resetStorageTestState(t)
+	var calls atomic.Int32
+	var wg sync.WaitGroup
+	ReloadStorageFromConsul = func() error {
+		calls.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		return nil
+	}
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = GetStorage(context.Background(), "x")
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int32(1), calls.Load())
+}
+
+// TestGetStorage_missReload_cooldown：首次 miss 会触发一次 reload；冷却期内第二次 miss 不再调用 ReloadStorageFromConsul。
+func TestGetStorage_missReload_cooldown(t *testing.T) {
+	resetStorageTestState(t)
+	SetStorageMissReloadCooldown(time.Hour)
+	var calls atomic.Int32
+	ReloadStorageFromConsul = func() error {
+		calls.Add(1)
+		return nil
+	}
+
+	ctx := context.Background()
+	_, err := GetStorage(ctx, "nope")
+	require.Error(t, err)
+	require.Equal(t, int32(1), calls.Load())
+
+	_, err = GetStorage(ctx, "still-no")
+	require.Error(t, err)
+	require.Equal(t, int32(1), calls.Load(), "within cooldown should not invoke reload again")
+}
+
+// TestGetStorage_missReload_returnsErrorStillFails：reload 回调返回错误时 GetStorage 仍为 ErrStorageNotFound，且不 panic。
+func TestGetStorage_missReload_returnsErrorStillFails(t *testing.T) {
+	resetStorageTestState(t)
+	ReloadStorageFromConsul = func() error {
+		return errors.New("consul down")
+	}
+	_, err := GetStorage(context.Background(), "id")
+	require.Error(t, err)
+}

--- a/pkg/unify-query/tsdb/storage_test.go
+++ b/pkg/unify-query/tsdb/storage_test.go
@@ -9,8 +9,8 @@
 
 package tsdb
 
-// 本文件测试 GetStorage miss 路径：ReloadStorageAfterMiss 的 singleflight、冷却、二次查找及 span 行为。
-// 使用 package tsdb 以便重置包级 storageMap / ReloadStorageFromConsul 等状态。
+// 本文件测试 GetStorage miss 路径和默认 miss-reload 策略。
+// 使用 package tsdb 以便重置包级 storageMap / 默认策略状态。
 
 import (
 	"context"
@@ -20,89 +20,55 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/consul"
 )
 
-// resetStorageTestState 清空内存 map、reload 回调与节流状态，并 Forget singleflight key，避免用例间串扰。
+type stubStorageMissReloadStrategy struct {
+	calls atomic.Int32
+}
+
+func (s *stubStorageMissReloadStrategy) ReloadAfterMiss(context.Context, string) {
+	s.calls.Add(1)
+}
+
+// resetStorageTestState 清空内存 map 和默认策略状态，避免用例间串扰。
 func resetStorageTestState(t *testing.T) {
 	t.Helper()
 	storageLock.Lock()
 	storageMap = make(map[string]*Storage)
 	storageMapHash = ""
 	storageLock.Unlock()
-	lastMissReloadAttemptUnixNano.Store(0)
-	ReloadStorageFromConsul = nil
-	SetStorageMissReloadCooldown(defaultStorageMissReloadCooldown)
-	storageMissReloadGroup.Forget(storageMissReloadSingleflightKey)
+	SetStorageMissReloadStrategy(nil)
+	defaultStorageMissReloadStrategy.resetForTest()
+	getTsDBStorageInfo = consul.GetTsDBStorageInfo
 }
 
-// installTestTracer 注册 TracerProvider + SpanRecorder，用于断言是否创建 get-tsdb-storage span。
-func installTestTracer(t *testing.T) *tracetest.SpanRecorder {
-	t.Helper()
-	rec := tracetest.NewSpanRecorder()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	t.Cleanup(func() {
-		_ = tp.Shutdown(context.Background())
-		otel.SetTracerProvider(prev)
-	})
-	return rec
-}
-
-// endedSpanNames 返回已结束 span 的名称列表。
-func endedSpanNames(rec *tracetest.SpanRecorder) []string {
-	spans := rec.Ended()
-	names := make([]string, 0, len(spans))
-	for _, s := range spans {
-		names = append(names, s.Name())
-	}
-	return names
-}
-
-// TestGetStorage_hit_doesNotStartSpan：命中热路径不创建 get-tsdb-storage span。
-func TestGetStorage_hit_doesNotStartSpan(t *testing.T) {
+// TestGetStorage_hit_doesNotTriggerReload：命中热路径不触发 miss-reload 策略。
+func TestGetStorage_hit_doesNotTriggerReload(t *testing.T) {
 	resetStorageTestState(t)
-	rec := installTestTracer(t)
+	stub := &stubStorageMissReloadStrategy{}
+	SetStorageMissReloadStrategy(stub)
 
 	SetStorage("1", &Storage{Address: "addr-a"})
 	st, err := GetStorage(context.Background(), "1")
 	require.NoError(t, err)
 	require.Equal(t, "addr-a", st.Address)
-
-	assert.NotContains(t, endedSpanNames(rec), "get-tsdb-storage")
-}
-
-// TestGetStorage_miss_createsSpan：内存 miss 且注入 reload 空操作后仍不存在时，应产生 get-tsdb-storage span。
-func TestGetStorage_miss_createsSpan(t *testing.T) {
-	resetStorageTestState(t)
-	rec := installTestTracer(t)
-
-	ReloadStorageFromConsul = func() error { return nil }
-	_, err := GetStorage(context.Background(), "missing")
-	require.Error(t, err)
-
-	assert.Contains(t, endedSpanNames(rec), "get-tsdb-storage")
+	require.Equal(t, int32(0), stub.calls.Load())
 }
 
 // TestGetStorage_miss_reloadSecondHit：miss 触发 ReloadStorageFromConsul 写入 map 后，二次查找应命中。
 func TestGetStorage_miss_reloadSecondHit(t *testing.T) {
 	resetStorageTestState(t)
-	rec := installTestTracer(t)
 
-	ReloadStorageFromConsul = func() error {
+	SetStorageMissReloadFunc(func() error {
 		SetStorage("99", &Storage{Address: "from-reload"})
 		return nil
-	}
+	})
 	st, err := GetStorage(context.Background(), "99")
 	require.NoError(t, err)
 	require.Equal(t, "from-reload", st.Address)
-
-	assert.Contains(t, endedSpanNames(rec), "get-tsdb-storage")
 }
 
 // TestGetStorage_missReload_singleflight：并发多次 miss，ReloadStorageFromConsul 在同一刷新窗口内只执行一次。
@@ -110,11 +76,11 @@ func TestGetStorage_missReload_singleflight(t *testing.T) {
 	resetStorageTestState(t)
 	var calls atomic.Int32
 	var wg sync.WaitGroup
-	ReloadStorageFromConsul = func() error {
+	SetStorageMissReloadFunc(func() error {
 		calls.Add(1)
 		time.Sleep(20 * time.Millisecond)
 		return nil
-	}
+	})
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
 		go func() {
@@ -131,10 +97,10 @@ func TestGetStorage_missReload_cooldown(t *testing.T) {
 	resetStorageTestState(t)
 	SetStorageMissReloadCooldown(time.Hour)
 	var calls atomic.Int32
-	ReloadStorageFromConsul = func() error {
+	SetStorageMissReloadFunc(func() error {
 		calls.Add(1)
 		return nil
-	}
+	})
 
 	ctx := context.Background()
 	_, err := GetStorage(ctx, "nope")
@@ -149,9 +115,115 @@ func TestGetStorage_missReload_cooldown(t *testing.T) {
 // TestGetStorage_missReload_returnsErrorStillFails：reload 回调返回错误时 GetStorage 仍为 ErrStorageNotFound，且不 panic。
 func TestGetStorage_missReload_returnsErrorStillFails(t *testing.T) {
 	resetStorageTestState(t)
-	ReloadStorageFromConsul = func() error {
+	SetStorageMissReloadFunc(func() error {
 		return errors.New("consul down")
-	}
+	})
 	_, err := GetStorage(context.Background(), "id")
 	require.Error(t, err)
+}
+
+func TestGetStorage_missReloadFetchesConsulStorageIDs(t *testing.T) {
+	resetStorageTestState(t)
+	var fetchCalls atomic.Int32
+
+	getTsDBStorageInfo = func() (map[string]*consul.Storage, error) {
+		fetchCalls.Add(1)
+		return map[string]*consul.Storage{
+			"20": {},
+			"3":  {},
+			"11": {},
+		}, nil
+	}
+	SetStorageMissReloadFunc(func() error {
+		return nil
+	})
+
+	_, err := GetStorage(context.Background(), "404")
+	require.Error(t, err)
+	require.Equal(t, int32(1), fetchCalls.Load())
+}
+
+func TestGetStorage_missReloadFailureStillFetchesConsulStorageIDs(t *testing.T) {
+	resetStorageTestState(t)
+	var fetchCalls atomic.Int32
+
+	getTsDBStorageInfo = func() (map[string]*consul.Storage, error) {
+		fetchCalls.Add(1)
+		return map[string]*consul.Storage{
+			"20": {},
+			"3":  {},
+			"11": {},
+		}, nil
+	}
+	SetStorageMissReloadFunc(func() error {
+		return errors.New("consul down")
+	})
+
+	_, err := GetStorage(context.Background(), "404")
+	require.Error(t, err)
+	require.Equal(t, int32(1), fetchCalls.Load())
+}
+
+func TestStorageMissReloadStrategy_nilReloadFuncNoop(t *testing.T) {
+	resetStorageTestState(t)
+	strategy := newCooldownStorageMissReloadStrategy(time.Second, nil)
+
+	strategy.ReloadAfterMiss(context.Background(), "id")
+
+	require.Equal(t, int64(0), strategy.lastAttempt.Load())
+}
+
+func TestStorageMissReloadStrategy_nonPositiveCooldownFallsBackToDefault(t *testing.T) {
+	resetStorageTestState(t)
+	strategy := newCooldownStorageMissReloadStrategy(0, nil)
+
+	require.Equal(t, defaultStorageMissReloadCooldown, strategy.cooldown())
+
+	strategy.SetCooldown(-time.Second)
+	require.Equal(t, defaultStorageMissReloadCooldown, strategy.cooldown())
+}
+
+func TestStorageMissReloadStrategy_settersTakeEffectImmediately(t *testing.T) {
+	resetStorageTestState(t)
+	strategy := newCooldownStorageMissReloadStrategy(time.Hour, nil)
+	var calls atomic.Int32
+
+	strategy.SetReloadFunc(func() error {
+		calls.Add(1)
+		return nil
+	})
+	strategy.ReloadAfterMiss(context.Background(), "id")
+	require.Equal(t, int32(1), calls.Load())
+
+	strategy.SetCooldown(time.Nanosecond)
+	time.Sleep(time.Millisecond)
+	strategy.ReloadAfterMiss(context.Background(), "id")
+	require.Equal(t, int32(2), calls.Load())
+}
+
+func TestLoadConsulStorageIDs_sorted(t *testing.T) {
+	resetStorageTestState(t)
+	getTsDBStorageInfo = func() (map[string]*consul.Storage, error) {
+		return map[string]*consul.Storage{
+			"20": {},
+			"3":  {},
+			"11": {},
+			"a":  {},
+		}, nil
+	}
+
+	ids, err := loadConsulStorageIDs()
+	require.NoError(t, err)
+	require.Equal(t, []string{"3", "11", "20", "a"}, ids)
+}
+
+func TestLoadConsulStorageIDs_returnsError(t *testing.T) {
+	resetStorageTestState(t)
+	getTsDBStorageInfo = func() (map[string]*consul.Storage, error) {
+		return nil, errors.New("consul unavailable")
+	}
+
+	ids, err := loadConsulStorageIDs()
+	require.Error(t, err)
+	require.Nil(t, ids)
 }

--- a/pkg/unify-query/tsdb/storage_test.go
+++ b/pkg/unify-query/tsdb/storage_test.go
@@ -25,15 +25,15 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/consul"
 )
 
-type stubStorageMissReloadStrategy struct {
+type stubReloadStrategy struct {
 	calls atomic.Int32
 }
 
-func (s *stubStorageMissReloadStrategy) ReloadAfterMiss(context.Context, string) {
+func (s *stubReloadStrategy) Reload(context.Context, time.Duration, func() error) {
 	s.calls.Add(1)
 }
 
-// resetStorageTestState 清空内存 map 和默认策略状态，避免用例间串扰。
+// resetStorageTestState 清空内存 map、默认策略状态与包级 reload 配置，避免用例间串扰。
 func resetStorageTestState(t *testing.T) {
 	t.Helper()
 	storageLock.Lock()
@@ -41,6 +41,7 @@ func resetStorageTestState(t *testing.T) {
 	storageMapHash = ""
 	storageLock.Unlock()
 	SetStorageMissReloadStrategy(nil)
+	SetStorageMissReload(0, nil)
 	defaultStorageMissReloadStrategy.resetForTest()
 	getTsDBStorageInfo = consul.GetTsDBStorageInfo
 }
@@ -48,7 +49,7 @@ func resetStorageTestState(t *testing.T) {
 // TestGetStorage_hit_doesNotTriggerReload：命中热路径不触发 miss-reload 策略。
 func TestGetStorage_hit_doesNotTriggerReload(t *testing.T) {
 	resetStorageTestState(t)
-	stub := &stubStorageMissReloadStrategy{}
+	stub := &stubReloadStrategy{}
 	SetStorageMissReloadStrategy(stub)
 
 	SetStorage("1", &Storage{Address: "addr-a"})
@@ -62,10 +63,10 @@ func TestGetStorage_hit_doesNotTriggerReload(t *testing.T) {
 func TestGetStorage_miss_reloadSecondHit(t *testing.T) {
 	resetStorageTestState(t)
 
-	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
+	SetStorageMissReload(defaultStorageMissReloadCooldown, func() error {
 		SetStorage("99", &Storage{Address: "from-reload"})
 		return nil
-	}))
+	})
 	st, err := GetStorage(context.Background(), "99")
 	require.NoError(t, err)
 	require.Equal(t, "from-reload", st.Address)
@@ -76,11 +77,11 @@ func TestGetStorage_missReload_singleflight(t *testing.T) {
 	resetStorageTestState(t)
 	var calls atomic.Int32
 	var wg sync.WaitGroup
-	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
+	SetStorageMissReload(defaultStorageMissReloadCooldown, func() error {
 		calls.Add(1)
 		time.Sleep(20 * time.Millisecond)
 		return nil
-	}))
+	})
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
 		go func() {
@@ -96,10 +97,10 @@ func TestGetStorage_missReload_singleflight(t *testing.T) {
 func TestGetStorage_missReload_cooldown(t *testing.T) {
 	resetStorageTestState(t)
 	var calls atomic.Int32
-	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(time.Hour, func() error {
+	SetStorageMissReload(time.Hour, func() error {
 		calls.Add(1)
 		return nil
-	}))
+	})
 
 	ctx := context.Background()
 	_, err := GetStorage(ctx, "nope")
@@ -114,9 +115,9 @@ func TestGetStorage_missReload_cooldown(t *testing.T) {
 // TestGetStorage_missReload_returnsErrorStillFails：reload 回调返回错误时 GetStorage 仍为 ErrStorageNotFound，且不 panic。
 func TestGetStorage_missReload_returnsErrorStillFails(t *testing.T) {
 	resetStorageTestState(t)
-	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
+	SetStorageMissReload(defaultStorageMissReloadCooldown, func() error {
 		return errors.New("consul down")
-	}))
+	})
 	_, err := GetStorage(context.Background(), "id")
 	require.Error(t, err)
 }
@@ -133,9 +134,9 @@ func TestGetStorage_missReloadFetchesConsulStorageIDs(t *testing.T) {
 			"11": {},
 		}, nil
 	}
-	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
+	SetStorageMissReload(defaultStorageMissReloadCooldown, func() error {
 		return nil
-	}))
+	})
 
 	_, err := GetStorage(context.Background(), "404")
 	require.Error(t, err)
@@ -154,9 +155,9 @@ func TestGetStorage_missReloadFailureStillFetchesConsulStorageIDs(t *testing.T) 
 			"11": {},
 		}, nil
 	}
-	SetStorageMissReloadStrategy(NewCooldownStorageMissReloadStrategy(defaultStorageMissReloadCooldown, func() error {
+	SetStorageMissReload(defaultStorageMissReloadCooldown, func() error {
 		return errors.New("consul down")
-	}))
+	})
 
 	_, err := GetStorage(context.Background(), "404")
 	require.Error(t, err)
@@ -165,38 +166,46 @@ func TestGetStorage_missReloadFailureStillFetchesConsulStorageIDs(t *testing.T) 
 
 func TestStorageMissReloadStrategy_nilReloadFuncNoop(t *testing.T) {
 	resetStorageTestState(t)
-	strategy := newCooldownStorageMissReloadStrategy(time.Second, nil)
+	strategy := newCooldownReloadStrategy()
 
-	strategy.ReloadAfterMiss(context.Background(), "id")
+	strategy.Reload(context.Background(), time.Second, nil)
 
 	require.Equal(t, int64(0), strategy.lastAttempt.Load())
 }
 
+// 非正 cooldown 应回退到 defaultStorageMissReloadCooldown：通过外部行为验证——
+// 默认 10 分钟 cooldown 必然挡住第二次调用，使 reloadFn 只被执行一次。
 func TestStorageMissReloadStrategy_nonPositiveCooldownFallsBackToDefault(t *testing.T) {
 	resetStorageTestState(t)
-	strategy := newCooldownStorageMissReloadStrategy(0, nil)
-
-	require.Equal(t, defaultStorageMissReloadCooldown, strategy.cooldown())
-
-	strategy.SetCooldown(-time.Second)
-	require.Equal(t, defaultStorageMissReloadCooldown, strategy.cooldown())
-}
-
-func TestStorageMissReloadStrategy_settersTakeEffectImmediately(t *testing.T) {
-	resetStorageTestState(t)
-	strategy := newCooldownStorageMissReloadStrategy(time.Hour, nil)
+	strategy := newCooldownReloadStrategy()
 	var calls atomic.Int32
-
-	strategy.SetReloadFunc(func() error {
+	fn := func() error {
 		calls.Add(1)
 		return nil
-	})
-	strategy.ReloadAfterMiss(context.Background(), "id")
+	}
+
+	strategy.Reload(context.Background(), 0, fn)
+	strategy.Reload(context.Background(), -time.Second, fn)
+
+	require.Equal(t, int32(1), calls.Load())
+}
+
+// cooldown 由调用方在每次 Reload 时传入，因此天然"立即生效"——
+// 这里覆盖"同一 strategy 用不同 cooldown 立即生效"的行为。
+func TestStorageMissReloadStrategy_settersTakeEffectImmediately(t *testing.T) {
+	resetStorageTestState(t)
+	strategy := newCooldownReloadStrategy()
+	var calls atomic.Int32
+	fn := func() error {
+		calls.Add(1)
+		return nil
+	}
+
+	strategy.Reload(context.Background(), time.Hour, fn)
 	require.Equal(t, int32(1), calls.Load())
 
-	strategy.SetCooldown(time.Nanosecond)
 	time.Sleep(time.Millisecond)
-	strategy.ReloadAfterMiss(context.Background(), "id")
+	strategy.Reload(context.Background(), time.Nanosecond, fn)
 	require.Equal(t, int32(2), calls.Load())
 }
 

--- a/pkg/unify-query/unify-query.yaml
+++ b/pkg/unify-query/unify-query.yaml
@@ -40,6 +40,9 @@ influxdb:
 es:
   max_concurrency: 200
   alias_refresh_period: 1m
+tsdb:
+  # GetStorage 未命中时，触发 Consul 刷新内存的最短间隔（节流）
+  storage_miss_reload_cooldown: 10m
 http:
   multiTenantMode: false
   address: 127.0.0.1


### PR DESCRIPTION
## 本次改动
- 为 `tsdb.GetStorage` 增加 miss 后自恢复机制：
  - 引入 `StorageMissReloadStrategy`，默认策略为 `cooldown + singleflight`
  - miss 时触发从 Consul 刷新内存 storage map，并在刷新后二次查询
- 新增可配置节流参数：`tsdb.storage_miss_reload_cooldown`（默认 `10m`）
- 新增指标 `unify_query_tsdb_get_storage_total{result=hit|hit_after_reload|miss}`，覆盖 GetStorage 三类返回路径
- 调整 miss 诊断日志：仅在真正进入 reload 窗口时记录触发信息与 Consul 中可见 storage id
- service 层注入 reload 回调：`SetStorageMissReloadFunc(s.reloadStorage)`