### PR TITLE
fix: (processbeat) 修复 dataid 覆盖逻辑

### DIFF
--- a/pkg/bkmonitorbeat/configs/processbeat.go
+++ b/pkg/bkmonitorbeat/configs/processbeat.go
@@ -80,14 +80,20 @@ func (c *ProcessbeatConfig) InitIdent() error {
 	// 需要在计算 indent 之前进行 dataid 替换 否则 reload 不会生效
 
 	storage := tenant.DefaultStorage()
-	if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_port"); ok {
-		c.PortDataId = v
+	if c.PortDataId != 0 {
+		if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_port"); ok {
+			c.PortDataId = v
+		}
 	}
-	if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_top"); ok {
-		c.TopDataId = v
+	if c.TopDataId != 0 {
+		if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_top"); ok {
+			c.TopDataId = v
+		}
 	}
-	if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_perf"); ok {
-		c.PerfDataId = v
+	if c.PerfDataId != 0 {
+		if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_perf"); ok {
+			c.PerfDataId = v
+		}
 	}
 
 	return c.initIdent(c)


### PR DESCRIPTION
fix: (processbeat) 修复 dataid 覆盖逻辑

仅在对应 dataid 配置非 0 时，才使用租户任务 dataid 覆盖，避免未启用的数据上报项被错误替换。