### PR TITLE
feat: (unify-query) uq 兼容 SaaS data_source 别名 --story=134199291

### DIFF
--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -159,7 +159,7 @@ func (q *QueryTs) ToQueryReference(ctx context.Context) (metadata.QueryReference
 	queryReference := make(metadata.QueryReference)
 	for _, query := range q.QueryList {
 		// 兼容 SaaS 命名（bk_data / bk_log_search / bk_apm）-> 内部命名（bkdata / bklog / bkapm）
-		query.DataSource = NormalizeDataSource(query.DataSource)
+		query.DataSource = normalizeDataSource(query.DataSource)
 
 		// 时间复用
 		query.Timezone = q.Timezone

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -158,6 +158,9 @@ func (q *QueryTs) ToQueryReference(ctx context.Context) (metadata.QueryReference
 
 	queryReference := make(metadata.QueryReference)
 	for _, query := range q.QueryList {
+		// 兼容 SaaS 命名（bk_data / bk_log_search / bk_apm）-> 内部命名（bkdata / bklog / bkapm）
+		query.DataSource = NormalizeDataSource(query.DataSource)
+
 		// 时间复用
 		query.Timezone = q.Timezone
 		query.Start = q.Start

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -1972,8 +1972,16 @@ func TestQueryTs_ToQueryReference_DataSourceAlias(t *testing.T) {
 		require.NoError(t, err)
 
 		// 规范化原地写回 QueryTs.QueryList[*].DataSource
-		assert.Equal(t, BkLog, ts.QueryList[0].DataSource, "bk_log_search 应被规范化为 bklog")
-		assert.Equal(t, BkApm, ts.QueryList[1].DataSource, "bk_apm 应被规范化为 bkapm")
+		require.Len(t, ts.QueryList, 2)
+		for i, tc := range []struct {
+			want string
+			msg  string
+		}{
+			{BkLog, "bk_log_search 应被规范化为 bklog"},
+			{BkApm, "bk_apm 应被规范化为 bkapm"},
+		} {
+			assert.Equal(t, tc.want, ts.QueryList[i].DataSource, tc.msg)
+		}
 	})
 }
 

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -1905,6 +1905,78 @@ func TestQueryTs_ToQueryReference(t *testing.T) {
 	}
 }
 
+// TestQueryTs_ToQueryReference_DataSourceAlias 验证 SaaS 命名（bk_data / bk_log_search / bk_apm）
+// 经 ToQueryReference 入口被规范化为内部命名（bkdata / bklog / bkapm），其中 bk_data 别名应正确进入 BkSql 分支。
+func TestQueryTs_ToQueryReference_DataSourceAlias(t *testing.T) {
+	mock.Init()
+	ctx := md.InitHashID(context.Background())
+	influxdb.MockSpaceRouter(ctx)
+
+	t.Run("bk_data alias enters BkSql branch", func(t *testing.T) {
+		ts := &QueryTs{
+			SpaceUid: influxdb.SpaceUid, // bkcc__2，满足 BkData 分支「业务空间下查询」校验
+			QueryList: []*Query{
+				{
+					DataSource:    "bk_data", // SaaS 命名，期望被规范化为 BkData
+					TableID:       "2_table_id",
+					FieldName:     "kube_pod_info",
+					ReferenceName: "a",
+				},
+			},
+			MetricMerge: "a",
+			Start:       "1718865258",
+			End:         "1718868858",
+			Step:        "1m",
+		}
+
+		ref, err := ts.ToQueryReference(ctx)
+		require.NoError(t, err)
+
+		// 规范化后写回 QueryTs.QueryList（指针原地修改）
+		assert.Equal(t, BkData, ts.QueryList[0].DataSource, "bk_data 应被规范化为 bkdata")
+
+		// 走通 BkSql 分支：StorageType == BkSqlStorageType，DB 非空
+		require.Contains(t, ref, "a")
+		require.NotEmpty(t, ref["a"])
+		require.NotEmpty(t, ref["a"][0].QueryList)
+		q := ref["a"][0].QueryList[0]
+		assert.Equal(t, BkData, q.DataSource)
+		assert.Equal(t, md.BkSqlStorageType, q.StorageType, "bkdata 应正确进入 BkSql 分支")
+		assert.NotEmpty(t, q.DB, "BkSql 分支 DB 不应为空")
+	})
+
+	t.Run("bk_log_search and bk_apm aliases normalized", func(t *testing.T) {
+		ts := &QueryTs{
+			SpaceUid: influxdb.SpaceUid,
+			QueryList: []*Query{
+				{
+					DataSource:    "bk_log_search",
+					TableID:       "result_table.es",
+					FieldName:     "kube_pod_info",
+					ReferenceName: "a",
+				},
+				{
+					DataSource:    "bk_apm",
+					TableID:       "",
+					FieldName:     "kube_pod_info",
+					ReferenceName: "b",
+				},
+			},
+			MetricMerge: "a + b",
+			Start:       "1718865258",
+			End:         "1718868858",
+			Step:        "1m",
+		}
+
+		_, err := ts.ToQueryReference(ctx)
+		require.NoError(t, err)
+
+		// 规范化原地写回 QueryTs.QueryList[*].DataSource
+		assert.Equal(t, BkLog, ts.QueryList[0].DataSource, "bk_log_search 应被规范化为 bklog")
+		assert.Equal(t, BkApm, ts.QueryList[1].DataSource, "bk_apm 应被规范化为 bkapm")
+	})
+}
+
 func TestAggregations(t *testing.T) {
 	for name, c := range map[string]struct {
 		query *Query

--- a/pkg/unify-query/query/structured/route.go
+++ b/pkg/unify-query/query/structured/route.go
@@ -38,6 +38,23 @@ var dataSourceMap = map[string]struct{}{
 	BkApm:          {},
 }
 
+// DataSourceAliases SaaS 侧（alert/detail、bk_log_search 等接口）历史命名 -> unify-query 内部命名。
+// 仅作用于结构化字段 Query.DataSource 入口；不参与 dataSourceMap（指标名前缀解析不受影响）。
+var DataSourceAliases = map[string]string{
+	"bk_data":       BkData, // bk_data       -> bkdata
+	"bk_log_search": BkLog,  // bk_log_search -> bklog
+	"bk_apm":        BkApm,  // bk_apm        -> bkapm
+}
+
+// NormalizeDataSource 规范化外部传入的 data_source 值；非别名原样返回（包括空串与未知值）。
+// 空串保留给上游 ToQueryMetric 自动补默认 BkMonitor 使用；未知值不静默吞掉，便于排障。
+func NormalizeDataSource(s string) string {
+	if v, ok := DataSourceAliases[s]; ok {
+		return v
+	}
+	return s
+}
+
 type TableID string
 
 // Split 按照格式解析 TableID

--- a/pkg/unify-query/query/structured/route.go
+++ b/pkg/unify-query/query/structured/route.go
@@ -38,18 +38,18 @@ var dataSourceMap = map[string]struct{}{
 	BkApm:          {},
 }
 
-// DataSourceAliases SaaS 侧（alert/detail、bk_log_search 等接口）历史命名 -> unify-query 内部命名。
+// dataSourceAliases SaaS 侧（alert/detail、bk_log_search 等接口）历史命名 -> unify-query 内部命名。
 // 仅作用于结构化字段 Query.DataSource 入口；不参与 dataSourceMap（指标名前缀解析不受影响）。
-var DataSourceAliases = map[string]string{
+var dataSourceAliases = map[string]string{
 	"bk_data":       BkData, // bk_data       -> bkdata
 	"bk_log_search": BkLog,  // bk_log_search -> bklog
 	"bk_apm":        BkApm,  // bk_apm        -> bkapm
 }
 
-// NormalizeDataSource 规范化外部传入的 data_source 值；非别名原样返回（包括空串与未知值）。
+// normalizeDataSource 规范化外部传入的 data_source 值；非别名原样返回（包括空串与未知值）。
 // 空串保留给上游 ToQueryMetric 自动补默认 BkMonitor 使用；未知值不静默吞掉，便于排障。
-func NormalizeDataSource(s string) string {
-	if v, ok := DataSourceAliases[s]; ok {
+func normalizeDataSource(s string) string {
+	if v, ok := dataSourceAliases[s]; ok {
 		return v
 	}
 	return s

--- a/pkg/unify-query/query/structured/route_test.go
+++ b/pkg/unify-query/query/structured/route_test.go
@@ -165,27 +165,27 @@ func TestNormalizeDataSource(t *testing.T) {
 		want  string
 	}{
 		// 别名 -> 内部值
-		"alias bk_data":       {"bk_data", BkData},
-		"alias bk_log_search": {"bk_log_search", BkLog},
-		"alias bk_apm":        {"bk_apm", BkApm},
+		"alias bk_data":       {input: "bk_data", want: BkData},
+		"alias bk_log_search": {input: "bk_log_search", want: BkLog},
+		"alias bk_apm":        {input: "bk_apm", want: BkApm},
 
 		// 内部值原样返回
-		"internal bkdata":    {BkData, BkData},
-		"internal bklog":     {BkLog, BkLog},
-		"internal bkapm":     {BkApm, BkApm},
-		"internal bkmonitor": {BkMonitor, BkMonitor},
-		"internal custom":    {Custom, Custom},
+		"internal bkdata":    {input: BkData, want: BkData},
+		"internal bklog":     {input: BkLog, want: BkLog},
+		"internal bkapm":     {input: BkApm, want: BkApm},
+		"internal bkmonitor": {input: BkMonitor, want: BkMonitor},
+		"internal custom":    {input: Custom, want: Custom},
 
 		// 空串保留给上游 ToQueryMetric 自动补默认 BkMonitor 使用
-		"empty": {"", ""},
+		"empty": {input: "", want: ""},
 
 		// 未知值原样返回，不静默吞掉
-		"unknown": {"unknown_source", "unknown_source"},
+		"unknown": {input: "unknown_source", want: "unknown_source"},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, NormalizeDataSource(tc.input))
+			assert.Equal(t, tc.want, normalizeDataSource(tc.input))
 		})
 	}
 }

--- a/pkg/unify-query/query/structured/route_test.go
+++ b/pkg/unify-query/query/structured/route_test.go
@@ -158,6 +158,38 @@ func TestMakeRouteFromMetricName(t *testing.T) {
 	}
 }
 
+// TestNormalizeDataSource 覆盖 SaaS 别名映射、内部值原样返回、空串、未知值四类输入。
+func TestNormalizeDataSource(t *testing.T) {
+	testCases := map[string]struct {
+		input string
+		want  string
+	}{
+		// 别名 -> 内部值
+		"alias bk_data":       {"bk_data", BkData},
+		"alias bk_log_search": {"bk_log_search", BkLog},
+		"alias bk_apm":        {"bk_apm", BkApm},
+
+		// 内部值原样返回
+		"internal bkdata":    {BkData, BkData},
+		"internal bklog":     {BkLog, BkLog},
+		"internal bkapm":     {BkApm, BkApm},
+		"internal bkmonitor": {BkMonitor, BkMonitor},
+		"internal custom":    {Custom, Custom},
+
+		// 空串保留给上游 ToQueryMetric 自动补默认 BkMonitor 使用
+		"empty": {"", ""},
+
+		// 未知值原样返回，不静默吞掉
+		"unknown": {"unknown_source", "unknown_source"},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeDataSource(tc.input))
+		})
+	}
+}
+
 // TestMakeRouteFromLabelMatch
 func TestMakeRouteFromLabelMatch(t *testing.T) {
 	miss := []*labels.Matcher{}


### PR DESCRIPTION
### 1.背景

监控不同接口的 `data_source` 字段命名历史不一致：

- 告警 `alert/detail`、`bk_log_search` 等 SaaS 接口返回的 `data_source_label` 取值为：`bk_data` / `bk_log_search` / `bk_apm`。
- unify-query 内部统一使用：`bkdata` / `bklog` / `bkapm`（见 `pkg/unify-query/query/structured/route.go` 中的 `BkData` / `BkLog` / `BkApm` 常量）。

用户拿到 alert/detail 的 `data_source_label=bk_data` 后，需要在调用方手动转换为 `bkdata` 才能查通 unify-query；否则会绕过 `query_ts.go` 中 `q.DataSource == BkData` / `BkLog` / `BkApm` 的分支判断，错误地走默认 `bkmonitor` 路径，导致 BkSql / 日志类查询路由错乱。

### 2.修复说明

unify-query 入口侧增加一层别名兼容，外部不再需要做命名转换：

- `pkg/unify-query/query/structured/route.go` 新增 `DataSourceAliases` 映射表与 `NormalizeDataSource(s string) string` 工具函数：
  - `bk_data` → `bkdata`
  - `bk_log_search` → `bklog`
  - `bk_apm` → `bkapm`
  - 内部值 / 空串 / 未知值均原样返回（空串保留 `ToQueryMetric` 自动补 `bkmonitor` 的既有行为；未知值不静默吞掉，便于排障）。
- `pkg/unify-query/query/structured/query_ts.go` 在 `QueryTs.ToQueryReference` 子查询循环最前调用一次 `NormalizeDataSource`，覆盖所有 HTTP handler（`/query/ts`、`/query/ts/promql`、`/check/query/ts`、`/check/query/ts/promql` 等都经此入口）。

只规范化结构化字段 `Query.DataSource`，不改动 `dataSourceMap`，因此 `MakeRouteFromMetricName` 对指标名前缀（`bkmonitor:db:tab:metric`）的解析行为保持不变，无回归风险。