### PR TITLE
fix: 修复 bkmonitorbeat resource_limit 模板渲染

### DIFF
--- a/pkg/bkmonitorbeat/script/generate_support_files/write_root_conf_tpl.sh
+++ b/pkg/bkmonitorbeat/script/generate_support_files/write_root_conf_tpl.sh
@@ -55,7 +55,7 @@ resource_limit:
 {%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
   enabled: false
 {%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
+{%- set resource_limit = resource_limit | default({}) %}
   enabled: true
   cpu: {{
     [

--- a/pkg/bkmonitorbeat/script/generate_support_files/write_root_conf_tpl_test.go
+++ b/pkg/bkmonitorbeat/script/generate_support_files/write_root_conf_tpl_test.go
@@ -1,0 +1,37 @@
+package generate_support_files
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResourceLimitSetDoesNotTrimFollowingNewline(t *testing.T) {
+	paths := []string{"write_root_conf_tpl.sh"}
+
+	err := filepath.WalkDir("../../support-files/templates", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Base(path) == "bkmonitorbeat.conf.tpl" {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk support-files templates: %v", err)
+	}
+
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		if strings.Contains(string(content), "{%- set resource_limit = resource_limit | default({}) -%}") {
+			t.Fatalf("%s trims the newline after resource_limit set, which can render invalid YAML", path)
+		}
+	}
+}

--- a/pkg/bkmonitorbeat/support-files/templates/freebsd/x86_64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/freebsd/x86_64/etc/bkmonitorbeat.conf.tpl
@@ -32,7 +32,7 @@ resource_limit:
 {%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
   enabled: false
 {%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
+{%- set resource_limit = resource_limit | default({}) %}
   enabled: true
   cpu: {{
     [

--- a/pkg/bkmonitorbeat/support-files/templates/linux/aarch64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/linux/aarch64/etc/bkmonitorbeat.conf.tpl
@@ -32,7 +32,7 @@ resource_limit:
 {%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
   enabled: false
 {%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
+{%- set resource_limit = resource_limit | default({}) %}
   enabled: true
   cpu: {{
     [

--- a/pkg/bkmonitorbeat/support-files/templates/linux/x86/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/linux/x86/etc/bkmonitorbeat.conf.tpl
@@ -32,7 +32,7 @@ resource_limit:
 {%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
   enabled: false
 {%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
+{%- set resource_limit = resource_limit | default({}) %}
   enabled: true
   cpu: {{
     [

--- a/pkg/bkmonitorbeat/support-files/templates/linux/x86_64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/linux/x86_64/etc/bkmonitorbeat.conf.tpl
@@ -32,7 +32,7 @@ resource_limit:
 {%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
   enabled: false
 {%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
+{%- set resource_limit = resource_limit | default({}) %}
   enabled: true
   cpu: {{
     [

--- a/pkg/bkmonitorbeat/support-files/templates/windows/x86/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/windows/x86/etc/bkmonitorbeat.conf.tpl
@@ -32,7 +32,7 @@ resource_limit:
 {%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
   enabled: false
 {%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
+{%- set resource_limit = resource_limit | default({}) %}
   enabled: true
   cpu: {{
     [

--- a/pkg/bkmonitorbeat/support-files/templates/windows/x86_64/etc/bkmonitorbeat.conf.tpl
+++ b/pkg/bkmonitorbeat/support-files/templates/windows/x86_64/etc/bkmonitorbeat.conf.tpl
@@ -32,7 +32,7 @@ resource_limit:
 {%- if extra_vars is defined and extra_vars.disable_resource_limit is defined and extra_vars.disable_resource_limit == "true" %}
   enabled: false
 {%- elif cmdb_instance.host.bk_cpu and cmdb_instance.host.bk_mem %}
-{%- set resource_limit = resource_limit | default({}) -%}
+{%- set resource_limit = resource_limit | default({}) %}
   enabled: true
   cpu: {{
     [


### PR DESCRIPTION
## Summary
- 修复 bkmonitorbeat 主配置模板中 `resource_limit` 分支的 Jinja2 换行裁剪问题，避免渲染出 `resource_limit:enabled: true` 这类非法 YAML。
- 同步生成脚本和 linux/windows/freebsd 已生成模板。
- 增加回归测试，防止 `resource_limit` 的 set 语句再次裁剪后续换行。

## Test plan
- `go test ./script/generate_support_files`
- 使用 Jinja2 渲染 `linux/x86_64/etc/bkmonitorbeat.conf.tpl` 的 Resource 段，并用 PyYAML 解析确认 YAML 合法

Made with [Cursor](https://cursor.com)