### PR TITLE
feat: （unify-query）Check 校验接口返回子查询路由与结果表信息 --story=134190079

### DIFF
--- a/pkg/unify-query/docs/api/api.md
+++ b/pkg/unify-query/docs/api/api.md
@@ -654,10 +654,11 @@
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `data` | array | 每项为某子查询存储 **`tsdb.Instance.GetRequestBody(ctx)`** 的 JSON；直查 VM 时常为 **单元素**，形态见下表 `VmQueryCheckBody` |
+| `data` | array | 每项为某子查询存储 **`tsdb.Instance.GetRequestBody(ctx)`** 的 JSON；直查 VM 时常为 **单元素**，形态见下表 `VmQueryCheckBody`。**可为空数组**：当各存储未实现预览体时，若 `route_rows` 非空仍返回 **HTTP 200**（仅路由预览，不调 TSDB） |
+| `route_rows` | array | 与 **`ToQueryReference`** 展开后的子查询一一对应的路由摘要（`table_id`、`db`、`data_label`、`storage_type` 等），用于与正式查询对齐排障 |
 | `trace_id` | string | 链路追踪 ID |
 
-**失败（HTTP 400）**：`ErrResponse`，含 `error`（及可选 `trace_id`）。
+**失败（HTTP 400）**：`ErrResponse`，含 `error`（及可选 `trace_id`）。当 **`route_rows` 与 `data` 皆为空**（无任何子查询路由）时仍为 400。
 
 ### 5.1 直查 VM 时 `data[]` 元素形态（`VmQueryCheckBody`）
 
@@ -669,7 +670,7 @@
 
 ### 5.2 非直查
 
-当前实现：遍历子查询 `GetTsDbInstance`，再调用 **`GetRequestBody(ctx)`**；**`DefaultInstance`** 等无预览体时返回 **(nil, nil)**，该子查询**不产生** `data` 元素（内部打日志跳过）。若遍历结束后 **`data` 仍为空** 则 **400**（「未解析到可路由的查询」），而非 200 空数组。
+遍历子查询 `GetTsDbInstance`，再调用 **`GetRequestBody(ctx)`**；**`DefaultInstance`** 等无预览体时返回 **(nil, nil)**，该子查询**不产生** `data` 元素（内部打日志跳过）。**若遍历结束后 `data` 仍为空，但 `ToQueryReference` 已展开出子查询**，则 **`route_rows` 非空**，接口返回 **200** 且 `data` 为空数组，便于路由排障；仅当 **`route_rows` 与 `data` 皆空** 时返回 **400**（「未解析到可路由的查询」）。
 
 ### 5.3 校验结构体查询
 

--- a/pkg/unify-query/docs/api/api.md
+++ b/pkg/unify-query/docs/api/api.md
@@ -654,11 +654,11 @@
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `data` | array | 每项为某子查询存储 **`tsdb.Instance.GetRequestBody(ctx)`** 的 JSON；直查 VM 时常为 **单元素**，形态见下表 `VmQueryCheckBody`。**可为空数组**：当各存储未实现预览体时，若 `route_rows` 非空仍返回 **HTTP 200**（仅路由预览，不调 TSDB） |
-| `route_rows` | array | 与 **`ToQueryReference`** 展开后的子查询一一对应的路由摘要（`table_id`、`db`、`data_label`、`storage_type` 等），用于与正式查询对齐排障 |
+| `data` | array | 每项为某子查询存储 **`tsdb.Instance.GetRequestBody(ctx)`** 的 JSON；直查 VM 时常为 **单元素**，形态见下表 `VmQueryCheckBody`。**可为空数组**：当各存储未实现预览体时，若 `route_info` 非空仍返回 **HTTP 200**（仅路由预览，不调 TSDB） |
+| `route_info` | array | 与 **`ToQueryReference`** 展开后的子查询一一对应的路由摘要（`table_id`、`db`、`data_label`、`storage_type` 等），用于与正式查询对齐排障。对应 Go 字段 **`RouteInfo`**（`CheckQueryTsDataResponse`） |
 | `trace_id` | string | 链路追踪 ID |
 
-**失败（HTTP 400）**：`ErrResponse`，含 `error`（及可选 `trace_id`）。当 **`route_rows` 与 `data` 皆为空**（无任何子查询路由）时仍为 400。
+**失败（HTTP 400）**：`ErrResponse`，含 `error`（及可选 `trace_id`）。当 **`route_info` 与 `data` 皆为空**（无任何子查询路由）时仍为 400。
 
 ### 5.1 直查 VM 时 `data[]` 元素形态（`VmQueryCheckBody`）
 
@@ -670,7 +670,7 @@
 
 ### 5.2 非直查
 
-遍历子查询 `GetTsDbInstance`，再调用 **`GetRequestBody(ctx)`**；**`DefaultInstance`** 等无预览体时返回 **(nil, nil)**，该子查询**不产生** `data` 元素（内部打日志跳过）。**若遍历结束后 `data` 仍为空，但 `ToQueryReference` 已展开出子查询**，则 **`route_rows` 非空**，接口返回 **200** 且 `data` 为空数组，便于路由排障；仅当 **`route_rows` 与 `data` 皆空** 时返回 **400**（「未解析到可路由的查询」）。
+遍历子查询 `GetTsDbInstance`，再调用 **`GetRequestBody(ctx)`**；**`DefaultInstance`** 等无预览体时返回 **(nil, nil)**，该子查询**不产生** `data` 元素（内部打日志跳过）。**若遍历结束后 `data` 仍为空，但 `ToQueryReference` 已展开出子查询**，则 **`route_info` 非空**，接口返回 **200** 且 `data` 为空数组，便于路由排障；仅当 **`route_info` 与 `data` 皆空** 时返回 **400**（「未解析到可路由的查询」）。
 
 ### 5.3 校验结构体查询
 

--- a/pkg/unify-query/docs/docs.go
+++ b/pkg/unify-query/docs/docs.go
@@ -1381,33 +1381,19 @@ const docTemplate = `{
                 }
             }
         },
-        "http.CheckRouteRow": {
-            "type": "object",
-            "properties": {
-                "reference_name": {"type": "string"},
-                "metric_name": {"type": "string"},
-                "table_id": {"type": "string"},
-                "db": {"type": "string"},
-                "data_label": {"type": "string"},
-                "data_source": {"type": "string"},
-                "storage_type": {"type": "string"},
-                "storage_id": {"type": "string"},
-                "measurement": {"type": "string"}
-            }
-        },
         "http.CheckQueryTsDataResponse": {
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody。非直查若某存储无预览体则该项不出现在 data 中；可为空数组，此时若 route_rows 非空仍返回 200 表示仅路由预览。",
+                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody。非直查若某存储无预览体则该项不出现在 data 中；可为空数组，此时若 route_info 非空仍返回 200 表示仅路由预览。",
                     "type": "array",
                     "items": {}
                 },
-                "route_rows": {
+                "route_info": {
                     "description": "与 ToQueryReference 展开后的子查询对应的路由摘要，用于排障（不调真实 TSDB）。",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/http.CheckRouteRow"
+                        "$ref": "#/definitions/metadata.CheckRouteInfo"
                     }
                 },
                 "trace_id": {
@@ -1620,6 +1606,20 @@ const docTemplate = `{
                 "field": {
                     "type": "string"
                 }
+            }
+        },
+        "metadata.CheckRouteInfo": {
+            "type": "object",
+            "properties": {
+                "reference_name": {"type": "string"},
+                "metric_name": {"type": "string"},
+                "table_id": {"type": "string"},
+                "db": {"type": "string"},
+                "data_label": {"type": "string"},
+                "data_source": {"type": "string"},
+                "storage_type": {"type": "string"},
+                "storage_id": {"type": "string"},
+                "measurement": {"type": "string"}
             }
         },
         "metadata.FieldAlias": {

--- a/pkg/unify-query/docs/docs.go
+++ b/pkg/unify-query/docs/docs.go
@@ -1381,13 +1381,34 @@ const docTemplate = `{
                 }
             }
         },
+        "http.CheckRouteRow": {
+            "type": "object",
+            "properties": {
+                "reference_name": {"type": "string"},
+                "metric_name": {"type": "string"},
+                "table_id": {"type": "string"},
+                "db": {"type": "string"},
+                "data_label": {"type": "string"},
+                "data_source": {"type": "string"},
+                "storage_type": {"type": "string"},
+                "storage_id": {"type": "string"},
+                "measurement": {"type": "string"}
+            }
+        },
         "http.CheckQueryTsDataResponse": {
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody：metricql 由 vmCheckMetricql 生成后经 metadata.SetCheckPreviewMetricQL 写入，VM 实例在 GetRequestBody 中与 GetExpand 一并读出。非直查若某存储无预览体则跳过该项；若最终无任何元素则 400。不下发真实 TSDB。",
+                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody。非直查若某存储无预览体则该项不出现在 data 中；可为空数组，此时若 route_rows 非空仍返回 200 表示仅路由预览。",
                     "type": "array",
                     "items": {}
+                },
+                "route_rows": {
+                    "description": "与 ToQueryReference 展开后的子查询对应的路由摘要，用于排障（不调真实 TSDB）。",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/http.CheckRouteRow"
+                    }
                 },
                 "trace_id": {
                     "description": "TraceID 链路 ID（与 trace span 一致）。",

--- a/pkg/unify-query/docs/swagger.json
+++ b/pkg/unify-query/docs/swagger.json
@@ -1365,33 +1365,19 @@
                 }
             }
         },
-        "http.CheckRouteRow": {
-            "type": "object",
-            "properties": {
-                "reference_name": {"type": "string"},
-                "metric_name": {"type": "string"},
-                "table_id": {"type": "string"},
-                "db": {"type": "string"},
-                "data_label": {"type": "string"},
-                "data_source": {"type": "string"},
-                "storage_type": {"type": "string"},
-                "storage_id": {"type": "string"},
-                "measurement": {"type": "string"}
-            }
-        },
         "http.CheckQueryTsDataResponse": {
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody。非直查无预览体则该项不出现；可为空数组，若 route_rows 非空仍 200 表示仅路由预览。",
+                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody。非直查无预览体则该项不出现；可为空数组，若 route_info 非空仍 200 表示仅路由预览。",
                     "type": "array",
                     "items": {}
                 },
-                "route_rows": {
+                "route_info": {
                     "description": "与 ToQueryReference 展开后的子查询对应的路由摘要（不调真实 TSDB）。",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/http.CheckRouteRow"
+                        "$ref": "#/definitions/metadata.CheckRouteInfo"
                     }
                 },
                 "trace_id": {
@@ -1604,6 +1590,20 @@
                 "field": {
                     "type": "string"
                 }
+            }
+        },
+        "metadata.CheckRouteInfo": {
+            "type": "object",
+            "properties": {
+                "reference_name": {"type": "string"},
+                "metric_name": {"type": "string"},
+                "table_id": {"type": "string"},
+                "db": {"type": "string"},
+                "data_label": {"type": "string"},
+                "data_source": {"type": "string"},
+                "storage_type": {"type": "string"},
+                "storage_id": {"type": "string"},
+                "measurement": {"type": "string"}
             }
         },
         "metadata.FieldAlias": {

--- a/pkg/unify-query/docs/swagger.json
+++ b/pkg/unify-query/docs/swagger.json
@@ -1365,13 +1365,34 @@
                 }
             }
         },
+        "http.CheckRouteRow": {
+            "type": "object",
+            "properties": {
+                "reference_name": {"type": "string"},
+                "metric_name": {"type": "string"},
+                "table_id": {"type": "string"},
+                "db": {"type": "string"},
+                "data_label": {"type": "string"},
+                "data_source": {"type": "string"},
+                "storage_type": {"type": "string"},
+                "storage_id": {"type": "string"},
+                "measurement": {"type": "string"}
+            }
+        },
         "http.CheckQueryTsDataResponse": {
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody：metricql 由 vmCheckMetricql 生成后经 metadata.SetCheckPreviewMetricQL 写入，VM 实例在 GetRequestBody 中与 GetExpand 一并读出。非直查若某存储无预览体则跳过该项；若最终无任何元素则 400。不下发真实 TSDB。",
+                    "description": "Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody。非直查无预览体则该项不出现；可为空数组，若 route_rows 非空仍 200 表示仅路由预览。",
                     "type": "array",
                     "items": {}
+                },
+                "route_rows": {
+                    "description": "与 ToQueryReference 展开后的子查询对应的路由摘要（不调真实 TSDB）。",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/http.CheckRouteRow"
+                    }
                 },
                 "trace_id": {
                     "description": "TraceID 链路 ID（与 trace span 一致）。",

--- a/pkg/unify-query/docs/swagger.yaml
+++ b/pkg/unify-query/docs/swagger.yaml
@@ -134,38 +134,17 @@ definitions:
       target_type:
         type: string
     type: object
-  http.CheckRouteRow:
-    properties:
-      data_label:
-        type: string
-      data_source:
-        type: string
-      db:
-        type: string
-      measurement:
-        type: string
-      metric_name:
-        type: string
-      reference_name:
-        type: string
-      storage_id:
-        type: string
-      storage_type:
-        type: string
-      table_id:
-        type: string
-    type: object
   http.CheckQueryTsDataResponse:
     properties:
       data:
         description: Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM
-          常为单元素 VmQueryCheckBody。非直查无预览体则该项不出现；可为空数组，若 route_rows 非空仍 200 表示仅路由预览。
+          常为单元素 VmQueryCheckBody。非直查无预览体则该项不出现；可为空数组，若 route_info 非空仍 200 表示仅路由预览。
         items: {}
         type: array
-      route_rows:
+      route_info:
         description: 与 ToQueryReference 展开后的子查询对应的路由摘要（不调真实 TSDB）。
         items:
-          $ref: '#/definitions/http.CheckRouteRow'
+          $ref: '#/definitions/metadata.CheckRouteInfo'
         type: array
       trace_id:
         description: TraceID 链路 ID（与 trace span 一致）。
@@ -305,6 +284,27 @@ definitions:
   metadata.Collapse:
     properties:
       field:
+        type: string
+    type: object
+  metadata.CheckRouteInfo:
+    properties:
+      data_label:
+        type: string
+      data_source:
+        type: string
+      db:
+        type: string
+      measurement:
+        type: string
+      metric_name:
+        type: string
+      reference_name:
+        type: string
+      storage_id:
+        type: string
+      storage_type:
+        type: string
+      table_id:
         type: string
     type: object
   metadata.FieldAlias:

--- a/pkg/unify-query/docs/swagger.yaml
+++ b/pkg/unify-query/docs/swagger.yaml
@@ -134,14 +134,38 @@ definitions:
       target_type:
         type: string
     type: object
+  http.CheckRouteRow:
+    properties:
+      data_label:
+        type: string
+      data_source:
+        type: string
+      db:
+        type: string
+      measurement:
+        type: string
+      metric_name:
+        type: string
+      reference_name:
+        type: string
+      storage_id:
+        type: string
+      storage_type:
+        type: string
+      table_id:
+        type: string
+    type: object
   http.CheckQueryTsDataResponse:
     properties:
       data:
         description: Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM
-          常为单元素 VmQueryCheckBody：metricql 由 vmCheckMetricql 生成后经 metadata.SetCheckPreviewMetricQL
-          写入，VM 实例在 GetRequestBody 中与 GetExpand 一并读出。非直查若某存储无预览体则跳过该项；若最终无任何元素则 400。不下发真实
-          TSDB。
+          常为单元素 VmQueryCheckBody。非直查无预览体则该项不出现；可为空数组，若 route_rows 非空仍 200 表示仅路由预览。
         items: {}
+        type: array
+      route_rows:
+        description: 与 ToQueryReference 展开后的子查询对应的路由摘要（不调真实 TSDB）。
+        items:
+          $ref: '#/definitions/http.CheckRouteRow'
         type: array
       trace_id:
         description: TraceID 链路 ID（与 trace span 一致）。

--- a/pkg/unify-query/metadata/struct.go
+++ b/pkg/unify-query/metadata/struct.go
@@ -209,6 +209,21 @@ type Query struct {
 	IsMergeDB bool `json:"is_merge_db"`
 }
 
+// ToCheckRouteInfo 生成 Check 接口用的单条子查询路由摘要，不调用实际 TSDB 查询
+func (q *Query) ToCheckRouteInfo(referenceName, metricName string) CheckRouteInfo {
+	return CheckRouteInfo{
+		ReferenceName: referenceName,
+		MetricName:    metricName,
+		TableID:       q.TableID,
+		DB:            q.DB,
+		DataLabel:     q.DataLabel,
+		DataSource:    q.DataSource,
+		StorageType:   q.StorageType,
+		StorageID:     q.StorageID,
+		Measurement:   q.Measurement,
+	}
+}
+
 // GetMergeDBStatus 判断是否进行 db 合并处理
 func (q *Query) GetMergeDBStatus() bool {
 	// 如果 db 为空，则不需要合并
@@ -325,6 +340,46 @@ type QueryClusterMetric struct {
 }
 
 type QueryReference map[string][]*QueryMetric
+
+// CheckRouteInfo Check 单条子查询路由摘要（与 Query 同源；不含敏感字段；不调真实 TSDB）。
+type CheckRouteInfo struct {
+	ReferenceName string `json:"reference_name"`
+	MetricName    string `json:"metric_name,omitempty"`
+	TableID       string `json:"table_id"`
+	DB            string `json:"db,omitempty"`
+	DataLabel     string `json:"data_label,omitempty"`
+	DataSource    string `json:"data_source,omitempty"`
+	StorageType   string `json:"storage_type,omitempty"`
+	StorageID     string `json:"storage_id,omitempty"`
+	Measurement   string `json:"measurement,omitempty"`
+}
+
+// CollectCheckRouteInfo 汇总子查询路由字段；reference 名排序以保证输出稳定。
+func (qRef QueryReference) CollectCheckRouteInfo() []CheckRouteInfo {
+	if len(qRef) == 0 {
+		return nil
+	}
+	refs := make([]string, 0, len(qRef))
+	for ref := range qRef {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	rows := make([]CheckRouteInfo, 0)
+	for _, refName := range refs {
+		for _, qm := range qRef[refName] {
+			if qm == nil {
+				continue
+			}
+			for _, qry := range qm.QueryList {
+				if qry == nil {
+					continue
+				}
+				rows = append(rows, qry.ToCheckRouteInfo(refName, qm.MetricName))
+			}
+		}
+	}
+	return rows
+}
 
 type Queries struct {
 	Query QueryReference

--- a/pkg/unify-query/metadata/struct_test.go
+++ b/pkg/unify-query/metadata/struct_test.go
@@ -189,3 +189,39 @@ func TestReplaceVmCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestQuery_ToCheckRouteInfo(t *testing.T) {
+	q := &Query{
+		TableID:     "rt.es",
+		DB:          "es_index",
+		DataLabel:   "es",
+		DataSource:  "bklog",
+		StorageType: "elasticsearch",
+		StorageID:   "3",
+		Measurement: "__default__",
+	}
+	info := q.ToCheckRouteInfo("ref_a", "metric_b")
+	assert.Equal(t, CheckRouteInfo{
+		ReferenceName: "ref_a",
+		MetricName:    "metric_b",
+		TableID:       "rt.es",
+		DB:            "es_index",
+		DataLabel:     "es",
+		DataSource:    "bklog",
+		StorageType:   "elasticsearch",
+		StorageID:     "3",
+		Measurement:   "__default__",
+	}, info)
+}
+
+func TestQueryReference_CollectCheckRouteInfo_ReferenceOrderStable(t *testing.T) {
+	qr := QueryReference{
+		"z": {{QueryList: []*Query{{TableID: "tz"}}}},
+		"a": {{QueryList: []*Query{{TableID: "ta"}}}},
+	}
+	rows := qr.CollectCheckRouteInfo()
+	assert.Equal(t, []CheckRouteInfo{
+		{ReferenceName: "a", TableID: "ta"},
+		{ReferenceName: "z", TableID: "tz"},
+	}, rows)
+}

--- a/pkg/unify-query/service/http/check_handler.go
+++ b/pkg/unify-query/service/http/check_handler.go
@@ -31,12 +31,65 @@ import (
 
 // --- 响应体
 
+// CheckRouteRow Check 单条子查询路由摘要（与 metadata.Query 同源；不含敏感字段；不调真实 TSDB）。
+type CheckRouteRow struct {
+	ReferenceName string `json:"reference_name"`
+	MetricName    string `json:"metric_name,omitempty"`
+	TableID       string `json:"table_id"`
+	DB            string `json:"db,omitempty"`
+	DataLabel     string `json:"data_label,omitempty"`
+	DataSource    string `json:"data_source,omitempty"`
+	StorageType   string `json:"storage_type,omitempty"`
+	StorageID     string `json:"storage_id,omitempty"`
+	Measurement   string `json:"measurement,omitempty"`
+}
+
 // CheckQueryTsDataResponse check 接口成功响应体。
 type CheckQueryTsDataResponse struct {
-	// Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody：metricql 由 vmCheckMetricql 生成后经 metadata.SetCheckPreviewMetricQL 写入，VM 实例在 GetRequestBody 中与 GetExpand 一并读出。非直查若某存储无预览体则跳过该项；若最终无任何元素则 400。不下发真实 TSDB。
+	// Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody：metricql 由 vmCheckMetricql 生成后经 metadata.SetCheckPreviewMetricQL 写入，VM 实例在 GetRequestBody 中与 GetExpand 一并读出。非直查若某存储无预览体则该项不出现在 data 中。
+	// Data 可为空：当仅有路由预览（RouteRows 非空）且各存储未实现 GetRequestBody 预览体时，不调真实 TSDB 仍返回 200。
 	Data []any `json:"data"`
+	// RouteRows 与 ToQueryReference 展开后的每条子查询一一对应，用于路由排障（如 table_id、db 是否为空）。与 data 是否为空无关。
+	RouteRows []CheckRouteRow `json:"route_rows,omitempty"`
 	// TraceID 链路 ID（与 trace span 一致）。
 	TraceID string `json:"trace_id"`
+}
+
+// collectRouteRows 从 QueryReference 汇总子查询路由字段；reference 名排序以保证输出稳定。
+func collectRouteRows(qr metadata.QueryReference) []CheckRouteRow {
+	if len(qr) == 0 {
+		return nil
+	}
+	refs := make([]string, 0, len(qr))
+	for ref := range qr {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	rows := make([]CheckRouteRow, 0)
+	for _, refName := range refs {
+		for _, qm := range qr[refName] {
+			if qm == nil {
+				continue
+			}
+			for _, qry := range qm.QueryList {
+				if qry == nil {
+					continue
+				}
+				rows = append(rows, CheckRouteRow{
+					ReferenceName: refName,
+					MetricName:    qm.MetricName,
+					TableID:       qry.TableID,
+					DB:            qry.DB,
+					DataLabel:     qry.DataLabel,
+					DataSource:    qry.DataSource,
+					StorageType:   qry.StorageType,
+					StorageID:     qry.StorageID,
+					Measurement:   qry.Measurement,
+				})
+			}
+		}
+	}
+	return rows
 }
 
 // --- HTTP Handlers
@@ -77,15 +130,16 @@ func HandlerCheckQueryTs(c *gin.Context) {
 		queryTs.SpaceUid = user.SpaceUID
 	}
 
-	data, err := checkQueryTsData(ctx, queryTs)
+	data, routeRows, err := checkQueryTsData(ctx, queryTs)
 	if err != nil {
 		resp.failed(ctx, err)
 		return
 	}
 
 	resp.success(ctx, CheckQueryTsDataResponse{
-		Data:    data,
-		TraceID: span.TraceID(),
+		Data:      data,
+		RouteRows: routeRows,
+		TraceID:   span.TraceID(),
 	})
 }
 
@@ -131,15 +185,16 @@ func HandlerCheckQueryPromQL(c *gin.Context) {
 		queryTs.SpaceUid = user.SpaceUID
 	}
 
-	data, err := checkQueryTsData(ctx, queryTs)
+	data, routeRows, err := checkQueryTsData(ctx, queryTs)
 	if err != nil {
 		resp.failed(ctx, err)
 		return
 	}
 
 	resp.success(ctx, CheckQueryTsDataResponse{
-		Data:    data,
-		TraceID: span.TraceID(),
+		Data:      data,
+		RouteRows: routeRows,
+		TraceID:   span.TraceID(),
 	})
 }
 
@@ -147,12 +202,13 @@ func HandlerCheckQueryPromQL(c *gin.Context) {
 
 // checkQueryTsData 将 QueryTs 转为 QueryReference，再按直查/非直查组装预览（不调真实 TSDB）。
 // 直查 VM：vmCheckMetricql 后 SetCheckPreviewMetricQL；与 queryTsToInstanceAndStmt 同源 GetTsDbInstance(VM)，Instance.GetRequestBody(ctx) 产出 VmQueryCheckBody。
-// 非直查：统一经 GetTsDbInstance + GetRequestBody，默认实现返回 nil 预览体则跳过。todo: 未来扩展具体预览体
-func checkQueryTsData(ctx context.Context, q *structured.QueryTs) ([]any, error) {
+// 非直查：统一经 GetTsDbInstance + GetRequestBody，默认实现返回 nil 预览体则跳过；若 RouteRows 非空仍返回 200 以便路由排障。
+func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, routeRows []CheckRouteRow, err error) {
 	qr, err := checkQueryTsToReference(ctx, q)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	routeRows = collectRouteRows(qr)
 
 	if metadata.GetQueryParams(ctx).IsDirectQuery() {
 		// 与 queryTsToInstanceAndStmt 直查分支一致：ToVmExpand + SetExpand，后续与 DirectQuery 同源读 GetExpand。
@@ -161,7 +217,7 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) ([]any, error)
 
 		promQL, err := vmCheckMetricql(ctx, q, qr)
 		if err != nil {
-			return nil, err
+			return nil, routeRows, err
 		}
 		metadata.SetCheckPreviewMetricQL(ctx, promQL)
 		instance := prometheus.GetTsDbInstance(ctx, &metadata.Query{
@@ -169,16 +225,16 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) ([]any, error)
 			StorageType: metadata.VictoriaMetricsStorageType,
 		})
 		if instance == nil {
-			return nil, fmt.Errorf("instance is null for direct vm check")
+			return nil, routeRows, fmt.Errorf("instance is null for direct vm check")
 		}
 		item, err := getCheckPreview(ctx, instance)
 		if err != nil {
-			return nil, err
+			return nil, routeRows, err
 		}
 		if item == nil {
-			return nil, fmt.Errorf("empty check preview for direct vm check")
+			return nil, routeRows, fmt.Errorf("empty check preview for direct vm check")
 		}
-		return []any{item}, nil
+		return []any{item}, routeRows, nil
 	}
 
 	// 非直查：遍历子查询 GetTsDbInstance + getCheckPreview（GetRequestBody 默认 nil 预览体则跳过）todo: 未来扩展各存储预览体
@@ -203,15 +259,18 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) ([]any, error)
 		}
 	})
 	if rangeErr != nil {
-		return nil, rangeErr
+		return nil, routeRows, rangeErr
 	}
-	if len(out) == 0 {
-		return nil, metadata.NewMessage(
+	if len(out) == 0 && len(routeRows) == 0 {
+		return nil, nil, metadata.NewMessage(
 			metadata.MsgQueryReference,
 			"未解析到可路由的查询",
 		).Error(ctx, fmt.Errorf("empty check query reference"))
 	}
-	return out, nil
+	if out == nil {
+		out = []any{}
+	}
+	return out, routeRows, nil
 }
 
 // --- QueryReference（与 queryTsToInstanceAndStmt 前置对齐）

--- a/pkg/unify-query/service/http/check_handler.go
+++ b/pkg/unify-query/service/http/check_handler.go
@@ -31,65 +31,15 @@ import (
 
 // --- 响应体
 
-// CheckRouteRow Check 单条子查询路由摘要（与 metadata.Query 同源；不含敏感字段；不调真实 TSDB）。
-type CheckRouteRow struct {
-	ReferenceName string `json:"reference_name"`
-	MetricName    string `json:"metric_name,omitempty"`
-	TableID       string `json:"table_id"`
-	DB            string `json:"db,omitempty"`
-	DataLabel     string `json:"data_label,omitempty"`
-	DataSource    string `json:"data_source,omitempty"`
-	StorageType   string `json:"storage_type,omitempty"`
-	StorageID     string `json:"storage_id,omitempty"`
-	Measurement   string `json:"measurement,omitempty"`
-}
-
 // CheckQueryTsDataResponse check 接口成功响应体。
 type CheckQueryTsDataResponse struct {
 	// Data 每项为子查询对应 tsdb.Instance.GetRequestBody(ctx) 的序列化结果。直查 VM 常为单元素 VmQueryCheckBody：metricql 由 vmCheckMetricql 生成后经 metadata.SetCheckPreviewMetricQL 写入，VM 实例在 GetRequestBody 中与 GetExpand 一并读出。非直查若某存储无预览体则该项不出现在 data 中。
-	// Data 可为空：当仅有路由预览（RouteRows 非空）且各存储未实现 GetRequestBody 预览体时，不调真实 TSDB 仍返回 200。
+	// Data 可为空：当仅有路由预览（RouteInfo 非空）且各存储未实现 GetRequestBody 预览体时，不调真实 TSDB 仍返回 200。
 	Data []any `json:"data"`
-	// RouteRows 与 ToQueryReference 展开后的每条子查询一一对应，用于路由排障（如 table_id、db 是否为空）。与 data 是否为空无关。
-	RouteRows []CheckRouteRow `json:"route_rows,omitempty"`
+	// RouteInfo 与 ToQueryReference 展开后的每条子查询一一对应，用于路由排障（如 table_id、db 是否为空）。与 data 是否为空无关。
+	RouteInfo []metadata.CheckRouteInfo `json:"route_info,omitempty"`
 	// TraceID 链路 ID（与 trace span 一致）。
 	TraceID string `json:"trace_id"`
-}
-
-// collectRouteRows 从 QueryReference 汇总子查询路由字段；reference 名排序以保证输出稳定。
-func collectRouteRows(qr metadata.QueryReference) []CheckRouteRow {
-	if len(qr) == 0 {
-		return nil
-	}
-	refs := make([]string, 0, len(qr))
-	for ref := range qr {
-		refs = append(refs, ref)
-	}
-	sort.Strings(refs)
-	rows := make([]CheckRouteRow, 0)
-	for _, refName := range refs {
-		for _, qm := range qr[refName] {
-			if qm == nil {
-				continue
-			}
-			for _, qry := range qm.QueryList {
-				if qry == nil {
-					continue
-				}
-				rows = append(rows, CheckRouteRow{
-					ReferenceName: refName,
-					MetricName:    qm.MetricName,
-					TableID:       qry.TableID,
-					DB:            qry.DB,
-					DataLabel:     qry.DataLabel,
-					DataSource:    qry.DataSource,
-					StorageType:   qry.StorageType,
-					StorageID:     qry.StorageID,
-					Measurement:   qry.Measurement,
-				})
-			}
-		}
-	}
-	return rows
 }
 
 // --- HTTP Handlers
@@ -130,7 +80,7 @@ func HandlerCheckQueryTs(c *gin.Context) {
 		queryTs.SpaceUid = user.SpaceUID
 	}
 
-	data, routeRows, err := checkQueryTsData(ctx, queryTs)
+	data, routeInfo, err := checkQueryTsData(ctx, queryTs)
 	if err != nil {
 		resp.failed(ctx, err)
 		return
@@ -138,7 +88,7 @@ func HandlerCheckQueryTs(c *gin.Context) {
 
 	resp.success(ctx, CheckQueryTsDataResponse{
 		Data:      data,
-		RouteRows: routeRows,
+		RouteInfo: routeInfo,
 		TraceID:   span.TraceID(),
 	})
 }
@@ -185,7 +135,7 @@ func HandlerCheckQueryPromQL(c *gin.Context) {
 		queryTs.SpaceUid = user.SpaceUID
 	}
 
-	data, routeRows, err := checkQueryTsData(ctx, queryTs)
+	data, routeInfo, err := checkQueryTsData(ctx, queryTs)
 	if err != nil {
 		resp.failed(ctx, err)
 		return
@@ -193,7 +143,7 @@ func HandlerCheckQueryPromQL(c *gin.Context) {
 
 	resp.success(ctx, CheckQueryTsDataResponse{
 		Data:      data,
-		RouteRows: routeRows,
+		RouteInfo: routeInfo,
 		TraceID:   span.TraceID(),
 	})
 }
@@ -202,13 +152,13 @@ func HandlerCheckQueryPromQL(c *gin.Context) {
 
 // checkQueryTsData 将 QueryTs 转为 QueryReference，再按直查/非直查组装预览（不调真实 TSDB）。
 // 直查 VM：vmCheckMetricql 后 SetCheckPreviewMetricQL；与 queryTsToInstanceAndStmt 同源 GetTsDbInstance(VM)，Instance.GetRequestBody(ctx) 产出 VmQueryCheckBody。
-// 非直查：统一经 GetTsDbInstance + GetRequestBody，默认实现返回 nil 预览体则跳过；若 RouteRows 非空仍返回 200 以便路由排障。
-func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, routeRows []CheckRouteRow, err error) {
+// 非直查：统一经 GetTsDbInstance + GetRequestBody，默认实现返回 nil 预览体则跳过；若 RouteInfo 非空仍返回 200 以便路由排障。
+func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, routeInfo []metadata.CheckRouteInfo, err error) {
 	qr, err := checkQueryTsToReference(ctx, q)
 	if err != nil {
 		return nil, nil, err
 	}
-	routeRows = collectRouteRows(qr)
+	routeInfo = qr.CollectCheckRouteInfo()
 
 	if metadata.GetQueryParams(ctx).IsDirectQuery() {
 		// 与 queryTsToInstanceAndStmt 直查分支一致：ToVmExpand + SetExpand，后续与 DirectQuery 同源读 GetExpand。
@@ -217,7 +167,7 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, r
 
 		promQL, err := vmCheckMetricql(ctx, q, qr)
 		if err != nil {
-			return nil, routeRows, err
+			return nil, routeInfo, err
 		}
 		metadata.SetCheckPreviewMetricQL(ctx, promQL)
 		instance := prometheus.GetTsDbInstance(ctx, &metadata.Query{
@@ -225,20 +175,20 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, r
 			StorageType: metadata.VictoriaMetricsStorageType,
 		})
 		if instance == nil {
-			return nil, routeRows, fmt.Errorf("instance is null for direct vm check")
+			return nil, routeInfo, fmt.Errorf("instance is null for direct vm check")
 		}
 		item, err := getCheckPreview(ctx, instance)
 		if err != nil {
-			return nil, routeRows, err
+			return nil, routeInfo, err
 		}
 		if item == nil {
-			return nil, routeRows, fmt.Errorf("empty check preview for direct vm check")
+			return nil, routeInfo, fmt.Errorf("empty check preview for direct vm check")
 		}
-		return []any{item}, routeRows, nil
+		return []any{item}, routeInfo, nil
 	}
 
 	// 非直查：遍历子查询 GetTsDbInstance + getCheckPreview（GetRequestBody 默认 nil 预览体则跳过）todo: 未来扩展各存储预览体
-	var out []any
+	out := make([]any, 0)
 	var rangeErr error
 	qr.Range("", func(qry *metadata.Query) {
 		if rangeErr != nil {
@@ -259,9 +209,9 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, r
 		}
 	})
 	if rangeErr != nil {
-		return nil, routeRows, rangeErr
+		return nil, routeInfo, rangeErr
 	}
-	if len(out) == 0 && len(routeRows) == 0 {
+	if len(out) == 0 && len(routeInfo) == 0 {
 		return nil, nil, metadata.NewMessage(
 			metadata.MsgQueryReference,
 			"未解析到可路由的查询",
@@ -270,7 +220,7 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, r
 	if out == nil {
 		out = []any{}
 	}
-	return out, routeRows, nil
+	return out, routeInfo, nil
 }
 
 // --- QueryReference（与 queryTsToInstanceAndStmt 前置对齐）

--- a/pkg/unify-query/service/http/check_handler.go
+++ b/pkg/unify-query/service/http/check_handler.go
@@ -217,9 +217,6 @@ func checkQueryTsData(ctx context.Context, q *structured.QueryTs) (data []any, r
 			"未解析到可路由的查询",
 		).Error(ctx, fmt.Errorf("empty check query reference"))
 	}
-	if out == nil {
-		out = []any{}
-	}
 	return out, routeInfo, nil
 }
 

--- a/pkg/unify-query/service/http/check_handler_test.go
+++ b/pkg/unify-query/service/http/check_handler_test.go
@@ -110,6 +110,52 @@ func resultTableIDFromResponse(t *testing.T, v any) []string {
 	return out
 }
 
+func TestCollectRouteRows_ReferenceOrderStable(t *testing.T) {
+	qr := metadata.QueryReference{
+		"z": {{QueryList: []*metadata.Query{{TableID: "tz"}}}},
+		"a": {{QueryList: []*metadata.Query{{TableID: "ta"}}}},
+	}
+	rows := collectRouteRows(qr)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "a", rows[0].ReferenceName)
+	assert.Equal(t, "ta", rows[0].TableID)
+	assert.Equal(t, "z", rows[1].ReferenceName)
+	assert.Equal(t, "tz", rows[1].TableID)
+}
+
+func TestCheckQueryTsData_BklogES_RouteRowsWithoutPreviewBody(t *testing.T) {
+	ctx := e2eCheckContext(t)
+	body := []byte(`{
+		"space_uid": "bkcc__2",
+		"query_list": [{
+			"data_source": "bklog",
+			"table_id": "result_table.es",
+			"field_name": "level",
+			"reference_name": "a",
+			"function": [{"method": "count", "dimensions": ["level"], "window": "60s"}]
+		}],
+		"metric_merge": "a",
+		"start_time": "1718865258",
+		"end_time": "1718868858",
+		"step": "60s",
+		"timezone": "UTC"
+	}`)
+	var qts structured.QueryTs
+	require.NoError(t, json.Unmarshal(body, &qts))
+	data, routeRows, err := checkQueryTsData(ctx, &qts)
+	require.NoError(t, err)
+	assert.Empty(t, data, "ES 默认无 GetRequestBody 预览体时 data 应为空")
+	require.NotEmpty(t, routeRows, "仍应返回 route_rows 便于路由排障")
+	var sawEs bool
+	for _, r := range routeRows {
+		if r.TableID == influxdb.ResultTableEs && r.StorageType == metadata.ElasticsearchStorageType {
+			sawEs = true
+			break
+		}
+	}
+	assert.True(t, sawEs, "应含 ES 结果表路由: %+v", routeRows)
+}
+
 func TestEndToEndHandlerCheckQueryTs_Success_VMPreview(t *testing.T) {
 	ctx := e2eCheckContext(t)
 	// system.cpu_detail / system.disk 在 router_mock 中走 must-vm-query，路由为 VM；IsDirectQuery 为 true，返回单条 VM 预览。
@@ -135,11 +181,13 @@ func TestEndToEndHandlerCheckQueryTs_Success_VMPreview(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data    []map[string]any `json:"data"`
-		TraceID string           `json:"trace_id"`
+		Data      []map[string]any `json:"data"`
+		RouteRows []CheckRouteRow  `json:"route_rows"`
+		TraceID   string           `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1, "直查 VM 路径应产出一条预览")
+	require.NotEmpty(t, resp.RouteRows, "check 应附带路由摘要")
 	assert.Equal(t, metadata.VictoriaMetricsStorageType, resp.Data[0]["storage_type"])
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)
@@ -171,11 +219,13 @@ func TestEndToEndHandlerCheckQueryTs_Success_VMPreview_Division(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data    []map[string]any `json:"data"`
-		TraceID string           `json:"trace_id"`
+		Data      []map[string]any `json:"data"`
+		RouteRows []CheckRouteRow  `json:"route_rows"`
+		TraceID   string           `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
+	require.NotEmpty(t, resp.RouteRows)
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)
 	assert.Equal(t, wantMql, gotMql)
@@ -207,11 +257,13 @@ func TestEndToEndHandlerCheckQueryTs_Success_MetricMergeSingleRef(t *testing.T) 
 
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data    []map[string]any `json:"data"`
-		TraceID string           `json:"trace_id"`
+		Data      []map[string]any `json:"data"`
+		RouteRows []CheckRouteRow  `json:"route_rows"`
+		TraceID   string           `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
+	require.NotEmpty(t, resp.RouteRows)
 	assert.Equal(t, metadata.VictoriaMetricsStorageType, resp.Data[0]["storage_type"])
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)
@@ -473,11 +525,13 @@ func TestEndToEndHandlerCheckQueryPromQL_Success_VMPreview(t *testing.T) {
 	w := runCheckHandler(t, req, HandlerCheckQueryPromQL)
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data    []map[string]any `json:"data"`
-		TraceID string           `json:"trace_id"`
+		Data      []map[string]any `json:"data"`
+		RouteRows []CheckRouteRow  `json:"route_rows"`
+		TraceID   string           `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
+	require.NotEmpty(t, resp.RouteRows)
 	assert.Equal(t, metadata.VictoriaMetricsStorageType, resp.Data[0]["storage_type"])
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)

--- a/pkg/unify-query/service/http/check_handler_test.go
+++ b/pkg/unify-query/service/http/check_handler_test.go
@@ -110,20 +110,7 @@ func resultTableIDFromResponse(t *testing.T, v any) []string {
 	return out
 }
 
-func TestCollectRouteRows_ReferenceOrderStable(t *testing.T) {
-	qr := metadata.QueryReference{
-		"z": {{QueryList: []*metadata.Query{{TableID: "tz"}}}},
-		"a": {{QueryList: []*metadata.Query{{TableID: "ta"}}}},
-	}
-	rows := collectRouteRows(qr)
-	require.Len(t, rows, 2)
-	assert.Equal(t, "a", rows[0].ReferenceName)
-	assert.Equal(t, "ta", rows[0].TableID)
-	assert.Equal(t, "z", rows[1].ReferenceName)
-	assert.Equal(t, "tz", rows[1].TableID)
-}
-
-func TestCheckQueryTsData_BklogES_RouteRowsWithoutPreviewBody(t *testing.T) {
+func TestCheckQueryTsData_BklogES_RouteInfoWithoutPreviewBody(t *testing.T) {
 	ctx := e2eCheckContext(t)
 	body := []byte(`{
 		"space_uid": "bkcc__2",
@@ -142,18 +129,18 @@ func TestCheckQueryTsData_BklogES_RouteRowsWithoutPreviewBody(t *testing.T) {
 	}`)
 	var qts structured.QueryTs
 	require.NoError(t, json.Unmarshal(body, &qts))
-	data, routeRows, err := checkQueryTsData(ctx, &qts)
+	data, routeInfo, err := checkQueryTsData(ctx, &qts)
 	require.NoError(t, err)
 	assert.Empty(t, data, "ES 默认无 GetRequestBody 预览体时 data 应为空")
-	require.NotEmpty(t, routeRows, "仍应返回 route_rows 便于路由排障")
+	require.NotEmpty(t, routeInfo, "仍应返回 route_info 便于路由排障")
 	var sawEs bool
-	for _, r := range routeRows {
+	for _, r := range routeInfo {
 		if r.TableID == influxdb.ResultTableEs && r.StorageType == metadata.ElasticsearchStorageType {
 			sawEs = true
 			break
 		}
 	}
-	assert.True(t, sawEs, "应含 ES 结果表路由: %+v", routeRows)
+	assert.True(t, sawEs, "应含 ES 结果表路由: %+v", routeInfo)
 }
 
 func TestEndToEndHandlerCheckQueryTs_Success_VMPreview(t *testing.T) {
@@ -181,13 +168,13 @@ func TestEndToEndHandlerCheckQueryTs_Success_VMPreview(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data      []map[string]any `json:"data"`
-		RouteRows []CheckRouteRow  `json:"route_rows"`
-		TraceID   string           `json:"trace_id"`
+		Data      []map[string]any          `json:"data"`
+		RouteInfo []metadata.CheckRouteInfo `json:"route_info"`
+		TraceID   string                    `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1, "直查 VM 路径应产出一条预览")
-	require.NotEmpty(t, resp.RouteRows, "check 应附带路由摘要")
+	require.NotEmpty(t, resp.RouteInfo, "check 应附带路由摘要")
 	assert.Equal(t, metadata.VictoriaMetricsStorageType, resp.Data[0]["storage_type"])
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)
@@ -219,13 +206,13 @@ func TestEndToEndHandlerCheckQueryTs_Success_VMPreview_Division(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data      []map[string]any `json:"data"`
-		RouteRows []CheckRouteRow  `json:"route_rows"`
-		TraceID   string           `json:"trace_id"`
+		Data      []map[string]any          `json:"data"`
+		RouteInfo []metadata.CheckRouteInfo `json:"route_info"`
+		TraceID   string                    `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
-	require.NotEmpty(t, resp.RouteRows)
+	require.NotEmpty(t, resp.RouteInfo)
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)
 	assert.Equal(t, wantMql, gotMql)
@@ -257,13 +244,13 @@ func TestEndToEndHandlerCheckQueryTs_Success_MetricMergeSingleRef(t *testing.T) 
 
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data      []map[string]any `json:"data"`
-		RouteRows []CheckRouteRow  `json:"route_rows"`
-		TraceID   string           `json:"trace_id"`
+		Data      []map[string]any          `json:"data"`
+		RouteInfo []metadata.CheckRouteInfo `json:"route_info"`
+		TraceID   string                    `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
-	require.NotEmpty(t, resp.RouteRows)
+	require.NotEmpty(t, resp.RouteInfo)
 	assert.Equal(t, metadata.VictoriaMetricsStorageType, resp.Data[0]["storage_type"])
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)
@@ -525,13 +512,13 @@ func TestEndToEndHandlerCheckQueryPromQL_Success_VMPreview(t *testing.T) {
 	w := runCheckHandler(t, req, HandlerCheckQueryPromQL)
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp struct {
-		Data      []map[string]any `json:"data"`
-		RouteRows []CheckRouteRow  `json:"route_rows"`
-		TraceID   string           `json:"trace_id"`
+		Data      []map[string]any          `json:"data"`
+		RouteInfo []metadata.CheckRouteInfo `json:"route_info"`
+		TraceID   string                    `json:"trace_id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
-	require.NotEmpty(t, resp.RouteRows)
+	require.NotEmpty(t, resp.RouteInfo)
 	assert.Equal(t, metadata.VictoriaMetricsStorageType, resp.Data[0]["storage_type"])
 	gotMql, ok := resp.Data[0]["metricql"].(string)
 	require.True(t, ok)


### PR DESCRIPTION
### 1.背景
Check 非直查时只靠各存储的 GetRequestBody 拼 data，ES 等没有预览体就会 data 全空，但路由其实已展开，接口仍判 400，和 field_map 能命中、却看不到命中哪些结果表不一致。

### 2.修复
成功展开路由后增加返回 route_info；只要 route_info 非空即允许 200、data 可为空数组；Check 与正式查询对齐 bklog/bkapm 下空 table_id 时对 table_id_conditions 的校验，并补单测与文档。