### PR TITLE
fix: (unify-query)修复处理 ES _source 扁平化时空对象嵌套分支被整段丢弃 --bug=157724828

### DIFF
--- a/pkg/unify-query/docs/storage-integration.md
+++ b/pkg/unify-query/docs/storage-integration.md
@@ -312,6 +312,7 @@ prometheus:
 - 使用 Elasticsearch Query DSL
 - 支持 Lucene 到 ES Query 的转换
 - 支持滚动查询（Scroll API）
+- `_source` 结果会按点路径扁平化返回；空对象叶子会保留为空 map，`null`、空数组、数组及非对象类型作为叶子值保留，避免嵌套空结构在格式化阶段丢失。
 
 **配置示例**：
 ```yaml
@@ -516,4 +517,3 @@ A: 使用 Go 的 `golang.org/x/time/rate` 包实现限流功能。
 - InfluxDB：`tsdb/influxdb/`
 - VictoriaMetrics：`tsdb/victoriaMetrics/`
 - Prometheus：`tsdb/prometheus/`
-

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -101,6 +101,7 @@ type TimeSeriesResult struct {
 
 // mapData 将嵌套的 map 按 ESStep 拍平成点路径键写入 res。
 // 当嵌套值为空对象（map[string]any{}）时，直接以点路径键保留原对象，避免该分支因为没有任何叶子字段而在最终结果中整段丢失。
+// null、数组及其他非对象类型按叶子值处理；数组内部仅做精度转换，不参与点路径展开。
 func mapData(prefix string, data map[string]any, res map[string]any) {
 	for k, v := range data {
 		if prefix != "" {

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -99,18 +99,28 @@ type TimeSeriesResult struct {
 	Error         error
 }
 
-func mapData(prefix string, data map[string]any, res map[string]any) {
+func mapData(prefix string, data map[string]any, res map[string]any) bool {
+	hasLeaf := false
 	for k, v := range data {
 		if prefix != "" {
 			k = prefix + ESStep + k
 		}
+
 		switch nv := v.(type) {
 		case map[string]any:
-			mapData(k, nv, res)
+			if mapData(k, nv, res) {
+				hasLeaf = true
+				continue
+			}
+			//当嵌套对象没有任何叶子字段产出时，回退保留该对象，避免路径在最终结果中整段丢失
+			res[k] = precision.ProcessValue(nv)
+			hasLeaf = true
 		default:
 			res[k] = precision.ProcessValue(nv)
+			hasLeaf = true
 		}
 	}
+	return hasLeaf
 }
 
 type ValueAgg struct {

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -99,28 +99,24 @@ type TimeSeriesResult struct {
 	Error         error
 }
 
-func mapData(prefix string, data map[string]any, res map[string]any) bool {
-	hasLeaf := false
+// mapData 将嵌套的 map 按 ESStep 拍平成点路径键写入 res。
+// 当嵌套值为空对象（map[string]any{}）时，直接以点路径键保留原对象，避免该分支因为没有任何叶子字段而在最终结果中整段丢失。
+func mapData(prefix string, data map[string]any, res map[string]any) {
 	for k, v := range data {
 		if prefix != "" {
 			k = prefix + ESStep + k
 		}
-
 		switch nv := v.(type) {
 		case map[string]any:
-			if mapData(k, nv, res) {
-				hasLeaf = true
+			if len(nv) == 0 {
+				res[k] = precision.ProcessValue(nv)
 				continue
 			}
-			//当嵌套对象没有任何叶子字段产出时，回退保留该对象，避免路径在最终结果中整段丢失
-			res[k] = precision.ProcessValue(nv)
-			hasLeaf = true
+			mapData(k, nv, res)
 		default:
 			res[k] = precision.ProcessValue(nv)
-			hasLeaf = true
 		}
 	}
-	return hasLeaf
 }
 
 type ValueAgg struct {

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -1672,9 +1672,9 @@ func TestFormatFactory_Orders(t *testing.T) {
 	}
 
 	for name, c := range map[string]struct {
-		timeField    metadata.TimeField
-		orders       metadata.Orders
-		expected     metadata.Orders
+		timeField metadata.TimeField
+		orders    metadata.Orders
+		expected  metadata.Orders
 	}{
 		"time field uses timeField.Type as unmapped_type": {
 			timeField: metadata.TimeField{
@@ -1745,6 +1745,97 @@ func TestFormatFactory_Orders(t *testing.T) {
 
 			got := fact.Orders()
 			assert.Equal(t, c.expected, got)
+		})
+	}
+}
+
+func TestFormatFactory_SetData(t *testing.T) {
+	ctx := context.Background()
+
+	for name, c := range map[string]struct {
+		source         map[string]any
+		expectedValues map[string]any
+		notContains    []string
+	}{
+		// 还原场景：直查 ES 的 _source 含嵌套 body，叶子为 {}；
+		// SetData 经 mapData 拍平后应保留带点路径，否则前端经 uq 看不到 body。
+		"preserves body with empty object leaves": {
+			source: map[string]any{
+				"source": "skill_rating",
+				"meta": map[string]any{
+					"Reason":    "MatchmakingDataChanged",
+					"game_mode": "mode10v10",
+				},
+				"body": map[string]any{
+					"old_matchmaking_data": map[string]any{
+						"76346346-466c600000e": map[string]any{},
+						"98456436-466c600000d": map[string]any{},
+					},
+					"new_matchmaking_data": map[string]any{
+						"76346346-466c600000e": map[string]any{},
+					},
+				},
+			},
+			expectedValues: map[string]any{
+				"meta.Reason":    "MatchmakingDataChanged",
+				"meta.game_mode": "mode10v10",
+				"body.old_matchmaking_data.76346346-466c600000e": map[string]any{},
+				"body.old_matchmaking_data.98456436-466c600000d": map[string]any{},
+				"body.new_matchmaking_data.76346346-466c600000e": map[string]any{},
+			},
+		},
+		"keeps flattened leaf when scalar exists": {
+			source: map[string]any{
+				"body": map[string]any{
+					"new_matchmaking_data": map[string]any{
+						"76346346-466c600000e": map[string]any{
+							"score": 99,
+						},
+					},
+				},
+			},
+			expectedValues: map[string]any{
+				"body.new_matchmaking_data.76346346-466c600000e.score": 99,
+			},
+			notContains: []string{
+				"body.new_matchmaking_data.76346346-466c600000e",
+			},
+		},
+		"mixed nested fallback and flatten": {
+			source: map[string]any{
+				"body": map[string]any{
+					"region": "ap-sh",
+					"old_matchmaking_data": map[string]any{
+						"76346346-466c600000e": map[string]any{},
+					},
+					"new_matchmaking_data": map[string]any{
+						"76346346-466c600000e": map[string]any{
+							"score": 100,
+						},
+					},
+				},
+			},
+			expectedValues: map[string]any{
+				"body.region": "ap-sh",
+				"body.old_matchmaking_data.76346346-466c600000e":       map[string]any{},
+				"body.new_matchmaking_data.76346346-466c600000e.score": 100,
+			},
+			notContains: []string{
+				"body.new_matchmaking_data.76346346-466c600000e",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fact := NewFormatFactory(ctx)
+			fact.SetData(c.source)
+
+			for k, expected := range c.expectedValues {
+				assert.Equal(t, expected, fact.data[k])
+			}
+
+			for _, key := range c.notContains {
+				assert.NotContains(t, fact.data, key)
+			}
 		})
 	}
 }

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -11,6 +11,7 @@ package elasticsearch
 
 import (
 	"context"
+	stdjson "encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -1777,6 +1778,7 @@ func TestFormatFactory_SetData(t *testing.T) {
 				},
 			},
 			expectedValues: map[string]any{
+				"source":         "skill_rating",
 				"meta.Reason":    "MatchmakingDataChanged",
 				"meta.game_mode": "mode10v10",
 				"body.old_matchmaking_data.76346346-466c600000e": map[string]any{},
@@ -1822,6 +1824,29 @@ func TestFormatFactory_SetData(t *testing.T) {
 			},
 			notContains: []string{
 				"body.new_matchmaking_data.76346346-466c600000e",
+			},
+		},
+		// 精度回归：空对象分支与 json.Number 同时存在时，
+		// 大整数仍应经 precision.ProcessValue 处理为 uint，避免精度丢失。
+		"preserves big number alongside empty object": {
+			source: map[string]any{
+				"body": map[string]any{
+					"stats": map[string]any{
+						// 9223372036854775808 = math.MaxInt64 + 1，超出 int64 范围
+						"trace_id": stdjson.Number("9223372036854775808"),
+					},
+					"old_matchmaking_data": map[string]any{
+						"76346346-466c600000e": map[string]any{},
+					},
+				},
+			},
+			expectedValues: map[string]any{
+				"body.stats.trace_id":                            uint(9223372036854775808),
+				"body.old_matchmaking_data.76346346-466c600000e": map[string]any{},
+			},
+			notContains: []string{
+				"body.stats",
+				"body.old_matchmaking_data",
 			},
 		},
 	} {

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -1754,9 +1754,8 @@ func TestFormatFactory_SetData(t *testing.T) {
 	ctx := context.Background()
 
 	for name, c := range map[string]struct {
-		source         map[string]any
-		expectedValues map[string]any
-		notContains    []string
+		source       map[string]any
+		expectedData map[string]any
 	}{
 		// 还原场景：直查 ES 的 _source 含嵌套 body，叶子为 {}；
 		// SetData 经 mapData 拍平后应保留带点路径，否则前端经 uq 看不到 body。
@@ -1777,13 +1776,35 @@ func TestFormatFactory_SetData(t *testing.T) {
 					},
 				},
 			},
-			expectedValues: map[string]any{
+			expectedData: map[string]any{
 				"source":         "skill_rating",
 				"meta.Reason":    "MatchmakingDataChanged",
 				"meta.game_mode": "mode10v10",
 				"body.old_matchmaking_data.76346346-466c600000e": map[string]any{},
 				"body.old_matchmaking_data.98456436-466c600000d": map[string]any{},
 				"body.new_matchmaking_data.76346346-466c600000e": map[string]any{},
+			},
+		},
+		"preserves completely empty nested object": {
+			source: map[string]any{
+				"x": map[string]any{
+					"y": map[string]any{},
+				},
+			},
+			expectedData: map[string]any{
+				"x.y": map[string]any{},
+			},
+		},
+		"flattens partial empty nested object with scalar": {
+			source: map[string]any{
+				"x": map[string]any{
+					"y": map[string]any{},
+					"z": 1,
+				},
+			},
+			expectedData: map[string]any{
+				"x.y": map[string]any{},
+				"x.z": 1,
 			},
 		},
 		"keeps flattened leaf when scalar exists": {
@@ -1796,11 +1817,8 @@ func TestFormatFactory_SetData(t *testing.T) {
 					},
 				},
 			},
-			expectedValues: map[string]any{
+			expectedData: map[string]any{
 				"body.new_matchmaking_data.76346346-466c600000e.score": 99,
-			},
-			notContains: []string{
-				"body.new_matchmaking_data.76346346-466c600000e",
 			},
 		},
 		"mixed nested fallback and flatten": {
@@ -1817,13 +1835,62 @@ func TestFormatFactory_SetData(t *testing.T) {
 					},
 				},
 			},
-			expectedValues: map[string]any{
+			expectedData: map[string]any{
 				"body.region": "ap-sh",
 				"body.old_matchmaking_data.76346346-466c600000e":       map[string]any{},
 				"body.new_matchmaking_data.76346346-466c600000e.score": 100,
 			},
-			notContains: []string{
-				"body.new_matchmaking_data.76346346-466c600000e",
+		},
+		"flattens deeply mixed levels": {
+			source: map[string]any{
+				"x": map[string]any{
+					"y": map[string]any{
+						"empty": map[string]any{},
+						"z": map[string]any{
+							"name": "leaf",
+							"n":    stdjson.Number("42"),
+						},
+					},
+					"enabled": true,
+				},
+			},
+			expectedData: map[string]any{
+				"x.y.empty":  map[string]any{},
+				"x.y.z.name": "leaf",
+				"x.y.z.n":    42,
+				"x.enabled":  true,
+			},
+		},
+		"keeps null empty array nested array and scalar values": {
+			source: map[string]any{
+				"nil_value": nil,
+				"empty_arr": []any{},
+				"arr": []any{
+					map[string]any{
+						"k":     stdjson.Number("7"),
+						"empty": map[string]any{},
+					},
+					"text",
+				},
+				"obj": map[string]any{
+					"number": stdjson.Number("3.14"),
+					"flag":   false,
+					"empty":  map[string]any{},
+				},
+			},
+			expectedData: map[string]any{
+				"nil_value": nil,
+				"empty_arr": []any{},
+				"arr": []any{
+					map[string]any{
+						"k":     7,
+						"empty": map[string]any{},
+					},
+					"text",
+				},
+				"obj.number": 3.14,
+				"obj.flag":   false,
+				"obj.empty":  map[string]any{},
 			},
 		},
 		// 精度回归：空对象分支与 json.Number 同时存在时，
@@ -1840,13 +1907,9 @@ func TestFormatFactory_SetData(t *testing.T) {
 					},
 				},
 			},
-			expectedValues: map[string]any{
+			expectedData: map[string]any{
 				"body.stats.trace_id":                            uint(9223372036854775808),
 				"body.old_matchmaking_data.76346346-466c600000e": map[string]any{},
-			},
-			notContains: []string{
-				"body.stats",
-				"body.old_matchmaking_data",
 			},
 		},
 	} {
@@ -1854,13 +1917,41 @@ func TestFormatFactory_SetData(t *testing.T) {
 			fact := NewFormatFactory(ctx)
 			fact.SetData(c.source)
 
-			for k, expected := range c.expectedValues {
-				assert.Equal(t, expected, fact.data[k])
-			}
-
-			for _, key := range c.notContains {
-				assert.NotContains(t, fact.data, key)
-			}
+			assert.Equal(t, c.expectedData, fact.data)
 		})
+	}
+}
+
+func BenchmarkFormatFactory_SetData_LargeNestedObject(b *testing.B) {
+	ctx := context.Background()
+	source := map[string]any{
+		"source": "benchmark",
+		"body":   make(map[string]any, 1024),
+	}
+
+	body := source["body"].(map[string]any)
+	for i := 0; i < 1024; i++ {
+		body[fmt.Sprintf("entity_%04d", i)] = map[string]any{
+			"score":  stdjson.Number(fmt.Sprintf("%d", i)),
+			"active": i%2 == 0,
+			"empty":  map[string]any{},
+			"tags": []any{
+				stdjson.Number(fmt.Sprintf("%d", i)),
+				map[string]any{"nested_empty": map[string]any{}},
+			},
+			"deep": map[string]any{
+				"level_1": map[string]any{
+					"level_2": map[string]any{
+						"value": stdjson.Number(fmt.Sprintf("%d.5", i)),
+					},
+				},
+			},
+		}
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		fact := NewFormatFactory(ctx)
+		fact.SetData(source)
 	}
 }


### PR DESCRIPTION
### 背景
线上场景中，直查 ES 可见 body 相关嵌套内容；经 unify-query 扁平化后，若分支叶子均为 {}，结果中该字段分支会消失，造成“字段缺失”的感知偏差。

### 修复说明
修复 unify-query 在处理 ES _source 扁平化时，空对象嵌套分支被整段丢弃的问题。
在 mapData 增加通用回退逻辑：当某子树递归后没有任何叶子字段产出时，保留空对象叶子到对应点路径键下。
保持原有行为兼容：当子树存在标量叶子时，继续执行点路径扁平化输出。

### 补充验证
- 补充 `TestFormatFactory_SetData` case，覆盖完全空嵌套、部分空嵌套混合标量、深度混合层级、多类型字段混杂、`null`、空数组、嵌套数组等边界。
- 补充 `BenchmarkFormatFactory_SetData_LargeNestedObject`，用于评估大规模嵌套结构下 SetData flatten 的 latency / alloc。
- 补充 `_source` 扁平化行为边界注释与存储集成文档。

### 本地验证
```bash
env GOCACHE=/tmp/go-build-cache go test ./tsdb/elasticsearch -run TestFormatFactory_SetData
env GOCACHE=/tmp/go-build-cache go test ./tsdb/elasticsearch -run '^$' -bench BenchmarkFormatFactory_SetData_LargeNestedObject -benchtime=100x
git diff --check
```

Benchmark 结果：约 `3002120 ns/op`，`1513739 B/op`，`21286 allocs/op`。
