### PR TITLE
feat: (unify-query)支持es + doris双写

### DIFF
--- a/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
+++ b/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
@@ -216,6 +216,9 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string, currentTab
 				for k, v := range dorisRoute {
 					route[k] = v
 				}
+				// Doris 分段路由必须携带命中的集群名，否则 BKBase query_sync 无法按 segment 切换 properties.cluster_name。
+				route["storage_name"] = clusterInfo.ClusterName
+				route["cluster_name"] = clusterInfo.ClusterName
 			} else if storageType == models.StorageTypeES {
 				for k, v := range esRoute {
 					route[k] = v

--- a/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
+++ b/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/jinzhu/gorm"
+	"github.com/samber/lo"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/metadata/models"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -60,8 +62,12 @@ func (ClusterRecord) TableName() string {
 }
 
 // ComposeTableIDStorageClusterRecords 组装指定 table_id 的历史存储集群记录
-func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string) ([]map[string]any, error) {
+func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string, currentTableID ...string) ([]map[string]any, error) {
 	logger.Infof("compose_table_id_storage_cluster_records: try to get storage cluster records for table_id->[%s]", tableID)
+	routeTableID := tableID
+	if len(currentTableID) > 0 && currentTableID[0] != "" {
+		routeTableID = currentTableID[0]
+	}
 
 	var records []ClusterRecord
 	// 查询数据库：过滤 table_id 和 is_deleted，按 create_time 升序排列
@@ -77,6 +83,118 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string) ([]map[str
 		return nil, err
 	}
 
+	clusterIDList := lo.Uniq(lo.FilterMap(records, func(record ClusterRecord, _ int) (uint, bool) {
+		if record.ClusterID > 0 {
+			return uint(record.ClusterID), true
+		}
+		return 0, false
+	}))
+
+	clusterInfoMap := make(map[uint]ClusterInfo, len(clusterIDList))
+	hasDorisRoute := false
+	hasESRoute := false
+	if len(clusterIDList) > 0 {
+		var clusterInfoList []ClusterInfo
+		if err = NewClusterInfoQuerySet(db).
+			Select(ClusterInfoDBSchema.ClusterID, ClusterInfoDBSchema.ClusterName, ClusterInfoDBSchema.ClusterType).
+			ClusterIDIn(clusterIDList...).
+			All(&clusterInfoList); err != nil {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query cluster info for table_id->[%s], error: %v", tableID, err)
+			return nil, err
+		}
+		for _, clusterInfo := range clusterInfoList {
+			clusterInfoMap[clusterInfo.ClusterID] = clusterInfo
+			switch clusterInfo.ClusterType {
+			case models.StorageTypeDoris:
+				hasDorisRoute = true
+			case models.StorageTypeES:
+				hasESRoute = true
+			}
+		}
+	}
+
+	// Doris 路由不能只写 storage_type=bk_sql，还要补 bkbase_table_id 和 doris measurement，
+	// 否则 UQ 会沿用外层 ES detail 的 db/measurement 去拼 BKSQL。
+	dorisRoute := map[string]any{}
+	if hasDorisRoute && db.HasTable(DorisStorage{}) {
+		var dorisStorage DorisStorage
+		if err = NewDorisStorageQuerySet(db).
+			Select(DorisStorageDBSchema.TableID, DorisStorageDBSchema.BkbaseTableID, DorisStorageDBSchema.OriginTableId, DorisStorageDBSchema.StorageClusterID).
+			TableIDEq(routeTableID).
+			One(&dorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query doris storage for table_id->[%s], error: %v", routeTableID, err)
+			return nil, err
+		}
+		if dorisStorage.BkbaseTableID == "" && routeTableID != tableID {
+			if err = NewDorisStorageQuerySet(db).
+				Select(DorisStorageDBSchema.TableID, DorisStorageDBSchema.BkbaseTableID, DorisStorageDBSchema.OriginTableId, DorisStorageDBSchema.StorageClusterID).
+				TableIDEq(tableID).
+				One(&dorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query doris storage for table_id->[%s], error: %v", tableID, err)
+				return nil, err
+			}
+		}
+		if dorisStorage.BkbaseTableID == "" && dorisStorage.OriginTableId != "" {
+			var originDorisStorage DorisStorage
+			if err = NewDorisStorageQuerySet(db).
+				Select(DorisStorageDBSchema.TableID, DorisStorageDBSchema.BkbaseTableID, DorisStorageDBSchema.StorageClusterID).
+				TableIDEq(dorisStorage.OriginTableId).
+				One(&originDorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query origin doris storage for table_id->[%s], origin_table_id->[%s], error: %v", tableID, dorisStorage.OriginTableId, err)
+				return nil, err
+			}
+			if dorisStorage.BkbaseTableID == "" {
+				dorisStorage.BkbaseTableID = originDorisStorage.BkbaseTableID
+			}
+			if dorisStorage.StorageClusterID == 0 {
+				dorisStorage.StorageClusterID = originDorisStorage.StorageClusterID
+			}
+		}
+		if dorisStorage.BkbaseTableID != "" {
+			dorisRoute["db"] = dorisStorage.BkbaseTableID
+			dorisRoute["measurement"] = models.DorisMeasurement
+		}
+	}
+
+	// ES 路由同样补齐 index_set 和默认 measurement，支持外层是 Doris 时按时间段回查 ES。
+	esRoute := map[string]any{}
+	if hasESRoute && db.HasTable(ESStorage{}) {
+		var esStorage ESStorage
+		if err = NewESStorageQuerySet(db).
+			Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.OriginTableId).
+			TableIDEq(routeTableID).
+			One(&esStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query es storage for table_id->[%s], error: %v", routeTableID, err)
+			return nil, err
+		}
+		if esStorage.IndexSet == "" && routeTableID != tableID {
+			if err = NewESStorageQuerySet(db).
+				Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.OriginTableId).
+				TableIDEq(tableID).
+				One(&esStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query es storage for table_id->[%s], error: %v", tableID, err)
+				return nil, err
+			}
+		}
+		if esStorage.IndexSet == "" && esStorage.OriginTableId != "" {
+			var originESStorage ESStorage
+			if err = NewESStorageQuerySet(db).
+				Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet).
+				TableIDEq(esStorage.OriginTableId).
+				One(&originESStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query origin es storage for table_id->[%s], origin_table_id->[%s], error: %v", tableID, esStorage.OriginTableId, err)
+				return nil, err
+			}
+			if esStorage.IndexSet == "" {
+				esStorage.IndexSet = originESStorage.IndexSet
+			}
+		}
+		if esStorage.IndexSet != "" {
+			esRoute["db"] = esStorage.IndexSet
+			esRoute["measurement"] = models.TSGroupDefaultMeasurement
+		}
+	}
+
 	// 组装结果集
 	result := make([]map[string]any, 0)
 	for _, record := range records {
@@ -86,11 +204,28 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string) ([]map[str
 			enableTimestamp = record.EnableTime.Unix()
 		}
 
-		// 追加到结果集合
-		result = append(result, map[string]any{
+		route := map[string]any{
 			"storage_id":  record.ClusterID,
 			"enable_time": enableTimestamp,
-		})
+		}
+		if clusterInfo, ok := clusterInfoMap[uint(record.ClusterID)]; ok {
+			storageType := clusterInfo.ClusterType
+			if storageType == models.StorageTypeDoris {
+				// metadata_clusterinfo 中 Doris 的 cluster_type 是 doris，UQ 查询侧使用 bk_sql。
+				storageType = models.StorageTypeBkSql
+				for k, v := range dorisRoute {
+					route[k] = v
+				}
+			} else if storageType == models.StorageTypeES {
+				for k, v := range esRoute {
+					route[k] = v
+				}
+			}
+			route["storage_type"] = storageType
+		}
+
+		// 追加到结果集合
+		result = append(result, route)
 	}
 
 	logger.Infof("compose_table_id_storage_cluster_records: get storage cluster records for table_id->[%s] success, records->[%v]", tableID, result)

--- a/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
+++ b/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
@@ -113,8 +113,7 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string, currentTab
 		}
 	}
 
-	// Doris 路由不能只写 storage_type=bk_sql，还要补 bkbase_table_id 和 doris measurement，
-	// 否则 UQ 会沿用外层 ES detail 的 db/measurement 去拼 BKSQL。
+	// Doris 分段路由需要携带 BKBase 表名和 doris measurement，用于 UQ 生成该时间段的 BKSQL 查询目标。
 	dorisRoute := map[string]any{}
 	if hasDorisRoute && db.HasTable(DorisStorage{}) {
 		var dorisStorage DorisStorage

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
@@ -22,6 +22,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/common"
 	cfg "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/config"
@@ -910,37 +911,24 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 		return err
 	}
 
-	originTableIdSet := make(map[string]struct{})
-	for _, doris := range dorisStorageList {
+	originTableIdList := lo.Uniq(lo.FilterMap(dorisStorageList, func(doris storage.DorisStorage, _ int) (string, bool) {
 		if doris.OriginTableId != "" {
-			originTableIdSet[doris.OriginTableId] = struct{}{}
+			return doris.OriginTableId, true
 		}
-	}
-	originTableIdList := make([]string, 0, len(originTableIdSet))
-	for tableId := range originTableIdSet {
-		originTableIdList = append(originTableIdList, tableId)
-	}
+		return "", false
+	}))
 	originDorisMap, err := s.getDorisStorageMap(originTableIdList)
 	if err != nil {
 		logger.Errorf("PushDorisTableIdDetail: failed to get origin doris storage map, error: %s", err)
 		return err
 	}
 
-	storageClusterIDSet := make(map[uint]struct{})
-	for _, doris := range dorisStorageList {
+	storageClusterIDList := lo.Uniq(lo.FilterMap(append(dorisStorageList, lo.Values(originDorisMap)...), func(doris storage.DorisStorage, _ int) (uint, bool) {
 		if doris.StorageClusterID != 0 {
-			storageClusterIDSet[doris.StorageClusterID] = struct{}{}
+			return doris.StorageClusterID, true
 		}
-	}
-	for _, doris := range originDorisMap {
-		if doris.StorageClusterID != 0 {
-			storageClusterIDSet[doris.StorageClusterID] = struct{}{}
-		}
-	}
-	storageClusterIDList := make([]uint, 0, len(storageClusterIDSet))
-	for storageClusterID := range storageClusterIDSet {
-		storageClusterIDList = append(storageClusterIDList, storageClusterID)
-	}
+		return 0, false
+	}))
 	storageClusterNameMap := make(map[uint]string, len(storageClusterIDList))
 	if len(storageClusterIDList) > 0 {
 		var storageClusterList []storage.ClusterInfo

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
@@ -879,6 +879,7 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 		storage.DorisStorageDBSchema.TableID,
 		storage.DorisStorageDBSchema.BkbaseTableID,
 		storage.DorisStorageDBSchema.OriginTableId,
+		storage.DorisStorageDBSchema.StorageClusterID,
 	)
 
 	// 如果过滤结果表存在，则添加过滤条件
@@ -925,6 +926,36 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 		return err
 	}
 
+	storageClusterIDSet := make(map[uint]struct{})
+	for _, doris := range dorisStorageList {
+		if doris.StorageClusterID != 0 {
+			storageClusterIDSet[doris.StorageClusterID] = struct{}{}
+		}
+	}
+	for _, doris := range originDorisMap {
+		if doris.StorageClusterID != 0 {
+			storageClusterIDSet[doris.StorageClusterID] = struct{}{}
+		}
+	}
+	storageClusterIDList := make([]uint, 0, len(storageClusterIDSet))
+	for storageClusterID := range storageClusterIDSet {
+		storageClusterIDList = append(storageClusterIDList, storageClusterID)
+	}
+	storageClusterNameMap := make(map[uint]string, len(storageClusterIDList))
+	if len(storageClusterIDList) > 0 {
+		var storageClusterList []storage.ClusterInfo
+		if err = storage.NewClusterInfoQuerySet(db).
+			Select(storage.ClusterInfoDBSchema.ClusterID, storage.ClusterInfoDBSchema.ClusterName).
+			ClusterIDIn(storageClusterIDList...).
+			All(&storageClusterList); err != nil {
+			logger.Errorf("PushDorisTableIdDetail: failed to get doris cluster info map, error: %s", err)
+			return err
+		}
+		for _, cluster := range storageClusterList {
+			storageClusterNameMap[cluster.ClusterID] = cluster.ClusterName
+		}
+	}
+
 	// 获取查询别名映射关系
 	fieldAliasMap, err := s.getFieldAliasMap(tidList)
 	if err != nil {
@@ -955,7 +986,7 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 				fieldAliasSettings = fieldAliasMap[tableId]
 			}
 
-			composedTableId, detailStr, err := s.composeDorisTableIdDetail(doris, rtMetaMap[tableId], originDorisMap, fieldAliasSettings)
+			composedTableId, detailStr, err := s.composeDorisTableIdDetail(doris, rtMetaMap[tableId], originDorisMap, storageClusterNameMap, fieldAliasSettings)
 			if err != nil {
 				logger.Errorf("PushDorisTableIdDetail:compose doris table id detail error, table_id: %s, error: %s", tableId, err)
 				return
@@ -1117,6 +1148,7 @@ func (s *SpacePusher) getDorisStorageMap(tableIDList []string) (map[string]stora
 			storage.DorisStorageDBSchema.TableID,
 			storage.DorisStorageDBSchema.BkbaseTableID,
 			storage.DorisStorageDBSchema.OriginTableId,
+			storage.DorisStorageDBSchema.StorageClusterID,
 		).TableIDIn(chunkTableIDList...).All(&dorisStorageList); err != nil {
 			return nil, err
 		}
@@ -1331,12 +1363,16 @@ func (s *SpacePusher) composeEsTableIdDetail(tableId string, options map[string]
 	return tableId, detailStr, err
 }
 
-func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMeta resultTableDetailMeta, originDorisMap map[string]storage.DorisStorage, fieldAliasSettings map[string]string) (string, string, error) {
+func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMeta resultTableDetailMeta, originDorisMap map[string]storage.DorisStorage, storageClusterNameMap map[uint]string, fieldAliasSettings map[string]string) (string, string, error) {
 	tableId := doris.TableID
 	bkbaseTableId := doris.BkbaseTableID
+	storageClusterID := doris.StorageClusterID
 	if bkbaseTableId == "" && doris.OriginTableId != "" {
 		if originDoris, ok := originDorisMap[doris.OriginTableId]; ok {
 			bkbaseTableId = originDoris.BkbaseTableID
+			if storageClusterID == 0 {
+				storageClusterID = originDoris.StorageClusterID
+			}
 		}
 	}
 	logger.Infof("composeDorisTableIdDetail: table_id [%s], bkbase_table_id [%s], origin_table_id [%s]", tableId, bkbaseTableId, doris.OriginTableId)
@@ -1351,6 +1387,7 @@ func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMe
 	// 组装数据
 	detailStr, err := jsonx.MarshalString(map[string]any{
 		"storage_type": models.StorageTypeBkSql,
+		"storage_name": storageClusterNameMap[storageClusterID],
 		"db":           bkbaseTableId,
 		"measurement":  models.DorisMeasurement,
 		"data_label":   rtMeta.DataLabel,

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
@@ -986,7 +986,17 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 				fieldAliasSettings = fieldAliasMap[tableId]
 			}
 
-			composedTableId, detailStr, err := s.composeDorisTableIdDetail(doris, rtMetaMap[tableId], originDorisMap, storageClusterNameMap, fieldAliasSettings)
+			realTableId := tableId
+			if doris.OriginTableId != "" {
+				realTableId = doris.OriginTableId
+			}
+			clusterRecords, err := storage.ComposeTableIDStorageClusterRecords(db, realTableId, tableId)
+			if err != nil {
+				logger.Errorf("PushDorisTableIdDetail:failed to get storage cluster records, table_id: %s, real_table_id: %s, error: %s", tableId, realTableId, err)
+				return
+			}
+
+			composedTableId, detailStr, err := s.composeDorisTableIdDetail(doris, rtMetaMap[tableId], originDorisMap, storageClusterNameMap, clusterRecords, fieldAliasSettings)
 			if err != nil {
 				logger.Errorf("PushDorisTableIdDetail:compose doris table id detail error, table_id: %s, error: %s", tableId, err)
 				return
@@ -1310,7 +1320,7 @@ func (s *SpacePusher) composeEsTableIdDetail(tableId string, options map[string]
 		realTableId = storageIns.OriginTableId
 	}
 
-	clusterRecords, err := storage.ComposeTableIDStorageClusterRecords(db, realTableId)
+	clusterRecords, err := storage.ComposeTableIDStorageClusterRecords(db, realTableId, tableId)
 	if err != nil {
 		logger.Errorf("composeEsTableIdDetail: failed to get storage cluster records for table_id [%s], error: %v", realTableId, err)
 		return "", "", err
@@ -1363,7 +1373,7 @@ func (s *SpacePusher) composeEsTableIdDetail(tableId string, options map[string]
 	return tableId, detailStr, err
 }
 
-func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMeta resultTableDetailMeta, originDorisMap map[string]storage.DorisStorage, storageClusterNameMap map[uint]string, fieldAliasSettings map[string]string) (string, string, error) {
+func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMeta resultTableDetailMeta, originDorisMap map[string]storage.DorisStorage, storageClusterNameMap map[uint]string, clusterRecords []map[string]any, fieldAliasSettings map[string]string) (string, string, error) {
 	tableId := doris.TableID
 	bkbaseTableId := doris.BkbaseTableID
 	storageClusterID := doris.StorageClusterID
@@ -1386,13 +1396,16 @@ func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMe
 
 	// 组装数据
 	detailStr, err := jsonx.MarshalString(map[string]any{
-		"storage_type": models.StorageTypeBkSql,
-		"storage_name": storageClusterNameMap[storageClusterID],
-		"db":           bkbaseTableId,
-		"measurement":  models.DorisMeasurement,
-		"data_label":   rtMeta.DataLabel,
-		"labels":       rtMeta.Labels,
-		"field_alias":  fieldAliasSettings, // 添加字段别名
+		"storage_type":            models.StorageTypeBkSql,
+		"storage_id":              storageClusterID,
+		"storage_name":            storageClusterNameMap[storageClusterID],
+		"cluster_name":            storageClusterNameMap[storageClusterID],
+		"db":                      bkbaseTableId,
+		"measurement":             models.DorisMeasurement,
+		"storage_cluster_records": clusterRecords,
+		"data_label":              rtMeta.DataLabel,
+		"labels":                  rtMeta.Labels,
+		"field_alias":             fieldAliasSettings, // 添加字段别名
 	})
 	if err != nil {
 		return tableId, "", err

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
@@ -2209,6 +2209,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		resultTableDetailMeta{DataLabel: dataLabel, Labels: normalizeResultTableLabels(tableID1, labels1)},
 		nil,
 		nil,
+		nil,
+		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
 	assert.Equal(t, tableID1, composedTableID, "entity doris detail key should be current table_id")
@@ -2224,6 +2226,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		resultTableDetailMeta{Labels: normalizeResultTableLabels(tableID2, labels2)},
 		nil,
 		nil,
+		nil,
+		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
 	var actualDetail2 map[string]any
@@ -2237,6 +2241,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		map[string]storage.DorisStorage{
 			originTableID: {TableID: originTableID, BkbaseTableID: "bklog_real_doris"},
 		},
+		nil,
+		nil,
 		map[string]string{"pod_name": "__ext.pod_name"},
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
@@ -2256,6 +2262,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 			originTableID: {TableID: originTableID, BkbaseTableID: "bklog_real_doris"},
 		},
 		nil,
+		nil,
+		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
 	var actualDetail4 map[string]any
@@ -2267,6 +2275,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		storage.DorisStorage{TableID: tableID4, BkbaseTableID: "bklog_missing_origin_fallback", OriginTableId: "bklog.not_exist"},
 		resultTableDetailMeta{},
 		map[string]storage.DorisStorage{},
+		nil,
+		nil,
 		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")

--- a/pkg/unify-query/docs/docs.go
+++ b/pkg/unify-query/docs/docs.go
@@ -1715,6 +1715,9 @@ const docTemplate = `{
                 },
                 "storage_id": {
                     "type": "string"
+                },
+                "storage_type": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/unify-query/docs/swagger.json
+++ b/pkg/unify-query/docs/swagger.json
@@ -1699,6 +1699,9 @@
                 },
                 "storage_id": {
                     "type": "string"
+                },
+                "storage_type": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/unify-query/docs/swagger.yaml
+++ b/pkg/unify-query/docs/swagger.yaml
@@ -369,6 +369,8 @@ definitions:
         type: integer
       storage_id:
         type: string
+      storage_type:
+        type: string
     type: object
   query.TsDBV2:
     properties:

--- a/pkg/unify-query/query/interfaces.go
+++ b/pkg/unify-query/query/interfaces.go
@@ -19,10 +19,21 @@ import (
 
 type Filter map[string]string
 
+// Record 表示 storage_cluster_records 中的一条时间分段路由。
+// 当一个 RT 在不同时间段写入不同存储（例如 ES + Doris）时，UQ 会用这里的字段覆盖外层 result_table_detail。
 type Record struct {
-	StorageID   string `json:"storage_id,omitempty"`
+	// StorageID 是该时间段命中的存储集群 ID，用于定位底层存储实例。
+	StorageID string `json:"storage_id,omitempty"`
+	// StorageType 是该时间段应查询的存储类型；Doris 在查询侧统一表达为 bk_sql。
 	StorageType string `json:"storage_type,omitempty"`
-	EnableTime  int64  `json:"enable_time,omitempty"`
+	// StorageName / ClusterName 表示存储集群名，Doris 查询 BKBase 时会透传为 properties.cluster_name。
+	StorageName string `json:"storage_name,omitempty"`
+	ClusterName string `json:"cluster_name,omitempty"`
+	// DB / Measurement 是该时间段的物理查询目标。ES 使用 index_set + __default__，Doris 使用 bkbase_table_id + doris。
+	DB          string `json:"db,omitempty"`
+	Measurement string `json:"measurement,omitempty"`
+	// EnableTime 是该路由开始生效的 Unix 秒级时间戳。
+	EnableTime int64 `json:"enable_time,omitempty"`
 }
 
 type StorageClusterRecords []Record
@@ -86,11 +97,28 @@ func (z *TsDBV2) GetStorageRoutes(start, end time.Time) []Record {
 	storageRoutes := make([]Record, 0)
 	routeKeys := make(map[string]struct{})
 	addRoute := func(record Record) {
+		// 兼容旧 Redis 数据：record 缺少字段时，继续使用外层 result_table_detail 的配置。
 		storageType := record.StorageType
 		if storageType == "" {
 			storageType = z.StorageType
 		}
-		key := fmt.Sprintf("%s\x00%s", record.StorageID, storageType)
+		storageName := record.StorageName
+		if storageName == "" {
+			storageName = z.StorageName
+		}
+		clusterName := record.ClusterName
+		if clusterName == "" {
+			clusterName = z.ClusterName
+		}
+		db := record.DB
+		if db == "" {
+			db = z.DB
+		}
+		measurement := record.Measurement
+		if measurement == "" {
+			measurement = z.Measurement
+		}
+		key := fmt.Sprintf("%s\x00%s\x00%s\x00%s", record.StorageID, storageType, db, measurement)
 		if _, ok := routeKeys[key]; ok {
 			return
 		}
@@ -98,6 +126,10 @@ func (z *TsDBV2) GetStorageRoutes(start, end time.Time) []Record {
 		storageRoutes = append(storageRoutes, Record{
 			StorageID:   record.StorageID,
 			StorageType: storageType,
+			StorageName: storageName,
+			ClusterName: clusterName,
+			DB:          db,
+			Measurement: measurement,
 			EnableTime:  record.EnableTime,
 		})
 	}

--- a/pkg/unify-query/query/interfaces.go
+++ b/pkg/unify-query/query/interfaces.go
@@ -27,12 +27,6 @@ type Record struct {
 
 type StorageClusterRecords []Record
 
-type StorageRoute struct {
-	StorageID   string `json:"storage_id,omitempty"`
-	StorageType string `json:"storage_type,omitempty"`
-	EnableTime  int64  `json:"enable_time,omitempty"`
-}
-
 // TsDBV2 适配查询语句的结构体，以 TableID + MetricName 为条件，检索出 RT 基本信息和存储信息
 type TsDBV2 struct {
 	TableID         string              `json:"table_id"`
@@ -80,16 +74,16 @@ func (z *TsDBV2) String() string {
 }
 
 // GetStorageRoutes 通过查询时间获取存储路由列表
-func (z *TsDBV2) GetStorageRoutes(start, end time.Time) []StorageRoute {
+func (z *TsDBV2) GetStorageRoutes(start, end time.Time) []Record {
 	// 如果没有迁移记录，则直接返回存储 ID
 	if len(z.StorageClusterRecords) == 0 {
-		return []StorageRoute{{
+		return []Record{{
 			StorageID:   z.StorageID,
 			StorageType: z.StorageType,
 		}}
 	}
 
-	storageRoutes := make([]StorageRoute, 0)
+	storageRoutes := make([]Record, 0)
 	routeKeys := make(map[string]struct{})
 	addRoute := func(record Record) {
 		storageType := record.StorageType
@@ -101,7 +95,7 @@ func (z *TsDBV2) GetStorageRoutes(start, end time.Time) []StorageRoute {
 			return
 		}
 		routeKeys[key] = struct{}{}
-		storageRoutes = append(storageRoutes, StorageRoute{
+		storageRoutes = append(storageRoutes, Record{
 			StorageID:   record.StorageID,
 			StorageType: storageType,
 			EnableTime:  record.EnableTime,
@@ -126,19 +120,4 @@ func (z *TsDBV2) GetStorageRoutes(start, end time.Time) []StorageRoute {
 	}
 
 	return storageRoutes
-}
-
-// GetStorageIDs 通过查询时间获取存储 ID 的列表
-func (z *TsDBV2) GetStorageIDs(start, end time.Time) []string {
-	routes := z.GetStorageRoutes(start, end)
-	storageIDs := make([]string, 0, len(routes))
-	storageIDSet := make(map[string]struct{})
-	for _, route := range routes {
-		if _, ok := storageIDSet[route.StorageID]; ok {
-			continue
-		}
-		storageIDSet[route.StorageID] = struct{}{}
-		storageIDs = append(storageIDs, route.StorageID)
-	}
-	return storageIDs
 }

--- a/pkg/unify-query/query/interfaces.go
+++ b/pkg/unify-query/query/interfaces.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/set"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
 )
@@ -21,11 +20,18 @@ import (
 type Filter map[string]string
 
 type Record struct {
-	StorageID  string `json:"storage_id,omitempty"`
-	EnableTime int64  `json:"enable_time,omitempty"`
+	StorageID   string `json:"storage_id,omitempty"`
+	StorageType string `json:"storage_type,omitempty"`
+	EnableTime  int64  `json:"enable_time,omitempty"`
 }
 
 type StorageClusterRecords []Record
+
+type StorageRoute struct {
+	StorageID   string `json:"storage_id,omitempty"`
+	StorageType string `json:"storage_type,omitempty"`
+	EnableTime  int64  `json:"enable_time,omitempty"`
+}
 
 // TsDBV2 适配查询语句的结构体，以 TableID + MetricName 为条件，检索出 RT 基本信息和存储信息
 type TsDBV2 struct {
@@ -73,14 +79,35 @@ func (z *TsDBV2) String() string {
 	)
 }
 
-// GetStorageIDs 通过查询时间获取存储 ID 的列表
-func (z *TsDBV2) GetStorageIDs(start, end time.Time) []string {
+// GetStorageRoutes 通过查询时间获取存储路由列表
+func (z *TsDBV2) GetStorageRoutes(start, end time.Time) []StorageRoute {
 	// 如果没有迁移记录，则直接返回存储 ID
 	if len(z.StorageClusterRecords) == 0 {
-		return []string{z.StorageID}
+		return []StorageRoute{{
+			StorageID:   z.StorageID,
+			StorageType: z.StorageType,
+		}}
 	}
 
-	storageIDSet := set.New[string]()
+	storageRoutes := make([]StorageRoute, 0)
+	routeKeys := make(map[string]struct{})
+	addRoute := func(record Record) {
+		storageType := record.StorageType
+		if storageType == "" {
+			storageType = z.StorageType
+		}
+		key := fmt.Sprintf("%s\x00%s", record.StorageID, storageType)
+		if _, ok := routeKeys[key]; ok {
+			return
+		}
+		routeKeys[key] = struct{}{}
+		storageRoutes = append(storageRoutes, StorageRoute{
+			StorageID:   record.StorageID,
+			StorageType: storageType,
+			EnableTime:  record.EnableTime,
+		})
+	}
+
 	// 遍历 storageClusterRecords 记录，按照开启时间倒序
 	for _, record := range z.StorageClusterRecords {
 		// 开始时间和结束时间分别扩 1h 预留查询量
@@ -89,7 +116,7 @@ func (z *TsDBV2) GetStorageIDs(start, end time.Time) []string {
 
 		// 开启时间小于结束时间则加入查询队列
 		if record.EnableTime < checkEnd {
-			storageIDSet.Add(record.StorageID)
+			addRoute(record)
 		}
 
 		// 开启时间小于开始时间，则退出该循环
@@ -98,5 +125,20 @@ func (z *TsDBV2) GetStorageIDs(start, end time.Time) []string {
 		}
 	}
 
-	return storageIDSet.ToArray()
+	return storageRoutes
+}
+
+// GetStorageIDs 通过查询时间获取存储 ID 的列表
+func (z *TsDBV2) GetStorageIDs(start, end time.Time) []string {
+	routes := z.GetStorageRoutes(start, end)
+	storageIDs := make([]string, 0, len(routes))
+	storageIDSet := make(map[string]struct{})
+	for _, route := range routes {
+		if _, ok := storageIDSet[route.StorageID]; ok {
+			continue
+		}
+		storageIDSet[route.StorageID] = struct{}{}
+		storageIDs = append(storageIDs, route.StorageID)
+	}
+	return storageIDs
 }

--- a/pkg/unify-query/query/interfaces_test.go
+++ b/pkg/unify-query/query/interfaces_test.go
@@ -54,3 +54,53 @@ func TestTsDBV2_GetStorageIDs(t *testing.T) {
 	sort.Strings(expected)
 	assert.Equal(t, expected, ids)
 }
+
+func TestTsDBV2_GetStorageRoutes(t *testing.T) {
+	start := time.Unix(1500, 0)
+	end := time.Unix(2500, 0)
+
+	t.Run("storage type fallback to tsdb", func(t *testing.T) {
+		db := &TsDBV2{
+			StorageID:   "1",
+			StorageType: "elasticsearch",
+		}
+
+		assert.Equal(t, []StorageRoute{
+			{
+				StorageID:   "1",
+				StorageType: "elasticsearch",
+			},
+		}, db.GetStorageRoutes(start, end))
+	})
+
+	t.Run("record storage type overrides tsdb storage type", func(t *testing.T) {
+		db := &TsDBV2{
+			StorageID:   "1",
+			StorageType: "elasticsearch",
+			StorageClusterRecords: []Record{
+				{
+					StorageID:   "3",
+					StorageType: "bk_sql",
+					EnableTime:  2000,
+				},
+				{
+					StorageID:  "2",
+					EnableTime: 1000,
+				},
+			},
+		}
+
+		assert.Equal(t, []StorageRoute{
+			{
+				StorageID:   "3",
+				StorageType: "bk_sql",
+				EnableTime:  2000,
+			},
+			{
+				StorageID:   "2",
+				StorageType: "elasticsearch",
+				EnableTime:  1000,
+			},
+		}, db.GetStorageRoutes(start, end))
+	})
+}

--- a/pkg/unify-query/query/interfaces_test.go
+++ b/pkg/unify-query/query/interfaces_test.go
@@ -64,4 +64,51 @@ func TestTsDBV2_GetStorageRoutes(t *testing.T) {
 			},
 		}, db.GetStorageRoutes(start, end))
 	})
+
+	t.Run("record route metadata overrides tsdb metadata with fallback", func(t *testing.T) {
+		db := &TsDBV2{
+			StorageID:   "1",
+			StorageType: "elasticsearch",
+			StorageName: "es_default",
+			ClusterName: "es_default",
+			DB:          "es_index",
+			Measurement: "__default__",
+			StorageClusterRecords: []Record{
+				{
+					StorageID:   "3",
+					StorageType: "bk_sql",
+					StorageName: "doris_default",
+					ClusterName: "doris_default",
+					DB:          "bkbase_table",
+					Measurement: "doris",
+					EnableTime:  2000,
+				},
+				{
+					StorageID:  "2",
+					EnableTime: 1000,
+				},
+			},
+		}
+
+		assert.Equal(t, []Record{
+			{
+				StorageID:   "3",
+				StorageType: "bk_sql",
+				StorageName: "doris_default",
+				ClusterName: "doris_default",
+				DB:          "bkbase_table",
+				Measurement: "doris",
+				EnableTime:  2000,
+			},
+			{
+				StorageID:   "2",
+				StorageType: "elasticsearch",
+				StorageName: "es_default",
+				ClusterName: "es_default",
+				DB:          "es_index",
+				Measurement: "__default__",
+				EnableTime:  1000,
+			},
+		}, db.GetStorageRoutes(start, end))
+	})
 }

--- a/pkg/unify-query/query/interfaces_test.go
+++ b/pkg/unify-query/query/interfaces_test.go
@@ -10,50 +10,11 @@
 package query
 
 import (
-	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestTsDBV2_GetStorageIDs(t *testing.T) {
-	db := &TsDBV2{
-		StorageID: "16",
-		StorageClusterRecords: []Record{
-			{
-				StorageID:  "16",
-				EnableTime: 1757401605, // 2025-09-09 15:06:45
-			},
-			{
-				StorageID:  "5",
-				EnableTime: 1756969402, // 2025-09-04 15:03:22
-			},
-			{
-				StorageID:  "27",
-				EnableTime: 1756957849, // 2025-09-04 11:50:49
-			},
-			{
-				StorageID:  "26",
-				EnableTime: 1756894884, // 2025-09-03 18:21:24
-			},
-			{
-				StorageID:  "16",
-				EnableTime: 1753789890, // 2025-07-29 19:51:30
-			},
-		},
-	}
-
-	start := time.UnixMilli(1757399805337) // 2025-09-09 14:36:45
-	end := time.UnixMilli(1757401605337)   // 2025-09-09 15:06:45
-
-	ids := db.GetStorageIDs(start, end)
-	// 由于set返回顺序不确定，需要排序后比较
-	sort.Strings(ids)
-	expected := []string{"16", "5"}
-	sort.Strings(expected)
-	assert.Equal(t, expected, ids)
-}
 
 func TestTsDBV2_GetStorageRoutes(t *testing.T) {
 	start := time.Unix(1500, 0)
@@ -65,7 +26,7 @@ func TestTsDBV2_GetStorageRoutes(t *testing.T) {
 			StorageType: "elasticsearch",
 		}
 
-		assert.Equal(t, []StorageRoute{
+		assert.Equal(t, []Record{
 			{
 				StorageID:   "1",
 				StorageType: "elasticsearch",
@@ -90,7 +51,7 @@ func TestTsDBV2_GetStorageRoutes(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, []StorageRoute{
+		assert.Equal(t, []Record{
 			{
 				StorageID:   "3",
 				StorageType: "bk_sql",

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -731,9 +731,9 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 
 	// 查询路由匹配中的 tsDB 列表
 	for _, tsDB := range tsDBs {
-		storageIDs := tsDB.GetStorageIDs(qp.Start, qp.End)
+		storageRoutes := tsDB.GetStorageRoutes(qp.Start, qp.End)
 
-		for _, storageID := range storageIDs {
+		for _, storageRoute := range storageRoutes {
 			query := q.BuildMetadataQuery(ctx, tsDB, allConditions)
 			if query == nil {
 				continue
@@ -741,7 +741,10 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 
 			query.Aggregates = aggregates.Copy()
 			query.Timezone = qp.Timezone
-			query.StorageID = storageID
+			query.StorageID = storageRoute.StorageID
+			if storageRoute.StorageType != "" {
+				query.StorageType = storageRoute.StorageType
+			}
 			query.ResultTableOption = q.ResultTableOptions.GetOption(query.TableUUID())
 
 			// 如果没有指定查询类型，则通过 storageID 获取

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -742,8 +742,23 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 			query.Aggregates = aggregates.Copy()
 			query.Timezone = qp.Timezone
 			query.StorageID = storageRoute.StorageID
+			// storageRoute 是按时间段命中的完整路由信息；存在时必须覆盖外层 RT detail，
+			// 否则 ES + Doris 混合场景会用外层存储的 db/measurement 去查另一种存储。
 			if storageRoute.StorageType != "" {
 				query.StorageType = storageRoute.StorageType
+			}
+			if storageRoute.StorageName != "" {
+				query.StorageName = storageRoute.StorageName
+			}
+			if storageRoute.ClusterName != "" {
+				query.ClusterName = storageRoute.ClusterName
+			}
+			if storageRoute.DB != "" {
+				query.DB = storageRoute.DB
+			}
+			if storageRoute.Measurement != "" {
+				query.Measurement = storageRoute.Measurement
+				query.Measurements = []string{storageRoute.Measurement}
 			}
 			query.ResultTableOption = q.ResultTableOptions.GetOption(query.TableUUID())
 

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/query"
 	md "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/mock"
+	uqQuery "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/query"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/query/promql"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/tsdb/bksql"
@@ -289,6 +290,49 @@ func TestQueryToMetric(t *testing.T) {
 			assert.Equal(t, string(a), string(b))
 		})
 	}
+}
+
+func TestQueryToMetricStorageClusterRecordStorageType(t *testing.T) {
+	ctx := md.InitHashID(context.Background())
+	start := time.Unix(1500, 0)
+	end := time.Unix(2500, 0)
+	md.GetQueryParams(ctx).SetTime(start, start, end, time.Minute, "s", "UTC")
+
+	queryMetric, err := (&Query{
+		DataSource:    BkLog,
+		TableID:       "result_table.es",
+		FieldName:     "dtEventTimeStamp",
+		ReferenceName: "a",
+	}).ToQueryMetric(ctx, influxdb.SpaceUid, TsDBs{
+		&uqQuery.TsDBV2{
+			TableID:     "result_table.es",
+			DataLabel:   "log_index_set_test",
+			StorageID:   "1",
+			StorageType: md.ElasticsearchStorageType,
+			DB:          "es_index",
+			Measurement: "__default__",
+			StorageClusterRecords: []uqQuery.Record{
+				{
+					StorageID:   "2",
+					StorageType: md.BkSqlStorageType,
+					EnableTime:  2000,
+				},
+				{
+					StorageID:  "1",
+					EnableTime: 1000,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, queryMetric.QueryList, 2)
+
+	storageTypes := make(map[string]string)
+	for _, query := range queryMetric.QueryList {
+		storageTypes[query.StorageID] = query.StorageType
+	}
+	assert.Equal(t, md.BkSqlStorageType, storageTypes["2"])
+	assert.Equal(t, md.ElasticsearchStorageType, storageTypes["1"])
 }
 
 func TestBkData_SQL_ToFinalSQL(t *testing.T) {

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/query/promql"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/tsdb/bksql"
+	routerInfluxdb "github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/router/influxdb"
 )
 
 func TestQueryToMetric(t *testing.T) {
@@ -293,6 +294,7 @@ func TestQueryToMetric(t *testing.T) {
 }
 
 func TestQueryToMetricStorageClusterRecordStorageType(t *testing.T) {
+	mock.Init()
 	ctx := md.InitHashID(context.Background())
 	start := time.Unix(1500, 0)
 	end := time.Unix(2500, 0)
@@ -331,6 +333,54 @@ func TestQueryToMetricStorageClusterRecordStorageType(t *testing.T) {
 	for _, query := range queryMetric.QueryList {
 		storageTypes[query.StorageID] = query.StorageType
 	}
+	assert.Equal(t, md.BkSqlStorageType, storageTypes["2"])
+	assert.Equal(t, md.ElasticsearchStorageType, storageTypes["1"])
+}
+
+func TestQueryToMetricStorageClusterRecordStorageTypeFromResultTableDetail(t *testing.T) {
+	mock.Init()
+	ctx := md.InitHashID(context.Background())
+	start := time.Unix(1500, 0)
+	end := time.Unix(2500, 0)
+	md.GetQueryParams(ctx).SetTime(start, start, end, time.Minute, "s", "UTC")
+
+	tsDB := (&SpaceFilter{}).getTsDBWithResultTableDetail(uqQuery.TsDBV2{
+		TableID:    "result_table.es",
+		MetricName: "dtEventTimeStamp",
+	}, &routerInfluxdb.ResultTableDetail{
+		StorageId:   1,
+		StorageType: md.ElasticsearchStorageType,
+		DB:          "es_index",
+		TableId:     "result_table.es",
+		Measurement: "__default__",
+		DataLabel:   "log_index_set_test",
+		StorageClusterRecords: []routerInfluxdb.Record{
+			{
+				StorageID:   2,
+				StorageType: md.BkSqlStorageType,
+				EnableTime:  2000,
+			},
+			{
+				StorageID:  1,
+				EnableTime: 1000,
+			},
+		},
+	})
+
+	queryMetric, err := (&Query{
+		DataSource:    BkLog,
+		TableID:       "result_table.es",
+		FieldName:     "dtEventTimeStamp",
+		ReferenceName: "a",
+	}).ToQueryMetric(ctx, influxdb.SpaceUid, TsDBs{&tsDB})
+	require.NoError(t, err)
+	require.Len(t, queryMetric.QueryList, 2)
+
+	storageTypes := make(map[string]string)
+	for _, query := range queryMetric.QueryList {
+		storageTypes[query.StorageID] = query.StorageType
+	}
+
 	assert.Equal(t, md.BkSqlStorageType, storageTypes["2"])
 	assert.Equal(t, md.ElasticsearchStorageType, storageTypes["1"])
 }

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -96,8 +96,9 @@ func (s *SpaceFilter) getTsDBWithResultTableDetail(t query.TsDBV2, d *routerInfl
 
 	for _, record := range d.StorageClusterRecords {
 		t.StorageClusterRecords = append(t.StorageClusterRecords, query.Record{
-			StorageID:  strconv.Itoa(int(record.StorageID)),
-			EnableTime: record.EnableTime,
+			StorageID:   strconv.Itoa(int(record.StorageID)),
+			StorageType: record.StorageType,
+			EnableTime:  record.EnableTime,
 		})
 	}
 

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -98,6 +98,10 @@ func (s *SpaceFilter) getTsDBWithResultTableDetail(t query.TsDBV2, d *routerInfl
 		t.StorageClusterRecords = append(t.StorageClusterRecords, query.Record{
 			StorageID:   strconv.Itoa(int(record.StorageID)),
 			StorageType: record.StorageType,
+			StorageName: record.StorageName,
+			ClusterName: record.ClusterName,
+			DB:          record.DB,
+			Measurement: record.Measurement,
 			EnableTime:  record.EnableTime,
 		})
 	}

--- a/pkg/unify-query/tsdb/bksql/client.go
+++ b/pkg/unify-query/tsdb/bksql/client.go
@@ -44,16 +44,21 @@ func (c *Client) WithHeader(headers map[string]string) *Client {
 	return c
 }
 
-func (c *Client) curlGet(ctx context.Context, method, sql string, res *Result, span *trace.Span) error {
-	if sql == "" {
+func (c *Client) curlGet(ctx context.Context, method string, req QuerySyncRequest, res *Result, span *trace.Span) error {
+	if req.SQL == "" {
 		return fmt.Errorf("query sql is empty")
 	}
 
 	if method == "" {
 		method = curl.Post
 	}
-	params := make(map[string]string)
-	params["sql"] = sql
+	params := make(map[string]any)
+	params["sql"] = req.SQL
+	if req.ClusterName != "" {
+		params["properties"] = QuerySyncProperties{
+			ClusterName: req.ClusterName,
+		}
+	}
 
 	// body 增加 bkdata auth 信息
 	for k, v := range bkapi.GetBkDataAPI().GetDataAuth() {
@@ -84,6 +89,9 @@ func (c *Client) curlGet(ctx context.Context, method, sql string, res *Result, s
 	queryCost := time.Since(startAnaylize)
 	if span != nil {
 		span.Set("query-cost", queryCost.String())
+		if req.ClusterName != "" {
+			span.Set("query-cluster-name", req.ClusterName)
+		}
 	}
 
 	metric.TsDBRequestSecond(
@@ -92,11 +100,11 @@ func (c *Client) curlGet(ctx context.Context, method, sql string, res *Result, s
 	return nil
 }
 
-func (c *Client) QuerySync(ctx context.Context, sql string, span *trace.Span) *Result {
+func (c *Client) QuerySync(ctx context.Context, req QuerySyncRequest, span *trace.Span) *Result {
 	data := &QuerySyncResultData{}
 	res := c.response(data)
 
-	err := c.curlGet(ctx, curl.Post, sql, res, span)
+	err := c.curlGet(ctx, curl.Post, req, res, span)
 	if err != nil {
 		return c.failed(ctx, err)
 	}

--- a/pkg/unify-query/tsdb/bksql/client_test.go
+++ b/pkg/unify-query/tsdb/bksql/client_test.go
@@ -84,11 +84,13 @@ func TestClient_QuerySync(t *testing.T) {
 
 	res := MockClient().QuerySync(
 		ctx,
-		fmt.Sprintf(
-			`SELECT * FROM restriction_table WHERE dtEventTimeStamp >= %d AND dtEventTimeStamp < %d LIMIT 5`,
-			start.UnixMilli(),
-			end.UnixMilli(),
-		),
+		bksql.QuerySyncRequest{
+			SQL: fmt.Sprintf(
+				`SELECT * FROM restriction_table WHERE dtEventTimeStamp >= %d AND dtEventTimeStamp < %d LIMIT 5`,
+				start.UnixMilli(),
+				end.UnixMilli(),
+			),
+		},
 		nil,
 	)
 

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -94,7 +94,7 @@ func (i *Instance) Check(ctx context.Context, promql string, start, end time.Tim
 	return ""
 }
 
-func (i *Instance) sqlQuery(ctx context.Context, sql string) (*QuerySyncResultData, error) {
+func (i *Instance) sqlQuery(ctx context.Context, req QuerySyncRequest) (*QuerySyncResultData, error) {
 	var (
 		data *QuerySyncResultData
 
@@ -106,11 +106,14 @@ func (i *Instance) sqlQuery(ctx context.Context, sql string) (*QuerySyncResultDa
 	ctx, span = trace.NewSpan(ctx, "sql-query")
 	defer span.End(&err)
 
-	if sql == "" {
+	if req.SQL == "" {
 		return data, nil
 	}
 
-	span.Set("query-sql", sql)
+	span.Set("query-sql", req.SQL)
+	if req.ClusterName != "" {
+		span.Set("query-cluster-name", req.ClusterName)
+	}
 
 	user := metadata.GetUser(ctx)
 
@@ -121,7 +124,7 @@ func (i *Instance) sqlQuery(ctx context.Context, sql string) (*QuerySyncResultDa
 	defer cancel()
 
 	// 发起异步查询
-	res := i.client.QuerySync(ctx, sql, span)
+	res := i.client.QuerySync(ctx, req, span)
 	if res == nil {
 		return nil, nil
 	}
@@ -151,14 +154,28 @@ func (i *Instance) sqlQuery(ctx context.Context, sql string) (*QuerySyncResultDa
 	return data, nil
 }
 
-func (i *Instance) getFieldsMap(ctx context.Context, sql string) (metadata.FieldsMap, error) {
+func queryClusterName(query *metadata.Query) string {
+	if query == nil {
+		return ""
+	}
+	return query.StorageName
+}
+
+func newQuerySyncRequest(sql string, query *metadata.Query) QuerySyncRequest {
+	return QuerySyncRequest{
+		SQL:         sql,
+		ClusterName: queryClusterName(query),
+	}
+}
+
+func (i *Instance) getFieldsMap(ctx context.Context, req QuerySyncRequest) (metadata.FieldsMap, error) {
 	fieldsMap := make(metadata.FieldsMap)
 
-	if sql == "" {
+	if req.SQL == "" {
 		return nil, nil
 	}
 
-	data, err := i.sqlQuery(ctx, sql)
+	data, err := i.sqlQuery(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +304,7 @@ func (i *Instance) QueryFieldMap(ctx context.Context, query *metadata.Query, sta
 		}
 
 		sql := f.expr.DescribeTableSQL(table)
-		res, err := i.getFieldsMap(ctx, sql)
+		res, err := i.getFieldsMap(ctx, newQuerySyncRequest(sql, query))
 		if err != nil {
 			continue
 		}
@@ -361,7 +378,7 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 		return size, total, option, err
 	}
 
-	data, err := i.sqlQuery(ctx, sql)
+	data, err := i.sqlQuery(ctx, newQuerySyncRequest(sql, query))
 	if err != nil {
 		err = fmt.Errorf("sql [%s] query err: %s", sql, err.Error())
 		return size, total, option, err
@@ -427,7 +444,7 @@ func (i *Instance) QuerySeriesSet(ctx context.Context, query *metadata.Query, st
 		return storage.ErrSeriesSet(err)
 	}
 
-	data, err := i.sqlQuery(ctx, sql)
+	data, err := i.sqlQuery(ctx, newQuerySyncRequest(sql, query))
 	if err != nil {
 		err = metadata.NewMessage(
 			metadata.MsgQueryBKSQL,
@@ -490,7 +507,7 @@ func (i *Instance) QueryLabelNames(ctx context.Context, query *metadata.Query, s
 		return nil, err
 	}
 
-	data, err := i.sqlQuery(ctx, sql)
+	data, err := i.sqlQuery(ctx, newQuerySyncRequest(sql, query))
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +556,7 @@ func (i *Instance) QueryLabelValues(ctx context.Context, query *metadata.Query, 
 		return nil, err
 	}
 
-	data, err := i.sqlQuery(ctx, sql)
+	data, err := i.sqlQuery(ctx, newQuerySyncRequest(sql, query))
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +635,7 @@ func (i *Instance) QuerySeries(ctx context.Context, query *metadata.Query, start
 		return nil, err
 	}
 
-	distinctData, err := i.sqlQuery(ctx, distinctSQL)
+	distinctData, err := i.sqlQuery(ctx, newQuerySyncRequest(distinctSQL, query))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/unify-query/tsdb/bksql/struct.go
+++ b/pkg/unify-query/tsdb/bksql/struct.go
@@ -25,6 +25,16 @@ const (
 type Params struct {
 	SQL           string `json:"sql"`
 	PreferStorage string `json:"prefer_storage"`
+	Properties    any    `json:"properties,omitempty"`
+}
+
+type QuerySyncRequest struct {
+	SQL         string
+	ClusterName string
+}
+
+type QuerySyncProperties struct {
+	ClusterName string `json:"cluster_name,omitempty"`
 }
 
 type Result struct {

--- a/pkg/utils/router/influxdb/space.go
+++ b/pkg/utils/router/influxdb/space.go
@@ -68,8 +68,9 @@ type TimeField struct {
 }
 
 type Record struct {
-	StorageID  int64 `json:"storage_id,omitempty"`
-	EnableTime int64 `json:"enable_time,omitempty"`
+	StorageID   int64  `json:"storage_id,omitempty"`
+	StorageType string `json:"storage_type,omitempty"`
+	EnableTime  int64  `json:"enable_time,omitempty"`
 }
 
 //go:generate msgp -tests=false

--- a/pkg/utils/router/influxdb/space.go
+++ b/pkg/utils/router/influxdb/space.go
@@ -67,10 +67,21 @@ type TimeField struct {
 	Unit string `json:"unit"`
 }
 
+// Record 是 Redis 中 result_table_detail.storage_cluster_records 的单条时间分段路由。
+// 字段需要和 UQ query.Record 保持一致，供 msgp 缓存和路由反序列化使用。
 type Record struct {
-	StorageID   int64  `json:"storage_id,omitempty"`
+	// StorageID 是该时间段命中的存储集群 ID。
+	StorageID int64 `json:"storage_id,omitempty"`
+	// StorageType 是该时间段应查询的存储类型；Doris 在查询侧统一表达为 bk_sql。
 	StorageType string `json:"storage_type,omitempty"`
-	EnableTime  int64  `json:"enable_time,omitempty"`
+	// StorageName / ClusterName 表示存储集群名，Doris 查询 BKBase 时会透传为 properties.cluster_name。
+	StorageName string `json:"storage_name,omitempty"`
+	ClusterName string `json:"cluster_name,omitempty"`
+	// DB / Measurement 是该时间段的物理查询目标。ES 使用 index_set + __default__，Doris 使用 bkbase_table_id + doris。
+	DB          string `json:"db,omitempty"`
+	Measurement string `json:"measurement,omitempty"`
+	// EnableTime 是该路由开始生效的 Unix 秒级时间戳。
+	EnableTime int64 `json:"enable_time,omitempty"`
 }
 
 //go:generate msgp -tests=false

--- a/pkg/utils/router/influxdb/space_gen.go
+++ b/pkg/utils/router/influxdb/space_gen.go
@@ -528,6 +528,12 @@ func (z *Record) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "StorageID")
 				return
 			}
+		case "StorageType":
+			z.StorageType, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "StorageType")
+				return
+			}
 		case "EnableTime":
 			z.EnableTime, err = dc.ReadInt64()
 			if err != nil {
@@ -547,15 +553,25 @@ func (z *Record) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z Record) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 2
+	// map header, size 3
 	// write "StorageID"
-	err = en.Append(0x82, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
+	err = en.Append(0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
 	if err != nil {
 		return
 	}
 	err = en.WriteInt64(z.StorageID)
 	if err != nil {
 		err = msgp.WrapError(err, "StorageID")
+		return
+	}
+	// write "StorageType"
+	err = en.Append(0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x54, 0x79, 0x70, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.StorageType)
+	if err != nil {
+		err = msgp.WrapError(err, "StorageType")
 		return
 	}
 	// write "EnableTime"
@@ -574,10 +590,13 @@ func (z Record) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z Record) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 2
+	// map header, size 3
 	// string "StorageID"
-	o = append(o, 0x82, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
+	o = append(o, 0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
 	o = msgp.AppendInt64(o, z.StorageID)
+	// string "StorageType"
+	o = append(o, 0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x54, 0x79, 0x70, 0x65)
+	o = msgp.AppendString(o, z.StorageType)
 	// string "EnableTime"
 	o = append(o, 0xaa, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x69, 0x6d, 0x65)
 	o = msgp.AppendInt64(o, z.EnableTime)
@@ -608,6 +627,12 @@ func (z *Record) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "StorageID")
 				return
 			}
+		case "StorageType":
+			z.StorageType, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "StorageType")
+				return
+			}
 		case "EnableTime":
 			z.EnableTime, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
@@ -628,7 +653,7 @@ func (z *Record) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z Record) Msgsize() (s int) {
-	s = 1 + 10 + msgp.Int64Size + 11 + msgp.Int64Size
+	s = 1 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageType) + 11 + msgp.Int64Size
 	return
 }
 
@@ -699,6 +724,12 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 						z.StorageClusterRecords[za0001].StorageID, err = dc.ReadInt64()
 						if err != nil {
 							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageID")
+							return
+						}
+					case "StorageType":
+						z.StorageClusterRecords[za0001].StorageType, err = dc.ReadString()
+						if err != nil {
+							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageType")
 							return
 						}
 					case "EnableTime":
@@ -1001,15 +1032,25 @@ func (z *ResultTableDetail) EncodeMsg(en *msgp.Writer) (err error) {
 		return
 	}
 	for za0001 := range z.StorageClusterRecords {
-		// map header, size 2
+		// map header, size 3
 		// write "StorageID"
-		err = en.Append(0x82, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
+		err = en.Append(0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
 		if err != nil {
 			return
 		}
 		err = en.WriteInt64(z.StorageClusterRecords[za0001].StorageID)
 		if err != nil {
 			err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageID")
+			return
+		}
+		// write "StorageType"
+		err = en.Append(0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x54, 0x79, 0x70, 0x65)
+		if err != nil {
+			return
+		}
+		err = en.WriteString(z.StorageClusterRecords[za0001].StorageType)
+		if err != nil {
+			err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageType")
 			return
 		}
 		// write "EnableTime"
@@ -1283,10 +1324,13 @@ func (z *ResultTableDetail) MarshalMsg(b []byte) (o []byte, err error) {
 	o = append(o, 0xb5, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.StorageClusterRecords)))
 	for za0001 := range z.StorageClusterRecords {
-		// map header, size 2
+		// map header, size 3
 		// string "StorageID"
-		o = append(o, 0x82, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
+		o = append(o, 0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
 		o = msgp.AppendInt64(o, z.StorageClusterRecords[za0001].StorageID)
+		// string "StorageType"
+		o = append(o, 0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x54, 0x79, 0x70, 0x65)
+		o = msgp.AppendString(o, z.StorageClusterRecords[za0001].StorageType)
 		// string "EnableTime"
 		o = append(o, 0xaa, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x69, 0x6d, 0x65)
 		o = msgp.AppendInt64(o, z.StorageClusterRecords[za0001].EnableTime)
@@ -1438,6 +1482,12 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						z.StorageClusterRecords[za0001].StorageID, bts, err = msgp.ReadInt64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageID")
+							return
+						}
+					case "StorageType":
+						z.StorageClusterRecords[za0001].StorageType, bts, err = msgp.ReadStringBytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageType")
 							return
 						}
 					case "EnableTime":
@@ -1699,7 +1749,11 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *ResultTableDetail) Msgsize() (s int) {
-	s = 3 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageName) + 12 + msgp.StringPrefixSize + len(z.StorageType) + 22 + msgp.ArrayHeaderSize + (len(z.StorageClusterRecords) * (22 + msgp.Int64Size + msgp.Int64Size)) + 12 + msgp.StringPrefixSize + len(z.ClusterName) + 3 + msgp.StringPrefixSize + len(z.DB) + 8 + msgp.StringPrefixSize + len(z.TableId) + 12 + msgp.StringPrefixSize + len(z.Measurement) + 5 + msgp.StringPrefixSize + len(z.VmRt) + 14 + msgp.StringPrefixSize + len(z.CmdbLevelVmRt) + 7 + msgp.ArrayHeaderSize
+	s = 3 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageName) + 12 + msgp.StringPrefixSize + len(z.StorageType) + 22 + msgp.ArrayHeaderSize
+	for za0001 := range z.StorageClusterRecords {
+		s += 1 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageClusterRecords[za0001].StorageType) + 11 + msgp.Int64Size
+	}
+	s += 12 + msgp.StringPrefixSize + len(z.ClusterName) + 3 + msgp.StringPrefixSize + len(z.DB) + 8 + msgp.StringPrefixSize + len(z.TableId) + 12 + msgp.StringPrefixSize + len(z.Measurement) + 5 + msgp.StringPrefixSize + len(z.VmRt) + 14 + msgp.StringPrefixSize + len(z.CmdbLevelVmRt) + 7 + msgp.ArrayHeaderSize
 	for za0002 := range z.Fields {
 		s += msgp.StringPrefixSize + len(z.Fields[za0002])
 	}

--- a/pkg/utils/router/influxdb/space_gen.go
+++ b/pkg/utils/router/influxdb/space_gen.go
@@ -534,6 +534,30 @@ func (z *Record) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "StorageType")
 				return
 			}
+		case "StorageName":
+			z.StorageName, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "StorageName")
+				return
+			}
+		case "ClusterName":
+			z.ClusterName, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "ClusterName")
+				return
+			}
+		case "DB":
+			z.DB, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "DB")
+				return
+			}
+		case "Measurement":
+			z.Measurement, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Measurement")
+				return
+			}
 		case "EnableTime":
 			z.EnableTime, err = dc.ReadInt64()
 			if err != nil {
@@ -552,10 +576,10 @@ func (z *Record) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z Record) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 3
+func (z *Record) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 7
 	// write "StorageID"
-	err = en.Append(0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
+	err = en.Append(0x87, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
 	if err != nil {
 		return
 	}
@@ -574,6 +598,46 @@ func (z Record) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "StorageType")
 		return
 	}
+	// write "StorageName"
+	err = en.Append(0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x4e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.StorageName)
+	if err != nil {
+		err = msgp.WrapError(err, "StorageName")
+		return
+	}
+	// write "ClusterName"
+	err = en.Append(0xab, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.ClusterName)
+	if err != nil {
+		err = msgp.WrapError(err, "ClusterName")
+		return
+	}
+	// write "DB"
+	err = en.Append(0xa2, 0x44, 0x42)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.DB)
+	if err != nil {
+		err = msgp.WrapError(err, "DB")
+		return
+	}
+	// write "Measurement"
+	err = en.Append(0xab, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Measurement)
+	if err != nil {
+		err = msgp.WrapError(err, "Measurement")
+		return
+	}
 	// write "EnableTime"
 	err = en.Append(0xaa, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x69, 0x6d, 0x65)
 	if err != nil {
@@ -588,15 +652,27 @@ func (z Record) EncodeMsg(en *msgp.Writer) (err error) {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z Record) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Record) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 3
+	// map header, size 7
 	// string "StorageID"
-	o = append(o, 0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
+	o = append(o, 0x87, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
 	o = msgp.AppendInt64(o, z.StorageID)
 	// string "StorageType"
 	o = append(o, 0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x54, 0x79, 0x70, 0x65)
 	o = msgp.AppendString(o, z.StorageType)
+	// string "StorageName"
+	o = append(o, 0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x4e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.StorageName)
+	// string "ClusterName"
+	o = append(o, 0xab, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.ClusterName)
+	// string "DB"
+	o = append(o, 0xa2, 0x44, 0x42)
+	o = msgp.AppendString(o, z.DB)
+	// string "Measurement"
+	o = append(o, 0xab, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74)
+	o = msgp.AppendString(o, z.Measurement)
 	// string "EnableTime"
 	o = append(o, 0xaa, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x69, 0x6d, 0x65)
 	o = msgp.AppendInt64(o, z.EnableTime)
@@ -633,6 +709,30 @@ func (z *Record) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "StorageType")
 				return
 			}
+		case "StorageName":
+			z.StorageName, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "StorageName")
+				return
+			}
+		case "ClusterName":
+			z.ClusterName, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ClusterName")
+				return
+			}
+		case "DB":
+			z.DB, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DB")
+				return
+			}
+		case "Measurement":
+			z.Measurement, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Measurement")
+				return
+			}
 		case "EnableTime":
 			z.EnableTime, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
@@ -652,8 +752,8 @@ func (z *Record) UnmarshalMsg(bts []byte) (o []byte, err error) {
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z Record) Msgsize() (s int) {
-	s = 1 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageType) + 11 + msgp.Int64Size
+func (z *Record) Msgsize() (s int) {
+	s = 1 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageType) + 12 + msgp.StringPrefixSize + len(z.StorageName) + 12 + msgp.StringPrefixSize + len(z.ClusterName) + 3 + msgp.StringPrefixSize + len(z.DB) + 12 + msgp.StringPrefixSize + len(z.Measurement) + 11 + msgp.Int64Size
 	return
 }
 
@@ -706,45 +806,10 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.StorageClusterRecords = make([]Record, zb0002)
 			}
 			for za0001 := range z.StorageClusterRecords {
-				var zb0003 uint32
-				zb0003, err = dc.ReadMapHeader()
+				err = z.StorageClusterRecords[za0001].DecodeMsg(dc)
 				if err != nil {
 					err = msgp.WrapError(err, "StorageClusterRecords", za0001)
 					return
-				}
-				for zb0003 > 0 {
-					zb0003--
-					field, err = dc.ReadMapKeyPtr()
-					if err != nil {
-						err = msgp.WrapError(err, "StorageClusterRecords", za0001)
-						return
-					}
-					switch msgp.UnsafeString(field) {
-					case "StorageID":
-						z.StorageClusterRecords[za0001].StorageID, err = dc.ReadInt64()
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageID")
-							return
-						}
-					case "StorageType":
-						z.StorageClusterRecords[za0001].StorageType, err = dc.ReadString()
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageType")
-							return
-						}
-					case "EnableTime":
-						z.StorageClusterRecords[za0001].EnableTime, err = dc.ReadInt64()
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "EnableTime")
-							return
-						}
-					default:
-						err = dc.Skip()
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001)
-							return
-						}
-					}
 				}
 			}
 		case "ClusterName":
@@ -784,16 +849,16 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Fields":
-			var zb0004 uint32
-			zb0004, err = dc.ReadArrayHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Fields")
 				return
 			}
-			if cap(z.Fields) >= int(zb0004) {
-				z.Fields = (z.Fields)[:zb0004]
+			if cap(z.Fields) >= int(zb0003) {
+				z.Fields = (z.Fields)[:zb0003]
 			} else {
-				z.Fields = make([]string, zb0004)
+				z.Fields = make([]string, zb0003)
 			}
 			for za0002 := range z.Fields {
 				z.Fields[za0002], err = dc.ReadString()
@@ -803,19 +868,19 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 		case "FieldAlias":
-			var zb0005 uint32
-			zb0005, err = dc.ReadMapHeader()
+			var zb0004 uint32
+			zb0004, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "FieldAlias")
 				return
 			}
 			if z.FieldAlias == nil {
-				z.FieldAlias = make(map[string]string, zb0005)
+				z.FieldAlias = make(map[string]string, zb0004)
 			} else if len(z.FieldAlias) > 0 {
 				clear(z.FieldAlias)
 			}
-			for zb0005 > 0 {
-				zb0005--
+			for zb0004 > 0 {
+				zb0004--
 				var za0003 string
 				za0003, err = dc.ReadString()
 				if err != nil {
@@ -849,16 +914,16 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "TagsKey":
-			var zb0006 uint32
-			zb0006, err = dc.ReadArrayHeader()
+			var zb0005 uint32
+			zb0005, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "TagsKey")
 				return
 			}
-			if cap(z.TagsKey) >= int(zb0006) {
-				z.TagsKey = (z.TagsKey)[:zb0006]
+			if cap(z.TagsKey) >= int(zb0005) {
+				z.TagsKey = (z.TagsKey)[:zb0005]
 			} else {
-				z.TagsKey = make([]string, zb0006)
+				z.TagsKey = make([]string, zb0005)
 			}
 			for za0005 := range z.TagsKey {
 				z.TagsKey[za0005], err = dc.ReadString()
@@ -880,19 +945,19 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Labels":
-			var zb0007 uint32
-			zb0007, err = dc.ReadMapHeader()
+			var zb0006 uint32
+			zb0006, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Labels")
 				return
 			}
 			if z.Labels == nil {
-				z.Labels = make(map[string]string, zb0007)
+				z.Labels = make(map[string]string, zb0006)
 			} else if len(z.Labels) > 0 {
 				clear(z.Labels)
 			}
-			for zb0007 > 0 {
-				zb0007--
+			for zb0006 > 0 {
+				zb0006--
 				var za0006 string
 				za0006, err = dc.ReadString()
 				if err != nil {
@@ -908,14 +973,14 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.Labels[za0006] = za0007
 			}
 		case "Options":
-			var zb0008 uint32
-			zb0008, err = dc.ReadMapHeader()
+			var zb0007 uint32
+			zb0007, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Options")
 				return
 			}
-			for zb0008 > 0 {
-				zb0008--
+			for zb0007 > 0 {
+				zb0007--
 				field, err = dc.ReadMapKeyPtr()
 				if err != nil {
 					err = msgp.WrapError(err, "Options")
@@ -923,14 +988,14 @@ func (z *ResultTableDetail) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				switch msgp.UnsafeString(field) {
 				case "TimeField":
-					var zb0009 uint32
-					zb0009, err = dc.ReadMapHeader()
+					var zb0008 uint32
+					zb0008, err = dc.ReadMapHeader()
 					if err != nil {
 						err = msgp.WrapError(err, "Options", "TimeField")
 						return
 					}
-					for zb0009 > 0 {
-						zb0009--
+					for zb0008 > 0 {
+						zb0008--
 						field, err = dc.ReadMapKeyPtr()
 						if err != nil {
 							err = msgp.WrapError(err, "Options", "TimeField")
@@ -1032,35 +1097,9 @@ func (z *ResultTableDetail) EncodeMsg(en *msgp.Writer) (err error) {
 		return
 	}
 	for za0001 := range z.StorageClusterRecords {
-		// map header, size 3
-		// write "StorageID"
-		err = en.Append(0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
+		err = z.StorageClusterRecords[za0001].EncodeMsg(en)
 		if err != nil {
-			return
-		}
-		err = en.WriteInt64(z.StorageClusterRecords[za0001].StorageID)
-		if err != nil {
-			err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageID")
-			return
-		}
-		// write "StorageType"
-		err = en.Append(0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x54, 0x79, 0x70, 0x65)
-		if err != nil {
-			return
-		}
-		err = en.WriteString(z.StorageClusterRecords[za0001].StorageType)
-		if err != nil {
-			err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageType")
-			return
-		}
-		// write "EnableTime"
-		err = en.Append(0xaa, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x69, 0x6d, 0x65)
-		if err != nil {
-			return
-		}
-		err = en.WriteInt64(z.StorageClusterRecords[za0001].EnableTime)
-		if err != nil {
-			err = msgp.WrapError(err, "StorageClusterRecords", za0001, "EnableTime")
+			err = msgp.WrapError(err, "StorageClusterRecords", za0001)
 			return
 		}
 	}
@@ -1324,16 +1363,11 @@ func (z *ResultTableDetail) MarshalMsg(b []byte) (o []byte, err error) {
 	o = append(o, 0xb5, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.StorageClusterRecords)))
 	for za0001 := range z.StorageClusterRecords {
-		// map header, size 3
-		// string "StorageID"
-		o = append(o, 0x83, 0xa9, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x49, 0x44)
-		o = msgp.AppendInt64(o, z.StorageClusterRecords[za0001].StorageID)
-		// string "StorageType"
-		o = append(o, 0xab, 0x53, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x54, 0x79, 0x70, 0x65)
-		o = msgp.AppendString(o, z.StorageClusterRecords[za0001].StorageType)
-		// string "EnableTime"
-		o = append(o, 0xaa, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x69, 0x6d, 0x65)
-		o = msgp.AppendInt64(o, z.StorageClusterRecords[za0001].EnableTime)
+		o, err = z.StorageClusterRecords[za0001].MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "StorageClusterRecords", za0001)
+			return
+		}
 	}
 	// string "ClusterName"
 	o = append(o, 0xab, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65)
@@ -1464,45 +1498,10 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.StorageClusterRecords = make([]Record, zb0002)
 			}
 			for za0001 := range z.StorageClusterRecords {
-				var zb0003 uint32
-				zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+				bts, err = z.StorageClusterRecords[za0001].UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StorageClusterRecords", za0001)
 					return
-				}
-				for zb0003 > 0 {
-					zb0003--
-					field, bts, err = msgp.ReadMapKeyZC(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "StorageClusterRecords", za0001)
-						return
-					}
-					switch msgp.UnsafeString(field) {
-					case "StorageID":
-						z.StorageClusterRecords[za0001].StorageID, bts, err = msgp.ReadInt64Bytes(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageID")
-							return
-						}
-					case "StorageType":
-						z.StorageClusterRecords[za0001].StorageType, bts, err = msgp.ReadStringBytes(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "StorageType")
-							return
-						}
-					case "EnableTime":
-						z.StorageClusterRecords[za0001].EnableTime, bts, err = msgp.ReadInt64Bytes(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001, "EnableTime")
-							return
-						}
-					default:
-						bts, err = msgp.Skip(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "StorageClusterRecords", za0001)
-							return
-						}
-					}
 				}
 			}
 		case "ClusterName":
@@ -1542,16 +1541,16 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Fields":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Fields")
 				return
 			}
-			if cap(z.Fields) >= int(zb0004) {
-				z.Fields = (z.Fields)[:zb0004]
+			if cap(z.Fields) >= int(zb0003) {
+				z.Fields = (z.Fields)[:zb0003]
 			} else {
-				z.Fields = make([]string, zb0004)
+				z.Fields = make([]string, zb0003)
 			}
 			for za0002 := range z.Fields {
 				z.Fields[za0002], bts, err = msgp.ReadStringBytes(bts)
@@ -1561,20 +1560,20 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 		case "FieldAlias":
-			var zb0005 uint32
-			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "FieldAlias")
 				return
 			}
 			if z.FieldAlias == nil {
-				z.FieldAlias = make(map[string]string, zb0005)
+				z.FieldAlias = make(map[string]string, zb0004)
 			} else if len(z.FieldAlias) > 0 {
 				clear(z.FieldAlias)
 			}
-			for zb0005 > 0 {
+			for zb0004 > 0 {
 				var za0004 string
-				zb0005--
+				zb0004--
 				var za0003 string
 				za0003, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
@@ -1607,16 +1606,16 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "TagsKey":
-			var zb0006 uint32
-			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "TagsKey")
 				return
 			}
-			if cap(z.TagsKey) >= int(zb0006) {
-				z.TagsKey = (z.TagsKey)[:zb0006]
+			if cap(z.TagsKey) >= int(zb0005) {
+				z.TagsKey = (z.TagsKey)[:zb0005]
 			} else {
-				z.TagsKey = make([]string, zb0006)
+				z.TagsKey = make([]string, zb0005)
 			}
 			for za0005 := range z.TagsKey {
 				z.TagsKey[za0005], bts, err = msgp.ReadStringBytes(bts)
@@ -1638,20 +1637,20 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Labels":
-			var zb0007 uint32
-			zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Labels")
 				return
 			}
 			if z.Labels == nil {
-				z.Labels = make(map[string]string, zb0007)
+				z.Labels = make(map[string]string, zb0006)
 			} else if len(z.Labels) > 0 {
 				clear(z.Labels)
 			}
-			for zb0007 > 0 {
+			for zb0006 > 0 {
 				var za0007 string
-				zb0007--
+				zb0006--
 				var za0006 string
 				za0006, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
@@ -1666,14 +1665,14 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.Labels[za0006] = za0007
 			}
 		case "Options":
-			var zb0008 uint32
-			zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 uint32
+			zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Options")
 				return
 			}
-			for zb0008 > 0 {
-				zb0008--
+			for zb0007 > 0 {
+				zb0007--
 				field, bts, err = msgp.ReadMapKeyZC(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Options")
@@ -1681,14 +1680,14 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				switch msgp.UnsafeString(field) {
 				case "TimeField":
-					var zb0009 uint32
-					zb0009, bts, err = msgp.ReadMapHeaderBytes(bts)
+					var zb0008 uint32
+					zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Options", "TimeField")
 						return
 					}
-					for zb0009 > 0 {
-						zb0009--
+					for zb0008 > 0 {
+						zb0008--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Options", "TimeField")
@@ -1751,7 +1750,7 @@ func (z *ResultTableDetail) UnmarshalMsg(bts []byte) (o []byte, err error) {
 func (z *ResultTableDetail) Msgsize() (s int) {
 	s = 3 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageName) + 12 + msgp.StringPrefixSize + len(z.StorageType) + 22 + msgp.ArrayHeaderSize
 	for za0001 := range z.StorageClusterRecords {
-		s += 1 + 10 + msgp.Int64Size + 12 + msgp.StringPrefixSize + len(z.StorageClusterRecords[za0001].StorageType) + 11 + msgp.Int64Size
+		s += z.StorageClusterRecords[za0001].Msgsize()
 	}
 	s += 12 + msgp.StringPrefixSize + len(z.ClusterName) + 3 + msgp.StringPrefixSize + len(z.DB) + 8 + msgp.StringPrefixSize + len(z.TableId) + 12 + msgp.StringPrefixSize + len(z.Measurement) + 5 + msgp.StringPrefixSize + len(z.VmRt) + 14 + msgp.StringPrefixSize + len(z.CmdbLevelVmRt) + 7 + msgp.ArrayHeaderSize
 	for za0002 := range z.Fields {


### PR DESCRIPTION
## 背景

在 ES + Doris 双写场景下，同一份日志数据会同时存在多份存储。UQ 查询侧需要根据 `result_table_detail.storage_cluster_records` 中的路由记录，判断查询时间范围内应该命中的存储实例。

原有逻辑中，路由记录只能表达 `storage_id`，查询构建阶段无法从单条路由记录上直接获得对应的 `storage_type`。当同一个结果表存在 ES、Doris 等不同类型存储时，仅依赖外层 `result_table_detail.storage_type` 会导致不同存储路由共用同一个存储类型，无法准确构建查询。

## 功能描述

本次变更在 `storage_cluster_records` 记录级别补充 `storage_type`，使 UQ 在根据时间范围命中存储路由时，可以同时获得 `storage_id` 和对应的 `storage_type`。

具体规则如下：

- 如果命中的 `storage_cluster_records` 记录中存在 `storage_type`，优先使用该记录级别的 `storage_type`。
- 如果命中的记录中没有 `storage_type`，则回退使用外层 `result_table_detail.storage_type`。
- 老数据中的 `storage_cluster_records` 不包含记录级 `storage_type`，仍按原逻辑回退外层存储类型，保持兼容。

该能力主要用于 ES + Doris 双写日志查询场景，确保查询构建阶段能够为不同存储路由生成正确的查询类型。