### PR TITLE
feat: （unify-query）跳过 db/dbs 为空的 ES 子任务以修复 raw_with_scroll 下载失败 --story=134166052

### DIFF
--- a/pkg/unify-query/metadata/struct.go
+++ b/pkg/unify-query/metadata/struct.go
@@ -225,6 +225,22 @@ func (q *Query) GetMergeDBStatus() bool {
 	return false
 }
 
+// IsElasticsearchIndexPrefixMissing 表示 ES 查询缺少可用的索引前缀（db / dbs）。
+func (q *Query) IsElasticsearchIndexPrefixMissing() bool {
+	if q == nil || q.StorageType != ElasticsearchStorageType {
+		return false
+	}
+	if strings.TrimSpace(q.DB) != "" {
+		return false
+	}
+	for _, db := range q.DBs {
+		if strings.TrimSpace(db) != "" {
+			return false
+		}
+	}
+	return true
+}
+
 func (q *Query) VMExpand() *VmExpand {
 	return &VmExpand{
 		ResultTableList: []string{q.VmRt},
@@ -394,6 +410,34 @@ func (qRef QueryReference) Count() int {
 	})
 
 	return i
+}
+
+func (qRef QueryReference) Filter(fn func(qry *Query) bool) QueryReference {
+	filtered := make(QueryReference, len(qRef))
+	for refName, references := range qRef {
+		for _, reference := range references {
+			if reference == nil {
+				continue
+			}
+
+			queryList := make(QueryList, 0, len(reference.QueryList))
+			for _, query := range reference.QueryList {
+				if query == nil || !fn(query) {
+					continue
+				}
+				queryList = append(queryList, query)
+			}
+			if len(queryList) == 0 {
+				continue
+			}
+
+			nextReference := *reference
+			nextReference.QueryList = queryList
+			filtered[refName] = append(filtered[refName], &nextReference)
+		}
+	}
+
+	return filtered
 }
 
 // Range 遍历查询列表

--- a/pkg/unify-query/service/http/query.go
+++ b/pkg/unify-query/service/http/query.go
@@ -41,20 +41,26 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/tsdb/redis"
 )
 
-// elasticsearchMissingIndexPrefix 表示 ES 查询缺少可用的索引前缀（db / dbs），此时下游 checkQuery 与 getAlias 必然失败；跳过可避免 raw / scroll 整批被单个元数据异常的表导致报错
-func elasticsearchMissingIndexPrefix(q *metadata.Query) bool {
-	if q == nil || q.StorageType != metadata.ElasticsearchStorageType {
-		return false
-	}
-	if strings.TrimSpace(q.DB) != "" {
-		return false
-	}
-	for _, db := range q.DBs {
-		if strings.TrimSpace(db) != "" {
-			return false
+func warnElasticsearchIndexPrefixMissing(ctx context.Context, qry *metadata.Query, msgType string) {
+	metadata.NewMessage(
+		msgType,
+		"%s ES 元数据 db(索引前缀)为空且无有效 dbs，已跳过该结果表",
+		qry.TableID,
+	).Warn(ctx)
+}
+
+func excludeElasticsearchIndexPrefixMissingQueries(ctx context.Context, queryRef metadata.QueryReference, msgType string, onSkip func(*metadata.Query)) metadata.QueryReference {
+	return queryRef.Filter(func(qry *metadata.Query) bool {
+		if !qry.IsElasticsearchIndexPrefixMissing() {
+			return true
 		}
-	}
-	return true
+
+		warnElasticsearchIndexPrefixMissing(ctx, qry, msgType)
+		if onSkip != nil {
+			onSkip(qry)
+		}
+		return false
+	})
 }
 
 func queryExemplar(ctx context.Context, query *structured.QueryTs) (any, error) {
@@ -191,6 +197,7 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 	if err != nil {
 		return total, list, resultTableOptions, err
 	}
+	queryRef = excludeElasticsearchIndexPrefixMissingQueries(ctx, queryRef, metadata.MsgQueryRaw, nil)
 
 	receiveWg.Add(1)
 	go func() {
@@ -351,15 +358,6 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 					sendWg.Done()
 				}()
 
-				if elasticsearchMissingIndexPrefix(qry) {
-					metadata.NewMessage(
-						metadata.MsgQueryRaw,
-						"%s ES 元数据 db(索引前缀)为空且无有效 dbs，已跳过该结果表",
-						qry.TableID,
-					).Warn(ctx)
-					return
-				}
-
 				instance := prometheus.GetTsDbInstance(ctx, qry)
 				if instance == nil {
 					errCh <- metadata.NewMessage(
@@ -460,6 +458,15 @@ func queryRawWithScroll(ctx context.Context, queryTs *structured.QueryTs, sessio
 			"查询参数配置异常",
 		).Error(ctx, err)
 	}
+	queryRef = excludeElasticsearchIndexPrefixMissingQueries(ctx, queryRef, metadata.MsgQueryRawScroll, func(qry *metadata.Query) {
+		for i := 0; i < session.SliceLength(); i++ {
+			sliceQry := *qry
+			sliceQry.SliceID = cast.ToString(i)
+			slice := session.Slice(sliceQry.TableUUID())
+			slice.Status = redisUtil.StatusCompleted
+			session.UpdateSliceStatus(sliceQry.TableUUID(), slice)
+		}
+	})
 
 	receiveWg.Add(1)
 	go func() {
@@ -526,16 +533,6 @@ func queryRawWithScroll(ctx context.Context, queryTs *structured.QueryTs, sessio
 				}()
 
 				if slice.Done() {
-					return
-				}
-
-				if elasticsearchMissingIndexPrefix(newQry) {
-					slice.Status = redisUtil.StatusCompleted
-					metadata.NewMessage(
-						metadata.MsgQueryRawScroll,
-						"%s ES 元数据 db(索引前缀)为空且无有效 dbs，已跳过该结果表",
-						newQry.TableID,
-					).Warn(ctx)
 					return
 				}
 

--- a/pkg/unify-query/service/http/query.go
+++ b/pkg/unify-query/service/http/query.go
@@ -41,6 +41,22 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/tsdb/redis"
 )
 
+// elasticsearchMissingIndexPrefix 表示 ES 查询缺少可用的索引前缀（db / dbs），此时下游 checkQuery 与 getAlias 必然失败；跳过可避免 raw / scroll 整批被单个元数据异常的表导致报错
+func elasticsearchMissingIndexPrefix(q *metadata.Query) bool {
+	if q == nil || q.StorageType != metadata.ElasticsearchStorageType {
+		return false
+	}
+	if strings.TrimSpace(q.DB) != "" {
+		return false
+	}
+	for _, db := range q.DBs {
+		if strings.TrimSpace(db) != "" {
+			return false
+		}
+	}
+	return true
+}
+
 func queryExemplar(ctx context.Context, query *structured.QueryTs) (any, error) {
 	var (
 		err error
@@ -335,6 +351,15 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 					sendWg.Done()
 				}()
 
+				if elasticsearchMissingIndexPrefix(qry) {
+					metadata.NewMessage(
+						metadata.MsgQueryRaw,
+						"%s ES 元数据 db(索引前缀)为空且无有效 dbs，已跳过该结果表",
+						qry.TableID,
+					).Warn(ctx)
+					return
+				}
+
 				instance := prometheus.GetTsDbInstance(ctx, qry)
 				if instance == nil {
 					errCh <- metadata.NewMessage(
@@ -501,6 +526,16 @@ func queryRawWithScroll(ctx context.Context, queryTs *structured.QueryTs, sessio
 				}()
 
 				if slice.Done() {
+					return
+				}
+
+				if elasticsearchMissingIndexPrefix(newQry) {
+					slice.Status = redisUtil.StatusCompleted
+					metadata.NewMessage(
+						metadata.MsgQueryRawScroll,
+						"%s ES 元数据 db(索引前缀)为空且无有效 dbs，已跳过该结果表",
+						newQry.TableID,
+					).Warn(ctx)
 					return
 				}
 

--- a/pkg/unify-query/service/http/query_test.go
+++ b/pkg/unify-query/service/http/query_test.go
@@ -4805,6 +4805,107 @@ func TestQueryRawPartialSuccessMultiRoute(t *testing.T) {
 	assert.Contains(t, st.Message, "query error:")
 }
 
+// TestQueryRaw_ES_empty_db_skipped ES 元数据 db/dbs 全空时跳过该结果表，raw 请求不失败、无数据。
+func TestQueryRaw_ES_empty_db_skipped(t *testing.T) {
+	mock.Init()
+	ctx := metadata.InitHashID(context.Background())
+	influxdb.MockSpaceRouter(ctx)
+	promql.MockEngine()
+
+	const badTable = "2_bklog.repro_empty_db_es"
+	qts := &structured.QueryTs{
+		SpaceUid: influxdb.SpaceUid,
+		QueryList: []*structured.Query{
+			{
+				DataSource:    structured.BkLog,
+				ReferenceName: "ref",
+				TableID:       structured.TableID(badTable),
+				KeepColumns:   []string{"level"},
+				Limit:         10,
+			},
+		},
+		Start: "1723594000",
+		End:   "1723595000",
+		TsDBMap: map[string]structured.TsDBs{
+			"ref": []*queryPkg.TsDBV2{
+				{
+					TableID:     badTable,
+					DataLabel:   "es",
+					DB:          "",
+					StorageType: metadata.ElasticsearchStorageType,
+					StorageID:   "3",
+					TimeField: metadata.TimeField{
+						Name: "dtEventTimeStamp",
+						Type: "long",
+						Unit: "millisecond",
+					},
+				},
+			},
+		},
+	}
+
+	total, list, _, err := queryRawWithInstance(ctx, qts)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), total)
+	assert.Empty(t, list)
+}
+
+// TestQueryRawWithScroll_ES_empty_db_skipped ES 元数据 db/dbs 全空时跳过该表：单次 scroll 不报错且会话可 Done。
+func TestQueryRawWithScroll_ES_empty_db_skipped(t *testing.T) {
+	mock.Init()
+	ctx := metadata.InitHashID(context.Background())
+	influxdb.MockSpaceRouter(ctx)
+	promql.MockEngine()
+
+	const badTable = "2_bklog.repro_scroll_empty_db_es"
+	qts := &structured.QueryTs{
+		SpaceUid: influxdb.SpaceUid,
+		QueryList: []*structured.Query{
+			{
+				DataSource:    structured.BkLog,
+				ReferenceName: "ref",
+				TableID:       structured.TableID(badTable),
+				KeepColumns:   []string{"level"},
+			},
+		},
+		Start:    "1757051309",
+		End:      "1757054909",
+		Step:     "1m",
+		Limit:    10,
+		Scroll:   "1m",
+		SliceMax: 1,
+		TsDBMap: map[string]structured.TsDBs{
+			"ref": []*queryPkg.TsDBV2{
+				{
+					TableID:     badTable,
+					DataLabel:   "es",
+					DB:          "",
+					StorageType: metadata.ElasticsearchStorageType,
+					StorageID:   "3",
+					TimeField: metadata.TimeField{
+						Name: "dtEventTimeStamp",
+						Type: "long",
+						Unit: "second",
+					},
+				},
+			},
+		},
+	}
+
+	queryByte, _ := json.Marshal(qts)
+	session, err := redisUtil.GetOrCreateScrollSession(ctx, string(queryByte), ScrollWindowTimeout, ScrollSessionLockTimeout, qts.SliceMax, qts.Limit)
+	if err != nil {
+		t.Skipf("Redis: %v", err)
+		return
+	}
+	defer func() { _ = session.Clear(ctx) }()
+
+	_, list, _, done, err := queryRawWithScroll(ctx, qts, session)
+	assert.NoError(t, err)
+	assert.Empty(t, list)
+	assert.True(t, done, "skipped bad table should mark slice completed so session Done")
+}
+
 // TestQueryTsPartialSuccessMultiRoute query/ts 多路查询时，至少一路成功应返回成功并标记 QueryTsPartial。
 func TestQueryTsPartialSuccessMultiRoute(t *testing.T) {
 	mock.Init()

--- a/pkg/unify-query/service/http/query_test.go
+++ b/pkg/unify-query/service/http/query_test.go
@@ -4850,6 +4850,85 @@ func TestQueryRaw_ES_empty_db_skipped(t *testing.T) {
 	assert.Empty(t, list)
 }
 
+// TestQueryRaw_ES_mixed_empty_db_and_ok 多结果表一路 ES 的 db 为空（跳过）、一路正常：应返回正常路数据且不应标记 Raw 部分失败。
+func TestQueryRaw_ES_mixed_empty_db_and_ok(t *testing.T) {
+	mock.Init()
+	ctx := metadata.InitHashID(context.Background())
+	metadata.SetUser(ctx, &metadata.User{SpaceUID: "bkcc__2"})
+
+	influxdb.MockSpaceRouter(ctx)
+
+	router, err := influxdb.GetSpaceTsDbRouter()
+	assert.NoError(t, err)
+
+	const mergeTable = "pr_empty_db_mixed_merge"
+	const okRT = "pr_empty_db_ok_rt"
+	const badRT = "pr_empty_db_bad_rt"
+
+	err = router.Add(ctx, ir.DataLabelToResultTableKey, mergeTable, &ir.ResultTableList{okRT, badRT})
+	assert.NoError(t, err)
+
+	err = router.Add(ctx, ir.ResultTableDetailKey, okRT, &ir.ResultTableDetail{
+		StorageId:   3,
+		TableId:     okRT,
+		DB:          "pr_mixed_ok_idx",
+		StorageType: "elasticsearch",
+		DataLabel:   "pr_mixed_ok",
+	})
+	assert.NoError(t, err)
+
+	err = router.Add(ctx, ir.ResultTableDetailKey, badRT, &ir.ResultTableDetail{
+		StorageId:   3,
+		TableId:     badRT,
+		DB:          "",
+		StorageType: "elasticsearch",
+		DataLabel:   "pr_mixed_bad",
+	})
+	assert.NoError(t, err)
+
+	space := router.GetSpace(ctx, "bkcc__2")
+	if space == nil {
+		space = make(ir.Space)
+	}
+	space[okRT] = &ir.SpaceResultTable{TableId: okRT}
+	space[badRT] = &ir.SpaceResultTable{TableId: badRT}
+	space[mergeTable] = &ir.SpaceResultTable{TableId: mergeTable}
+	err = router.Add(ctx, ir.SpaceToResultTableKey, "bkcc__2", &space)
+	assert.NoError(t, err)
+
+	const esURL = "http://127.0.0.1:93002"
+	mapBody := `{"pr_mixed_ok_idx":{"mappings":{"properties":{"dtEventTimeStamp":{"type":"date"},"log":{"type":"text"}}}}}`
+	httpmock.RegisterResponder(http.MethodGet, esURL+"/pr_mixed_ok_idx", httpmock.NewStringResponder(http.StatusOK, mapBody))
+	httpmock.RegisterResponder(http.MethodGet, esURL+"/pr_mixed_ok_idx/_mapping/", httpmock.NewStringResponder(http.StatusOK, mapBody))
+
+	okSearch := `{"took":1,"hits":{"total":{"value":1,"relation":"eq"},"hits":[{"_index":"pr_mixed_ok_idx","_id":"x1","_source":{"dtEventTimeStamp":"1752141800000","log":"mixed-ok"}}]}}`
+	httpmock.RegisterResponder(http.MethodPost, esURL+"/pr_mixed_ok_idx/_search", httpmock.NewStringResponder(http.StatusOK, okSearch))
+
+	queryTs := &structured.QueryTs{
+		SpaceUid: "bkcc__2",
+		QueryList: []*structured.Query{
+			{
+				TableID:   mergeTable,
+				FieldList: []string{"dtEventTimeStamp", "log"},
+			},
+		},
+		Start: "1752141400000",
+		End:   "1752141900000",
+		Limit: 50,
+	}
+
+	total, list, _, qerr := queryRawWithInstance(ctx, queryTs)
+	assert.NoError(t, qerr)
+	assert.Greater(t, total, int64(0))
+	assert.NotEmpty(t, list)
+	assert.Equal(t, "mixed-ok", list[0]["log"])
+
+	st := metadata.GetStatus(ctx)
+	if st != nil {
+		assert.NotEqual(t, metadata.QueryRawPartial, st.Code, "跳过缺索引前缀的 ES 子任务不应记为 Raw 部分失败")
+	}
+}
+
 // TestQueryRawWithScroll_ES_empty_db_skipped ES 元数据 db/dbs 全空时跳过该表：单次 scroll 不报错且会话可 Done。
 func TestQueryRawWithScroll_ES_empty_db_skipped(t *testing.T) {
 	mock.Init()


### PR DESCRIPTION
## 1. 背景

`query/raw` 和 `raw_with_scroll` 多结果表并发查询时，如果某些 ES 子查询元数据里的索引前缀缺失，即 `db` 和 `dbs` 都为空，下游查询会直接失败。

当前实现中，任意一个子任务报错都会拉高整次请求失败，导致其它正常结果表也无法返回。

## 2. 改动

本 PR 在进入真实 ES 查询前，预先识别并跳过这类 `db/dbs` 均为空的 ES 子查询：

- `query/raw` 路径：记录 `Warn` 日志并跳过，不再写入 `errCh`
- `raw_with_scroll` 路径：同样跳过，并主动将对应 slice 标记为 `completed`，避免 scroll 会话无法结束

同时补充了对应测试，覆盖：

- raw 场景下坏 ES 子查询被跳过
- scroll 场景下坏 ES 子查询被跳过且会话可正常结束

## 3. 行为变化

变更前：
- 只要请求里有一个这类坏 ES 子查询，整次 raw / scroll 请求都可能失败

变更后：
- 坏 ES 子查询会被跳过
- 其它正常结果表不受影响
- 如果整次请求里全是这类坏表，则接口成功返回空结果，需结合 Warn 日志排查
