### PR TITLE
feat: bmw 支持 Doris 分段路由元数据

### DIFF
--- a/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
+++ b/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/jinzhu/gorm"
+	"github.com/samber/lo"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/metadata/models"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -60,8 +62,12 @@ func (ClusterRecord) TableName() string {
 }
 
 // ComposeTableIDStorageClusterRecords 组装指定 table_id 的历史存储集群记录
-func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string) ([]map[string]any, error) {
+func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string, currentTableID ...string) ([]map[string]any, error) {
 	logger.Infof("compose_table_id_storage_cluster_records: try to get storage cluster records for table_id->[%s]", tableID)
+	routeTableID := tableID
+	if len(currentTableID) > 0 && currentTableID[0] != "" {
+		routeTableID = currentTableID[0]
+	}
 
 	var records []ClusterRecord
 	// 查询数据库：过滤 table_id 和 is_deleted，按 create_time 升序排列
@@ -77,6 +83,117 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string) ([]map[str
 		return nil, err
 	}
 
+	clusterIDList := lo.Uniq(lo.FilterMap(records, func(record ClusterRecord, _ int) (uint, bool) {
+		if record.ClusterID > 0 {
+			return uint(record.ClusterID), true
+		}
+		return 0, false
+	}))
+
+	clusterInfoMap := make(map[uint]ClusterInfo, len(clusterIDList))
+	hasDorisRoute := false
+	hasESRoute := false
+	if len(clusterIDList) > 0 {
+		var clusterInfoList []ClusterInfo
+		if err = NewClusterInfoQuerySet(db).
+			Select(ClusterInfoDBSchema.ClusterID, ClusterInfoDBSchema.ClusterName, ClusterInfoDBSchema.ClusterType).
+			ClusterIDIn(clusterIDList...).
+			All(&clusterInfoList); err != nil {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query cluster info for table_id->[%s], error: %v", tableID, err)
+			return nil, err
+		}
+		for _, clusterInfo := range clusterInfoList {
+			clusterInfoMap[clusterInfo.ClusterID] = clusterInfo
+			switch clusterInfo.ClusterType {
+			case models.StorageTypeDoris:
+				hasDorisRoute = true
+			case models.StorageTypeES:
+				hasESRoute = true
+			}
+		}
+	}
+
+	// Doris 分段路由需要携带 BKBase 表名和 doris measurement，用于 UQ 生成该时间段的 BKSQL 查询目标。
+	dorisRoute := map[string]any{}
+	if hasDorisRoute && db.HasTable(DorisStorage{}) {
+		var dorisStorage DorisStorage
+		if err = NewDorisStorageQuerySet(db).
+			Select(DorisStorageDBSchema.TableID, DorisStorageDBSchema.BkbaseTableID, DorisStorageDBSchema.OriginTableId, DorisStorageDBSchema.StorageClusterID).
+			TableIDEq(routeTableID).
+			One(&dorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query doris storage for table_id->[%s], error: %v", routeTableID, err)
+			return nil, err
+		}
+		if dorisStorage.BkbaseTableID == "" && routeTableID != tableID {
+			if err = NewDorisStorageQuerySet(db).
+				Select(DorisStorageDBSchema.TableID, DorisStorageDBSchema.BkbaseTableID, DorisStorageDBSchema.OriginTableId, DorisStorageDBSchema.StorageClusterID).
+				TableIDEq(tableID).
+				One(&dorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query doris storage for table_id->[%s], error: %v", tableID, err)
+				return nil, err
+			}
+		}
+		if dorisStorage.BkbaseTableID == "" && dorisStorage.OriginTableId != "" {
+			var originDorisStorage DorisStorage
+			if err = NewDorisStorageQuerySet(db).
+				Select(DorisStorageDBSchema.TableID, DorisStorageDBSchema.BkbaseTableID, DorisStorageDBSchema.StorageClusterID).
+				TableIDEq(dorisStorage.OriginTableId).
+				One(&originDorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query origin doris storage for table_id->[%s], origin_table_id->[%s], error: %v", tableID, dorisStorage.OriginTableId, err)
+				return nil, err
+			}
+			if dorisStorage.BkbaseTableID == "" {
+				dorisStorage.BkbaseTableID = originDorisStorage.BkbaseTableID
+			}
+			if dorisStorage.StorageClusterID == 0 {
+				dorisStorage.StorageClusterID = originDorisStorage.StorageClusterID
+			}
+		}
+		if dorisStorage.BkbaseTableID != "" {
+			dorisRoute["db"] = dorisStorage.BkbaseTableID
+			dorisRoute["measurement"] = models.DorisMeasurement
+		}
+	}
+
+	// ES 路由同样补齐 index_set 和默认 measurement，支持外层是 Doris 时按时间段回查 ES。
+	esRoute := map[string]any{}
+	if hasESRoute && db.HasTable(ESStorage{}) {
+		var esStorage ESStorage
+		if err = NewESStorageQuerySet(db).
+			Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.OriginTableId).
+			TableIDEq(routeTableID).
+			One(&esStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query es storage for table_id->[%s], error: %v", routeTableID, err)
+			return nil, err
+		}
+		if esStorage.IndexSet == "" && routeTableID != tableID {
+			if err = NewESStorageQuerySet(db).
+				Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.OriginTableId).
+				TableIDEq(tableID).
+				One(&esStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query es storage for table_id->[%s], error: %v", tableID, err)
+				return nil, err
+			}
+		}
+		if esStorage.IndexSet == "" && esStorage.OriginTableId != "" {
+			var originESStorage ESStorage
+			if err = NewESStorageQuerySet(db).
+				Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet).
+				TableIDEq(esStorage.OriginTableId).
+				One(&originESStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
+				logger.Errorf("compose_table_id_storage_cluster_records: failed to query origin es storage for table_id->[%s], origin_table_id->[%s], error: %v", tableID, esStorage.OriginTableId, err)
+				return nil, err
+			}
+			if esStorage.IndexSet == "" {
+				esStorage.IndexSet = originESStorage.IndexSet
+			}
+		}
+		if esStorage.IndexSet != "" {
+			esRoute["db"] = esStorage.IndexSet
+			esRoute["measurement"] = models.TSGroupDefaultMeasurement
+		}
+	}
+
 	// 组装结果集
 	result := make([]map[string]any, 0)
 	for _, record := range records {
@@ -86,11 +203,31 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string) ([]map[str
 			enableTimestamp = record.EnableTime.Unix()
 		}
 
-		// 追加到结果集合
-		result = append(result, map[string]any{
+		route := map[string]any{
 			"storage_id":  record.ClusterID,
 			"enable_time": enableTimestamp,
-		})
+		}
+		if clusterInfo, ok := clusterInfoMap[uint(record.ClusterID)]; ok {
+			storageType := clusterInfo.ClusterType
+			if storageType == models.StorageTypeDoris {
+				// metadata_clusterinfo 中 Doris 的 cluster_type 是 doris，UQ 查询侧使用 bk_sql。
+				storageType = models.StorageTypeBkSql
+				for k, v := range dorisRoute {
+					route[k] = v
+				}
+				// Doris 分段路由必须携带命中的集群名，否则 BKBase query_sync 无法按 segment 切换 properties.cluster_name。
+				route["storage_name"] = clusterInfo.ClusterName
+				route["cluster_name"] = clusterInfo.ClusterName
+			} else if storageType == models.StorageTypeES {
+				for k, v := range esRoute {
+					route[k] = v
+				}
+			}
+			route["storage_type"] = storageType
+		}
+
+		// 追加到结果集合
+		result = append(result, route)
 	}
 
 	logger.Infof("compose_table_id_storage_cluster_records: get storage cluster records for table_id->[%s] success, records->[%v]", tableID, result)

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
@@ -22,6 +22,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/common"
 	cfg "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/config"
@@ -879,6 +880,7 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 		storage.DorisStorageDBSchema.TableID,
 		storage.DorisStorageDBSchema.BkbaseTableID,
 		storage.DorisStorageDBSchema.OriginTableId,
+		storage.DorisStorageDBSchema.StorageClusterID,
 	)
 
 	// 如果过滤结果表存在，则添加过滤条件
@@ -909,20 +911,37 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 		return err
 	}
 
-	originTableIdSet := make(map[string]struct{})
-	for _, doris := range dorisStorageList {
+	originTableIdList := lo.Uniq(lo.FilterMap(dorisStorageList, func(doris storage.DorisStorage, _ int) (string, bool) {
 		if doris.OriginTableId != "" {
-			originTableIdSet[doris.OriginTableId] = struct{}{}
+			return doris.OriginTableId, true
 		}
-	}
-	originTableIdList := make([]string, 0, len(originTableIdSet))
-	for tableId := range originTableIdSet {
-		originTableIdList = append(originTableIdList, tableId)
-	}
+		return "", false
+	}))
 	originDorisMap, err := s.getDorisStorageMap(originTableIdList)
 	if err != nil {
 		logger.Errorf("PushDorisTableIdDetail: failed to get origin doris storage map, error: %s", err)
 		return err
+	}
+
+	storageClusterIDList := lo.Uniq(lo.FilterMap(append(dorisStorageList, lo.Values(originDorisMap)...), func(doris storage.DorisStorage, _ int) (uint, bool) {
+		if doris.StorageClusterID != 0 {
+			return doris.StorageClusterID, true
+		}
+		return 0, false
+	}))
+	storageClusterNameMap := make(map[uint]string, len(storageClusterIDList))
+	if len(storageClusterIDList) > 0 {
+		var storageClusterList []storage.ClusterInfo
+		if err = storage.NewClusterInfoQuerySet(db).
+			Select(storage.ClusterInfoDBSchema.ClusterID, storage.ClusterInfoDBSchema.ClusterName).
+			ClusterIDIn(storageClusterIDList...).
+			All(&storageClusterList); err != nil {
+			logger.Errorf("PushDorisTableIdDetail: failed to get doris cluster info map, error: %s", err)
+			return err
+		}
+		for _, cluster := range storageClusterList {
+			storageClusterNameMap[cluster.ClusterID] = cluster.ClusterName
+		}
 	}
 
 	// 获取查询别名映射关系
@@ -955,7 +974,17 @@ func (s *SpacePusher) PushDorisTableIdDetail(tableIdList []string, isPublish boo
 				fieldAliasSettings = fieldAliasMap[tableId]
 			}
 
-			composedTableId, detailStr, err := s.composeDorisTableIdDetail(doris, rtMetaMap[tableId], originDorisMap, fieldAliasSettings)
+			realTableId := tableId
+			if doris.OriginTableId != "" {
+				realTableId = doris.OriginTableId
+			}
+			clusterRecords, err := storage.ComposeTableIDStorageClusterRecords(db, realTableId, tableId)
+			if err != nil {
+				logger.Errorf("PushDorisTableIdDetail:failed to get storage cluster records, table_id: %s, real_table_id: %s, error: %s", tableId, realTableId, err)
+				return
+			}
+
+			composedTableId, detailStr, err := s.composeDorisTableIdDetail(doris, rtMetaMap[tableId], originDorisMap, storageClusterNameMap, clusterRecords, fieldAliasSettings)
 			if err != nil {
 				logger.Errorf("PushDorisTableIdDetail:compose doris table id detail error, table_id: %s, error: %s", tableId, err)
 				return
@@ -1117,6 +1146,7 @@ func (s *SpacePusher) getDorisStorageMap(tableIDList []string) (map[string]stora
 			storage.DorisStorageDBSchema.TableID,
 			storage.DorisStorageDBSchema.BkbaseTableID,
 			storage.DorisStorageDBSchema.OriginTableId,
+			storage.DorisStorageDBSchema.StorageClusterID,
 		).TableIDIn(chunkTableIDList...).All(&dorisStorageList); err != nil {
 			return nil, err
 		}
@@ -1278,7 +1308,7 @@ func (s *SpacePusher) composeEsTableIdDetail(tableId string, options map[string]
 		realTableId = storageIns.OriginTableId
 	}
 
-	clusterRecords, err := storage.ComposeTableIDStorageClusterRecords(db, realTableId)
+	clusterRecords, err := storage.ComposeTableIDStorageClusterRecords(db, realTableId, tableId)
 	if err != nil {
 		logger.Errorf("composeEsTableIdDetail: failed to get storage cluster records for table_id [%s], error: %v", realTableId, err)
 		return "", "", err
@@ -1331,12 +1361,16 @@ func (s *SpacePusher) composeEsTableIdDetail(tableId string, options map[string]
 	return tableId, detailStr, err
 }
 
-func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMeta resultTableDetailMeta, originDorisMap map[string]storage.DorisStorage, fieldAliasSettings map[string]string) (string, string, error) {
+func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMeta resultTableDetailMeta, originDorisMap map[string]storage.DorisStorage, storageClusterNameMap map[uint]string, clusterRecords []map[string]any, fieldAliasSettings map[string]string) (string, string, error) {
 	tableId := doris.TableID
 	bkbaseTableId := doris.BkbaseTableID
+	storageClusterID := doris.StorageClusterID
 	if bkbaseTableId == "" && doris.OriginTableId != "" {
 		if originDoris, ok := originDorisMap[doris.OriginTableId]; ok {
 			bkbaseTableId = originDoris.BkbaseTableID
+			if storageClusterID == 0 {
+				storageClusterID = originDoris.StorageClusterID
+			}
 		}
 	}
 	logger.Infof("composeDorisTableIdDetail: table_id [%s], bkbase_table_id [%s], origin_table_id [%s]", tableId, bkbaseTableId, doris.OriginTableId)
@@ -1350,12 +1384,16 @@ func (s *SpacePusher) composeDorisTableIdDetail(doris storage.DorisStorage, rtMe
 
 	// 组装数据
 	detailStr, err := jsonx.MarshalString(map[string]any{
-		"storage_type": models.StorageTypeBkSql,
-		"db":           bkbaseTableId,
-		"measurement":  models.DorisMeasurement,
-		"data_label":   rtMeta.DataLabel,
-		"labels":       rtMeta.Labels,
-		"field_alias":  fieldAliasSettings, // 添加字段别名
+		"storage_type":            models.StorageTypeBkSql,
+		"storage_id":              storageClusterID,
+		"storage_name":            storageClusterNameMap[storageClusterID],
+		"cluster_name":            storageClusterNameMap[storageClusterID],
+		"db":                      bkbaseTableId,
+		"measurement":             models.DorisMeasurement,
+		"storage_cluster_records": clusterRecords,
+		"data_label":              rtMeta.DataLabel,
+		"labels":                  rtMeta.Labels,
+		"field_alias":             fieldAliasSettings, // 添加字段别名
 	})
 	if err != nil {
 		return tableId, "", err

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
@@ -2209,6 +2209,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		resultTableDetailMeta{DataLabel: dataLabel, Labels: normalizeResultTableLabels(tableID1, labels1)},
 		nil,
 		nil,
+		nil,
+		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
 	assert.Equal(t, tableID1, composedTableID, "entity doris detail key should be current table_id")
@@ -2224,6 +2226,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		resultTableDetailMeta{Labels: normalizeResultTableLabels(tableID2, labels2)},
 		nil,
 		nil,
+		nil,
+		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
 	var actualDetail2 map[string]any
@@ -2237,6 +2241,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		map[string]storage.DorisStorage{
 			originTableID: {TableID: originTableID, BkbaseTableID: "bklog_real_doris"},
 		},
+		nil,
+		nil,
 		map[string]string{"pod_name": "__ext.pod_name"},
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
@@ -2256,6 +2262,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 			originTableID: {TableID: originTableID, BkbaseTableID: "bklog_real_doris"},
 		},
 		nil,
+		nil,
+		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")
 	var actualDetail4 map[string]any
@@ -2267,6 +2275,8 @@ func TestSpacePusher_composeDorisTableIdDetail(t *testing.T) {
 		storage.DorisStorage{TableID: tableID4, BkbaseTableID: "bklog_missing_origin_fallback", OriginTableId: "bklog.not_exist"},
 		resultTableDetailMeta{},
 		map[string]storage.DorisStorage{},
+		nil,
+		nil,
 		nil,
 	)
 	assert.NoError(t, err, "composeDorisTableIdDetail should not return an error")


### PR DESCRIPTION
拆分自 #1331。

变更范围：
- bk-monitor-worker 写入 Doris/ES 分段路由所需的 storage_cluster_records 元数据
- Doris result_table_detail 补充 storage_id/storage_name/cluster_name/storage_cluster_records
- 更新 composeDorisTableIdDetail 相关测试
