### PR TITLE
feat: (unify-query) 优化 GetStorage 热路径并新增 storage miss 指标 --story=134122540

### DIFF
--- a/pkg/unify-query/metric/metric.go
+++ b/pkg/unify-query/metric/metric.go
@@ -136,7 +136,7 @@ var (
 			Name:      "tsdb_get_storage_total",
 			Help:      "unify-query tsdb get storage result",
 		},
-		[]string{"result"},
+		[]string{"result", "version", "commit_id"},
 	)
 
 	tsDBGetStorageMissIDTotal = promauto.NewCounterVec(
@@ -145,7 +145,7 @@ var (
 			Name:      "tsdb_get_storage_miss_id_total",
 			Help:      "unify-query tsdb get storage missing storage id",
 		},
-		[]string{"storage_id"},
+		[]string{"storage_id", "version", "commit_id"},
 	)
 )
 
@@ -197,15 +197,18 @@ func BkDataRequestInc(ctx context.Context, spaceUID, tableID, isMatch, isFF stri
 
 // TSDBGetStorageTotalInc 统计 GetStorage 调用结果总量。
 // result 目前使用 hit/miss，可用于计算 miss 比例并观察整体命中率变化。
+// version、commit_id 与 api_request_total 一致，由构建 -ldflags 注入 config，便于按发版排查
 func TSDBGetStorageTotalInc(ctx context.Context, result string) {
-	metric, _ := tsDBGetStorageTotal.GetMetricWithLabelValues(result)
+	params := append([]string{}, result, config.Version, config.CommitHash)
+	metric, _ := tsDBGetStorageTotal.GetMetricWithLabelValues(params...)
 	counterInc(ctx, metric)
 }
 
 // TSDBGetStorageMissIDTotalInc 记录缺失 storageID 的次数，便于直接定位异常 ID
-// eg. unify_query_tsdb_get_storage_miss_id_total{storage_id="2"} = 3
+// eg. unify_query_tsdb_get_storage_miss_id_total{storage_id="2",version="...",commit_id="..."} = 3
 func TSDBGetStorageMissIDTotalInc(ctx context.Context, storageID string) {
-	metric, _ := tsDBGetStorageMissIDTotal.GetMetricWithLabelValues(storageID)
+	params := append([]string{}, storageID, config.Version, config.CommitHash)
+	metric, _ := tsDBGetStorageMissIDTotal.GetMetricWithLabelValues(params...)
 	counterInc(ctx, metric)
 }
 

--- a/pkg/unify-query/metric/metric.go
+++ b/pkg/unify-query/metric/metric.go
@@ -36,6 +36,11 @@ const (
 )
 
 const (
+	ResultHit  = "hit"
+	ResultMiss = "miss"
+)
+
+const (
 	_ = 1 << (10 * iota)
 	KB
 	MB
@@ -124,6 +129,24 @@ var (
 		},
 		[]string{"space_uid", "table_id", "is_match", "is_ff"},
 	)
+
+	tsDBGetStorageTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "unify_query",
+			Name:      "tsdb_get_storage_total",
+			Help:      "unify-query tsdb get storage result",
+		},
+		[]string{"result"},
+	)
+
+	tsDBGetStorageMissIDTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "unify_query",
+			Name:      "tsdb_get_storage_miss_id_total",
+			Help:      "unify-query tsdb get storage missing storage id",
+		},
+		[]string{"storage_id"},
+	)
 )
 
 func APIRequestInc(ctx context.Context, api, status, spaceUID, sourceType string) {
@@ -169,6 +192,20 @@ func JWTRequestInc(ctx context.Context, api, jwtAppCode, jwtAppUserName, spaceUI
 
 func BkDataRequestInc(ctx context.Context, spaceUID, tableID, isMatch, isFF string) {
 	metric, _ := bkDataApiRequestTotal.GetMetricWithLabelValues(spaceUID, tableID, isMatch, isFF)
+	counterInc(ctx, metric)
+}
+
+// TSDBGetStorageTotalInc 统计 GetStorage 调用结果总量。
+// result 目前使用 hit/miss，可用于计算 miss 比例并观察整体命中率变化。
+func TSDBGetStorageTotalInc(ctx context.Context, result string) {
+	metric, _ := tsDBGetStorageTotal.GetMetricWithLabelValues(result)
+	counterInc(ctx, metric)
+}
+
+// TSDBGetStorageMissIDTotalInc 记录缺失 storageID 的次数，便于直接定位异常 ID
+// eg. unify_query_tsdb_get_storage_miss_id_total{storage_id="2"} = 3
+func TSDBGetStorageMissIDTotalInc(ctx context.Context, storageID string) {
+	metric, _ := tsDBGetStorageMissIDTotal.GetMetricWithLabelValues(storageID)
 	counterInc(ctx, metric)
 }
 

--- a/pkg/unify-query/tsdb/storage.go
+++ b/pkg/unify-query/tsdb/storage.go
@@ -15,11 +15,11 @@ import (
 	"sort"
 	"strconv"
 	"sync"
-	"sync/atomic"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/consul"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metric"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
 )
 
@@ -27,10 +27,6 @@ var (
 	storageMap     = make(map[string]*Storage)
 	storageMapHash string
 	storageLock    = new(sync.RWMutex)
-
-	// getStorageKeysLogPending：本次 Reload 之后是否还需要打「首次命中」的全量 keys 诊断日志。
-	// Reload 成功替换 storageMap 后置为 true；任意一次成功 GetStorage 通过 CAS 消费掉该标记，或 miss 时直接置 false。
-	getStorageKeysLogPending atomic.Bool
 )
 
 // StorageMapHash 返回最近一次 ReloadTsDBStorage 写入的配置哈希（与 Consul 侧 hash 比对用于短路 reload）
@@ -83,7 +79,7 @@ func ReloadTsDBStorage(ctx context.Context, hash string, tsDBs map[string]*consu
 	for k := range newStorageMap {
 		newKeys = append(newKeys, k)
 	}
-	// 与 storageMapKeysLocked 一致：按 storage ID 数值升序，便于日志对照。
+	// 按 storage ID 数值升序，便于日志对照。
 	sortStorageIDKeysAsc(newKeys)
 
 	span.Set("old_hash", oldHash)
@@ -96,8 +92,6 @@ func ReloadTsDBStorage(ctx context.Context, hash string, tsDBs map[string]*consu
 
 	storageMap = newStorageMap
 	storageMapHash = hash
-	// 新 map 生效后允许再一次「首次成功 GetStorage」附带全量 map_keys，便于对照重载后的内存视图。
-	getStorageKeysLogPending.Store(true)
 
 	// oldHash 为空表示进程内首次写入，会打初始化日志；否则视为配置变更后的重载。
 	if oldHash == "" {
@@ -123,11 +117,6 @@ func Print() string {
 }
 
 // GetStorage 从内存 map 按 storageID 取 Storage。
-// 诊断日志（遍历全表 keys、metadata.Info）仅在两类场景打出，避免热路径每条请求扫 map：
-//   - miss：便于核对请求的 ID 与当前内存中的 ID 列表；
-//   - 本次 Reload 之后第一次成功命中：CompareAndSwap 保证全进程仅一次。
-//
-// 其余成功命中只写 span 的 storage_id、storage_hash。
 func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 	var err error
 	ctx, span := trace.NewSpan(ctx, "get-tsdb-storage")
@@ -136,28 +125,18 @@ func GetStorage(ctx context.Context, storageID string) (*Storage, error) {
 	storageLock.RLock()
 	defer storageLock.RUnlock()
 
-	span.Set("storage_id", storageID)
-	span.Set("storage_hash", storageMapHash)
-
 	storage, ok := storageMap[storageID]
 	if !ok {
-		// miss：始终打全量 keys；并取消「首次命中」待打标记，避免紧接着的成功请求再打一份全量 keys。
-		keys := storageMapKeysLocked()
-		span.Set("storage_keys", fmt.Sprintf("%v", keys))
-		getStorageKeysLogPending.Store(false)
-		metadata.NewMessage("tsdb_storage", "get storage miss: id=%s hash=%s map_keys=%v",
-			storageID, storageMapHash, keys).Info(ctx)
+		// miss 场景每次记录缺失 storageID，并上报缺失 ID 指标用于排障
+		metric.TSDBGetStorageTotalInc(ctx, metric.ResultMiss)
+		metric.TSDBGetStorageMissIDTotalInc(ctx, storageID)
+		metadata.NewMessage("tsdb_storage", "get storage miss: id=%s hash=%s",
+			storageID, storageMapHash).Info(ctx)
 		err = fmt.Errorf("%s: storageID: %s", ErrStorageNotFound, storageID)
 		return nil, err
 	}
 
-	// 仅当 pending 仍为 true 时进入：原子地从 true 翻成 false，保证多 goroutine 下只有一次会打「重载后首次命中」全量 keys。
-	if getStorageKeysLogPending.CompareAndSwap(true, false) {
-		keys := storageMapKeysLocked()
-		span.Set("storage_keys", fmt.Sprintf("%v", keys))
-		metadata.NewMessage("tsdb_storage", "get storage: id=%s hash=%s map_keys=%v",
-			storageID, storageMapHash, keys).Info(ctx)
-	}
+	metric.TSDBGetStorageTotalInc(ctx, metric.ResultHit)
 
 	return storage, nil
 }
@@ -168,16 +147,6 @@ func SetStorage(storageID string, storage *Storage) {
 	defer storageLock.Unlock()
 
 	storageMap[storageID] = storage
-}
-
-// storageMapKeysLocked 复制当前 storageMap 的全部 key，调用方须已持有 storageLock 读锁或写锁。
-func storageMapKeysLocked() []string {
-	keys := make([]string, 0, len(storageMap))
-	for k := range storageMap {
-		keys = append(keys, k)
-	}
-	sortStorageIDKeysAsc(keys)
-	return keys
 }
 
 // sortStorageIDKeysAsc 按 storage ID 的数值升序排列（ID 为十进制整数字符串时）。


### PR DESCRIPTION
### 问题描述
现网 `GetStorage` 属于高频路径，原有 trace/log 信息在高并发下会放大开销。
需要同时满足“低开销”与“可观测”：既能看整体 miss 率，又能定位具体异常 storage_id
### 修复说明
- 优化 `GetStorage` 热路径：移除高频 `span` 字段写入，降低每次调用开销。
- 新增指标 `unify_query_tsdb_get_storage_total{result}`，统计 `GetStorage` 的 hit/miss 总量。
- 新增指标 `unify_query_tsdb_get_storage_miss_id_total{storage_id}`，按缺失 `storage_id` 统计 `miss` 次数，便于直接定位异常 ID。
- 调整 `miss` 诊断日志：保留每次 `miss` 的 `storage_id` 打印，移除全量 `map_keys` 打印，避免高频遍历和大日志量。
- `sortStorageIDKeysAsc(newKeys)` 仅在 `ReloadTsDBStorage` 里使用，只会在重载 `storage` 配置时执行（包括进程启动后的首次加载和后续配置变更），便于排查对比