### PR TITLE
feat: (unify-query) 从 Redis 全量路由同步增加 Prometheus 计数 --story=134280715

### DIFF
--- a/pkg/unify-query/influxdb/spacetsdb_router.go
+++ b/pkg/unify-query/influxdb/spacetsdb_router.go
@@ -389,8 +389,8 @@ func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes
 		err      error
 		ok       bool
 		val      influxdb.GenericKV
-		recvErr  bool
-		batchErr bool
+		recvErr  bool // genericCh 曾收到带 Err 的项（如 HScan 失败、JSON 解析失败）
+		batchErr bool // 任一批 BatchAdd 写本地 KV 失败
 	)
 	batchSize := int64(r.batchSize)
 	entities := make([]influxdb.GenericKV, 0)
@@ -432,6 +432,7 @@ func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes
 				entities = entities[:0]
 			}
 			if !ok {
+				// 仅 SpaceAllKey 打点，避免非法 key 造成 Prometheus 高基数
 				if influxdb.IsSpaceAllRouterKey(key) {
 					if recvErr || batchErr {
 						metric.RedisRouterLoadResultInc(ctx, key, metric.RedisRouterLoadResultFailure)

--- a/pkg/unify-query/influxdb/spacetsdb_router.go
+++ b/pkg/unify-query/influxdb/spacetsdb_router.go
@@ -381,6 +381,7 @@ func (r *SpaceTsDbRouter) ReloadByChannel(ctx context.Context, channelKey string
 func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes bool) error {
 	r.rwLock.Lock()
 	defer r.rwLock.Unlock()
+	metric.RedisRouterLoadInc(ctx, key)
 	start := time.Now()
 	defer func() {
 		log.Debugf(ctx, "[SpaceTSDB] Load key(%s), time cost: %s", key, time.Since(start))

--- a/pkg/unify-query/influxdb/spacetsdb_router.go
+++ b/pkg/unify-query/influxdb/spacetsdb_router.go
@@ -434,7 +434,8 @@ func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes
 			if !ok {
 				// 仅 SpaceAllKey 打点，避免非法 key 造成 Prometheus 高基数
 				if influxdb.IsSpaceAllRouterKey(key) {
-					if recvErr || batchErr {
+					// ctx 被取消时，HScan 可能提前结束但不会显式透传 GenericKV.Err，记为 failure
+					if recvErr || batchErr || ctx.Err() != nil {
 						metric.RedisRouterLoadResultInc(ctx, key, metric.RedisRouterLoadResultFailure)
 					} else {
 						metric.RedisRouterLoadResultInc(ctx, key, metric.RedisRouterLoadResultSuccess)

--- a/pkg/unify-query/influxdb/spacetsdb_router.go
+++ b/pkg/unify-query/influxdb/spacetsdb_router.go
@@ -381,15 +381,16 @@ func (r *SpaceTsDbRouter) ReloadByChannel(ctx context.Context, channelKey string
 func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes bool) error {
 	r.rwLock.Lock()
 	defer r.rwLock.Unlock()
-	metric.RedisRouterLoadInc(ctx, key)
 	start := time.Now()
 	defer func() {
 		log.Debugf(ctx, "[SpaceTSDB] Load key(%s), time cost: %s", key, time.Since(start))
 	}()
 	var (
-		err error
-		ok  bool
-		val influxdb.GenericKV
+		err      error
+		ok       bool
+		val      influxdb.GenericKV
+		recvErr  bool
+		batchErr bool
 	)
 	batchSize := int64(r.batchSize)
 	entities := make([]influxdb.GenericKV, 0)
@@ -404,10 +405,11 @@ func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes
 		case val, ok = <-genericCh:
 			if ok {
 				if val.Err != nil {
+					recvErr = true
 					metadata.NewMessage(
 						metadata.MsgQueryRouter,
 						"空间TSDB路由加载异常 %v",
-						err,
+						val.Err,
 					).Warn(ctx)
 					continue
 				}
@@ -418,6 +420,7 @@ func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes
 				log.Debugf(ctx, "Read %v entities from key(%s) channel", len(entities), key)
 				err = r.BatchAdd(ctx, key, entities, false, printBytes)
 				if err != nil {
+					batchErr = true
 					metadata.NewMessage(
 						metadata.MsgQueryRouter,
 						"空间TSDB路由 %s 添加异常 %v",
@@ -429,6 +432,13 @@ func (r *SpaceTsDbRouter) LoadRouter(ctx context.Context, key string, printBytes
 				entities = entities[:0]
 			}
 			if !ok {
+				if influxdb.IsSpaceAllRouterKey(key) {
+					if recvErr || batchErr {
+						metric.RedisRouterLoadResultInc(ctx, key, metric.RedisRouterLoadResultFailure)
+					} else {
+						metric.RedisRouterLoadResultInc(ctx, key, metric.RedisRouterLoadResultSuccess)
+					}
+				}
 				return nil
 			}
 		}

--- a/pkg/unify-query/influxdb/spacetsdb_router_test.go
+++ b/pkg/unify-query/influxdb/spacetsdb_router_test.go
@@ -17,10 +17,13 @@ import (
 
 	miniredis "github.com/alicebob/miniredis/v2"
 	goRedis "github.com/go-redis/redis/v8"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metric"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/mock"
 	innerRedis "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
 	routerInfluxdb "github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/router/influxdb"
@@ -193,6 +196,23 @@ func (s *TestSuite) TestReloadKeyWithBigData() {
 	}
 }
 
+func (s *TestSuite) TestLoadRouterCanceledCountsFailure() {
+	failureBefore := getRedisRouterLoadMetricValue(routerInfluxdb.ResultTableDetailKey, metric.RedisRouterLoadResultFailure)
+	successBefore := getRedisRouterLoadMetricValue(routerInfluxdb.ResultTableDetailKey, metric.RedisRouterLoadResultSuccess)
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	cancel()
+
+	err := s.router.LoadRouter(ctx, routerInfluxdb.ResultTableDetailKey, true)
+	s.Require().NoError(err)
+
+	failureAfter := getRedisRouterLoadMetricValue(routerInfluxdb.ResultTableDetailKey, metric.RedisRouterLoadResultFailure)
+	successAfter := getRedisRouterLoadMetricValue(routerInfluxdb.ResultTableDetailKey, metric.RedisRouterLoadResultSuccess)
+
+	s.Equal(failureBefore+1, failureAfter, "canceled load should increment failure counter")
+	s.Equal(successBefore, successAfter, "canceled load should not increment success counter")
+}
+
 func (s *TestSuite) TestMultiTenantSupport() {
 	s.setupMultiTenantData()
 	s.testTenantDataIsolation()
@@ -299,4 +319,36 @@ func (s *TestSuite) createContext(tenantID string) context.Context {
 	}
 	metadata.SetUser(ctx, user)
 	return ctx
+}
+
+func getRedisRouterLoadMetricValue(routeKey, result string) float64 {
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return 0
+	}
+	for _, family := range metricFamilies {
+		if family.GetName() != "unify_query_redis_router_load_total" {
+			continue
+		}
+		for _, item := range family.GetMetric() {
+			if matchMetricLabels(item, routeKey, result) && item.GetCounter() != nil {
+				return item.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func matchMetricLabels(item *dto.Metric, routeKey, result string) bool {
+	hasRouteKey := false
+	hasResult := false
+	for _, label := range item.GetLabel() {
+		switch label.GetName() {
+		case "route_key":
+			hasRouteKey = label.GetValue() == routeKey
+		case "result":
+			hasResult = label.GetValue() == result
+		}
+	}
+	return hasRouteKey && hasResult
 }

--- a/pkg/unify-query/metric/metric.go
+++ b/pkg/unify-query/metric/metric.go
@@ -40,6 +40,12 @@ const (
 	ResultMiss = "miss"
 )
 
+// RedisRouterLoadResult 为 unify_query_redis_router_load_total 的 result 标签取值（固定 success|failure，基数可控）。
+const (
+	RedisRouterLoadResultSuccess = "success"
+	RedisRouterLoadResultFailure = "failure"
+)
+
 const (
 	_ = 1 << (10 * iota)
 	KB
@@ -148,14 +154,14 @@ var (
 		[]string{"storage_id", "version", "commit_id"},
 	)
 
-	// redis_router_load_total 仅统计 space_tsdb：每次从 Redis HScan 全量同步一条空间路由 Hash 时 +1
+	// redis_router_load_total：space_tsdb LoadRouter 每次结束记 1 次，result 为 success 或 failure（route_key 仅 SpaceAllKey）
 	redisRouterLoadTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unify_query",
 			Name:      "redis_router_load_total",
-			Help:      "unify-query space_tsdb: times each space routing hash is fully loaded from Redis (HScan)",
+			Help:      "unify-query space_tsdb: full LoadRouter from Redis (HScan) outcomes by route_key and result (success|failure)",
 		},
-		[]string{"route_key", "version", "commit_id"},
+		[]string{"route_key", "result", "version", "commit_id"},
 	)
 )
 
@@ -222,9 +228,13 @@ func TSDBGetStorageMissIDTotalInc(ctx context.Context, storageID string) {
 	counterInc(ctx, metric)
 }
 
-// RedisRouterLoadInc 仅用于 space_tsdb：每次 LoadRouter 从 Redis 全量扫描一条路由 Hash 时 +1
-func RedisRouterLoadInc(ctx context.Context, routeKey string) {
-	params := append([]string{}, routeKey, config.Version, config.CommitHash)
+// RedisRouterLoadResultInc 记录一次 space_tsdb LoadRouter 结束时的结果；route_key 须由调用方保证为 SpaceAllKey 之一。
+// result 须为 RedisRouterLoadResultSuccess 或 RedisRouterLoadResultFailure。
+func RedisRouterLoadResultInc(ctx context.Context, routeKey, result string) {
+	if result != RedisRouterLoadResultSuccess && result != RedisRouterLoadResultFailure {
+		return
+	}
+	params := append([]string{}, routeKey, result, config.Version, config.CommitHash)
 	metric, _ := redisRouterLoadTotal.GetMetricWithLabelValues(params...)
 	counterInc(ctx, metric)
 }

--- a/pkg/unify-query/metric/metric.go
+++ b/pkg/unify-query/metric/metric.go
@@ -228,8 +228,7 @@ func TSDBGetStorageMissIDTotalInc(ctx context.Context, storageID string) {
 	counterInc(ctx, metric)
 }
 
-// RedisRouterLoadResultInc 记录一次 space_tsdb LoadRouter 结束时的结果；route_key 须由调用方保证为 SpaceAllKey 之一。
-// result 须为 RedisRouterLoadResultSuccess 或 RedisRouterLoadResultFailure。
+// RedisRouterLoadResultInc 记录一次 LoadRouter 结束：success 表示 Redis 扫描与 BatchAdd 均无错误；failure 表示出现过 channel 错误或 BatchAdd 失败。route_key 须为 SpaceAllKey。
 func RedisRouterLoadResultInc(ctx context.Context, routeKey, result string) {
 	if result != RedisRouterLoadResultSuccess && result != RedisRouterLoadResultFailure {
 		return

--- a/pkg/unify-query/metric/metric.go
+++ b/pkg/unify-query/metric/metric.go
@@ -147,6 +147,16 @@ var (
 		},
 		[]string{"storage_id", "version", "commit_id"},
 	)
+
+	// redis_router_load_total 仅统计 space_tsdb：每次从 Redis HScan 全量同步一条空间路由 Hash 时 +1
+	redisRouterLoadTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "unify_query",
+			Name:      "redis_router_load_total",
+			Help:      "unify-query space_tsdb: times each space routing hash is fully loaded from Redis (HScan)",
+		},
+		[]string{"route_key", "version", "commit_id"},
+	)
 )
 
 func APIRequestInc(ctx context.Context, api, status, spaceUID, sourceType string) {
@@ -209,6 +219,13 @@ func TSDBGetStorageTotalInc(ctx context.Context, result string) {
 func TSDBGetStorageMissIDTotalInc(ctx context.Context, storageID string) {
 	params := append([]string{}, storageID, config.Version, config.CommitHash)
 	metric, _ := tsDBGetStorageMissIDTotal.GetMetricWithLabelValues(params...)
+	counterInc(ctx, metric)
+}
+
+// RedisRouterLoadInc 仅用于 space_tsdb：每次 LoadRouter 从 Redis 全量扫描一条路由 Hash 时 +1
+func RedisRouterLoadInc(ctx context.Context, routeKey string) {
+	params := append([]string{}, routeKey, config.Version, config.CommitHash)
+	metric, _ := redisRouterLoadTotal.GetMetricWithLabelValues(params...)
 	counterInc(ctx, metric)
 }
 

--- a/pkg/unify-query/service/http/info.go
+++ b/pkg/unify-query/service/http/info.go
@@ -205,6 +205,7 @@ func HandleSpacePrint(c *gin.Context) {
 	}
 	res := ""
 	if refresh {
+		// refresh 触发 LoadRouter 全表 HScan，type_key 须为 SpaceAllKey
 		if !routerInfluxdb.IsSpaceAllRouterKey(typeKey) {
 			c.String(400, fmt.Sprintf(
 				"invalid type_key for refresh: %q, must be one of: %s",

--- a/pkg/unify-query/service/http/info.go
+++ b/pkg/unify-query/service/http/info.go
@@ -205,6 +205,13 @@ func HandleSpacePrint(c *gin.Context) {
 	}
 	res := ""
 	if refresh {
+		if !routerInfluxdb.IsSpaceAllRouterKey(typeKey) {
+			c.String(400, fmt.Sprintf(
+				"invalid type_key for refresh: %q, must be one of: %s",
+				typeKey, strings.Join(routerInfluxdb.SpaceAllKey, ", "),
+			))
+			return
+		}
 		res += fmt.Sprintf("Refresh %s \n", typeKey)
 		err = router.LoadRouter(ctx, typeKey, true)
 		if err != nil {

--- a/pkg/utils/router/influxdb/influxdb.go
+++ b/pkg/utils/router/influxdb/influxdb.go
@@ -407,3 +407,13 @@ func NewGenericValue(typeKey string) (stoVal GenericValue, err error) {
 	}
 	return
 }
+
+// IsSpaceAllRouterKey 判断 key 是否为 space 侧支持 Redis 全量 HScan 同步的路由 Hash（与 SpaceAllKey 一致）。
+func IsSpaceAllRouterKey(key string) bool {
+	for _, k := range SpaceAllKey {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 1. 背景

可观测 space_tsdb 从 Redis **全量同步**（`LoadRouter` / HScan）的**频率与成败**，便于排查重载、订阅抖动、运维操作及 Redis/落库问题；`route_key` 仅限白名单，避免 Prometheus 高基数。

## 2. 改动摘要

- 新增 Counter **`unify_query_redis_router_load_total`**，标签：`route_key`、`result`（`success`|`failure`）、`version`、`commit_id`。
- **`LoadRouter`** 在 HScan **结束后**按本轮是否出现 channel 错误或 **`BatchAdd` 失败** 记 `success` / `failure`。
- **`route_key`** 仅 **`SpaceAllKey`**；**`HandleSpacePrint`** 在 `refresh=true` 且非法 `type_key` 时 **400**。
- 仅 space_tsdb **全量**路径；不含 InfluxDB 路由、不含 channel **增量 HGet**。

## 3. 使用说明

### 成功率
```promql 
sum by (route_key) (rate(unify_query_redis_router_load_total{result="success"}[5m]))
```
### 失败率
```promql
sum by (route_key) (rate(unify_query_redis_router_load_total{result="failure"}[5m])) 
```

### 多副本可按实例再看： 

```promql
sum by (route_key, instance) (rate(unify_query_redis_router_load_total[5m]))
```