### PR TITLE
fix: (unify-query)修复 queryExemplar 提前返回导致的 goroutine 泄漏 --bug=158685591

### DIFF
--- a/pkg/unify-query/service/http/query.go
+++ b/pkg/unify-query/service/http/query.go
@@ -97,6 +97,17 @@ func queryExemplar(ctx context.Context, query *structured.QueryTs) (any, error) 
 		totalTables = influxdb.MergeTables(tableList, false)
 	}()
 
+	tablesChClosed := false
+	closeTablesCh := func() {
+		if tablesChClosed {
+			return
+		}
+		close(tablesCh)
+		<-recvDone
+		tablesChClosed = true
+	}
+	defer closeTablesCh()
+
 	_, err = query.ToQueryReference(ctx)
 	if err != nil {
 		return nil, err
@@ -146,8 +157,7 @@ func queryExemplar(ctx context.Context, query *structured.QueryTs) (any, error) 
 		}
 	}
 
-	close(tablesCh)
-	<-recvDone
+	closeTablesCh()
 
 	tables := &promql.Tables{
 		Tables: make([]*promql.Table, 0, totalTables.Length()),

--- a/pkg/unify-query/service/http/query_test.go
+++ b/pkg/unify-query/service/http/query_test.go
@@ -10,9 +10,11 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -2482,6 +2484,43 @@ func TestQueryExemplar(t *testing.T) {
 	assert.Nil(t, err)
 	actual := string(out)
 	assert.Equal(t, `{"series":[{"name":"_result0","metric_name":"usage","columns":["_value","_time","bk_trace_id","bk_span_id","bk_trace_value","bk_trace_timestamp"],"types":["float","float","string","string","float","float"],"group_keys":[],"group_values":[],"values":[[30,1677081600000000000,"b9cc0e45d58a70b61e8db6fffb5e3376","3d2a373cbeefa1f8",1,1680157900669],[21,1677081660000000000,"fe45f0eccdce3e643a77504f6e6bd87a","c72dcc8fac9bcead",1,1682121442937],[1,1677081720000000000,"771073eb573336a6d3365022a512d6d8","fca46f1c065452e8",1,1682150008969]]}],"is_partial":false}`, actual)
+}
+
+func TestQueryExemplarDirectQueryReturnDoesNotLeakReceiver(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+
+	mock.Init()
+	promql.MockEngine()
+	influxdb.MockSpaceRouter(ctx)
+	metadata.SetUser(ctx, &metadata.User{SpaceUID: influxdb.SpaceUid})
+
+	qts := &structured.QueryTs{
+		SpaceUid: influxdb.SpaceUid,
+		QueryList: []*structured.Query{
+			{
+				TableID:       "system.cpu_detail",
+				FieldName:     "usage",
+				ReferenceName: "a",
+			},
+		},
+		MetricMerge: "a",
+	}
+
+	before := queryExemplarReceiverGoroutines()
+	res, err := queryExemplar(ctx, qts)
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+	assert.True(t, metadata.GetQueryParams(ctx).IsDirectQuery())
+
+	assert.Eventually(t, func() bool {
+		return queryExemplarReceiverGoroutines() == before
+	}, time.Second, 10*time.Millisecond)
+}
+
+func queryExemplarReceiverGoroutines() int {
+	var buf bytes.Buffer
+	_ = pprof.Lookup("goroutine").WriteTo(&buf, 2)
+	return strings.Count(buf.String(), "queryExemplar.func")
 }
 
 func TestVmQueryParams(t *testing.T) {


### PR DESCRIPTION
## 背景

`queryExemplar` 会启动 goroutine 从 `tablesCh` 读取查询结果并合并 `totalTables`。原逻辑只在函数正常执行到末尾时关闭 `tablesCh`，如果中途提前返回，接收 goroutine 会一直阻塞在 channel receive，造成 goroutine 泄漏。

触发提前返回的典型路径包括：

- `ToQueryReference` 解析或路由转换失败
- VM 直查场景不支持 Exemplar，直接返回空响应
- `ToQueryMetric` 转换失败
- Exemplar 查询结果中返回错误

## 修复说明

- 新增统一的 `closeTablesCh` 收口逻辑，负责关闭 `tablesCh` 并等待接收 goroutine 退出。
- 通过 `defer closeTablesCh()` 覆盖所有提前返回路径，避免 goroutine 泄漏。
- 正常路径在读取 `totalTables` 前主动调用 `closeTablesCh()`，确保结果合并完成。
- `closeTablesCh` 内部增加关闭状态判断，避免重复关闭 channel 导致 panic。