### PR TITLE
fix: (unify-query)修复 BKSQL 查询构造中的并发竞态问题 --bug=158697086

### DIFF
--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -478,10 +478,11 @@ func (i *Instance) QueryLabelNames(ctx context.Context, query *metadata.Query, s
 	ctx, span := trace.NewSpan(ctx, "bk-sql-label-name")
 	defer span.End(&err)
 
-	// 取字段名不需要返回数据，但是 size 不能使用 0，所以还是用 1
-	query.Size = 1
+	// 取字段名不需要返回数据，但是 size 不能使用 0，所以还是用 1。这里不能原地修改入参 query，调用方可能复用同一个 *metadata.Query。
+	labelNamesQuery := *query
+	labelNamesQuery.Size = 1
 
-	queryFactory, err := i.InitQueryFactory(ctx, query, start, end)
+	queryFactory, err := i.InitQueryFactory(ctx, &labelNamesQuery, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -576,11 +577,6 @@ func (i *Instance) QuerySeries(ctx context.Context, query *metadata.Query, start
 	ctx, span := trace.NewSpan(ctx, "bk-sql-query-series")
 	defer span.End(&err)
 
-	queryFactory, err := i.InitQueryFactory(ctx, query, start, end)
-	if err != nil {
-		return nil, err
-	}
-
 	if len(query.Source) == 0 {
 		err = fmt.Errorf("no source specified")
 		return nil, err
@@ -609,12 +605,14 @@ func (i *Instance) QuerySeries(ctx context.Context, query *metadata.Query, start
 		return nil, nil
 	}
 
-	// 设置 SelectDistinct 以获取唯一标签组合
-	query.SelectDistinct = labelNames
-	defer func() {
-		query.SelectDistinct = nil
-	}()
+	// 设置 SelectDistinct 以获取唯一标签组合。这里不能原地修改入参 query，调用方可能复用同一个 *metadata.Query。
+	seriesQuery := *query
+	seriesQuery.SelectDistinct = append([]string(nil), labelNames...)
 
+	queryFactory, err := i.InitQueryFactory(ctx, &seriesQuery, start, end)
+	if err != nil {
+		return nil, err
+	}
 	distinctSQL, err := queryFactory.SQL()
 	if err != nil {
 		return nil, err

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -528,12 +528,13 @@ func (i *Instance) QueryLabelValues(ctx context.Context, query *metadata.Query, 
 		return nil, fmt.Errorf("not support metric query with %s", name)
 	}
 
-	queryFactory, err := i.InitQueryFactory(ctx, query, start, end)
+	labelValuesQuery := *query
+	labelValuesQuery.SelectDistinct = []string{name}
+
+	queryFactory, err := i.InitQueryFactory(ctx, &labelValuesQuery, start, end)
 	if err != nil {
 		return nil, err
 	}
-
-	query.SelectDistinct = []string{name}
 
 	sql, err := queryFactory.SQL()
 	if err != nil {

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -409,15 +409,16 @@ func (i *Instance) QuerySeriesSet(ctx context.Context, query *metadata.Query, st
 	rangeLeftTime := end.Sub(start)
 	metric.TsDBRequestRangeMinute(ctx, rangeLeftTime, i.InstanceType())
 
-	// series 计算需要按照时间排序
-	query.Orders = append(metadata.Orders{
+	// series 计算需要按照时间排序。这里不能原地修改入参 query，调用方可能在多路查询中复用同一个 *metadata.Query。
+	seriesQuery := *query
+	seriesQuery.Orders = append(metadata.Orders{
 		{
 			Name: sql_expr.FieldTime,
 			Ast:  true,
 		},
-	}, query.Orders...)
+	}, append(metadata.Orders(nil), query.Orders...)...)
 
-	queryFactory, err := i.InitQueryFactory(ctx, query, start, end)
+	queryFactory, err := i.InitQueryFactory(ctx, &seriesQuery, start, end)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/unify-query/tsdb/bksql/instance_test.go
+++ b/pkg/unify-query/tsdb/bksql/instance_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -2441,6 +2442,42 @@ func TestInstance_QueryLabelValues_Normal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQueryLabelValuesConcurrentSharedQueryRace(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+	instance := createTestInstance(ctx)
+
+	end := time.Unix(1740553771, 0)
+	start := time.Unix(1740551971, 0)
+
+	mock.BkSQL.Set(map[string]any{
+		"SHOW CREATE TABLE `race_bklog`.doris": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int"},{"Field":"dteventtimestamp","Type":"bigint"},{"Field":"dteventtime","Type":"varchar(32)"},{"Field":"path","Type":"varchar(128)"},{"Field":"serverip","Type":"varchar(128)"}]}}`,
+		"SELECT DISTINCT `path` FROM `race_bklog`.doris WHERE `dtEventTimeStamp` >= 1740551971000 AND `dtEventTimeStamp` <= 1740553771000 AND `dtEventTime` >= '2025-02-26 14:39:31' AND `dtEventTime` <= '2025-02-26 15:09:32' AND `thedate` = '20250226' LIMIT 2":     `{"result":true,"message":"成功","code":"00","data":{"totalRecords":1,"list":[{"path":"/tmp/app.log"}]}}`,
+		"SELECT DISTINCT `serverip` FROM `race_bklog`.doris WHERE `dtEventTimeStamp` >= 1740551971000 AND `dtEventTimeStamp` <= 1740553771000 AND `dtEventTime` >= '2025-02-26 14:39:31' AND `dtEventTime` <= '2025-02-26 15:09:32' AND `thedate` = '20250226' LIMIT 2": `{"result":true,"message":"成功","code":"00","data":{"totalRecords":1,"list":[{"serverip":"127.0.0.1"}]}}`,
+	})
+
+	query := &metadata.Query{
+		DB:          "race_bklog",
+		Measurement: "doris",
+		Size:        2,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		for _, key := range []string{"path", "serverip"} {
+			wg.Add(1)
+			go func(key string) {
+				defer wg.Done()
+				values, err := instance.QueryLabelValues(metadata.InitHashID(context.Background()), query, key, start, end)
+				assert.NoError(t, err)
+				assert.NotEmpty(t, values)
+			}(key)
+		}
+	}
+	wg.Wait()
+
+	assert.Empty(t, query.SelectDistinct)
 }
 
 // 创建测试用Instance

--- a/pkg/unify-query/tsdb/bksql/sql_expr/base.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/base.go
@@ -327,18 +327,19 @@ func (d *DefaultSQLExpr) buildCondition(c metadata.ConditionField) (string, erro
 		return "", err
 	}
 
-	// 对值进行转义处理
+	// 对值进行转义处理。不要改写 c.Value，它可能与上游 Query 被多个并发路由共享。
+	values := make([]string, len(c.Value))
 	for i, v := range c.Value {
-		c.Value[i] = d.valueTransform(v)
+		values[i] = d.valueTransform(v)
 	}
 
 	// 根据操作符类型生成不同的SQL表达式
 	switch c.Operator {
 	// 处理等于类操作符（=, IN, LIKE）
 	case metadata.ConditionEqual, metadata.ConditionExact, metadata.ConditionContains:
-		if len(c.Value) > 1 && !c.IsWildcard {
+		if len(values) > 1 && !c.IsWildcard {
 			op = "IN"
-			val = fmt.Sprintf("('%s')", strings.Join(c.Value, "', '"))
+			val = fmt.Sprintf("('%s')", strings.Join(values, "', '"))
 		} else {
 			var format string
 			if c.IsWildcard {
@@ -350,7 +351,7 @@ func (d *DefaultSQLExpr) buildCondition(c metadata.ConditionField) (string, erro
 			}
 
 			var filter []string
-			for _, v := range c.Value {
+			for _, v := range values {
 				filter = append(filter, fmt.Sprintf("%s %s %s", key, op, fmt.Sprintf(format, v)))
 			}
 			key = ""
@@ -362,9 +363,9 @@ func (d *DefaultSQLExpr) buildCondition(c metadata.ConditionField) (string, erro
 		}
 	// 处理不等于类操作符（!=, NOT IN, NOT LIKE）
 	case metadata.ConditionNotEqual, metadata.ConditionNotContains:
-		if len(c.Value) > 1 && !c.IsWildcard {
+		if len(values) > 1 && !c.IsWildcard {
 			op = "NOT IN"
-			val = fmt.Sprintf("('%s')", strings.Join(c.Value, "', '"))
+			val = fmt.Sprintf("('%s')", strings.Join(values, "', '"))
 		} else {
 			var format string
 			if c.IsWildcard {
@@ -376,7 +377,7 @@ func (d *DefaultSQLExpr) buildCondition(c metadata.ConditionField) (string, erro
 			}
 
 			var filter []string
-			for _, v := range c.Value {
+			for _, v := range values {
 				filter = append(filter, fmt.Sprintf("%s %s %s", key, op, fmt.Sprintf(format, v)))
 			}
 			key = ""
@@ -392,48 +393,48 @@ func (d *DefaultSQLExpr) buildCondition(c metadata.ConditionField) (string, erro
 	// - 其他数据库使用 REGEXP 操作符
 	case metadata.ConditionRegEqual:
 		if d.key == HDFS {
-			pattern := strings.Join(c.Value, "|")
+			pattern := strings.Join(values, "|")
 			val = fmt.Sprintf("regexp_like(CAST(%s AS VARCHAR), '%s')", key, pattern)
 			key = ""
 		} else {
 			op = "REGEXP"
-			val = fmt.Sprintf("'%s'", strings.Join(c.Value, "|"))
+			val = fmt.Sprintf("'%s'", strings.Join(values, "|"))
 		}
 	case metadata.ConditionNotRegEqual:
 		if d.key == HDFS {
-			pattern := strings.Join(c.Value, "|")
+			pattern := strings.Join(values, "|")
 			val = fmt.Sprintf("NOT regexp_like(CAST(%s AS VARCHAR), '%s')", key, pattern)
 			key = ""
 		} else {
 			op = "NOT REGEXP"
-			val = fmt.Sprintf("'%s'", strings.Join(c.Value, "|"))
+			val = fmt.Sprintf("'%s'", strings.Join(values, "|"))
 		}
 
 	// 处理数值比较操作符（>, >=, <, <=）
 	case metadata.ConditionGt:
 		op = ">"
-		if len(c.Value) != 1 {
+		if len(values) != 1 {
 			return "", fmt.Errorf("operator %s only support 1 value", op)
 		}
-		val = c.Value[0]
+		val = values[0]
 	case metadata.ConditionGte:
 		op = ">="
-		if len(c.Value) != 1 {
+		if len(values) != 1 {
 			return "", fmt.Errorf("operator %s only support 1 value", op)
 		}
-		val = c.Value[0]
+		val = values[0]
 	case metadata.ConditionLt:
 		op = "<"
-		if len(c.Value) != 1 {
+		if len(values) != 1 {
 			return "", fmt.Errorf("operator %s only support 1 value", op)
 		}
-		val = c.Value[0]
+		val = values[0]
 	case metadata.ConditionLte:
 		op = "<="
-		if len(c.Value) != 1 {
+		if len(values) != 1 {
 			return "", fmt.Errorf("operator %s only support 1 value", op)
 		}
-		val = c.Value[0]
+		val = values[0]
 	default:
 		return "", fmt.Errorf("unknown operator %s", c.Operator)
 	}

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -354,21 +354,22 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 	oldKey = c.DimensionName
 	key, _ = d.dimTransform(oldKey)
 
-	// 对值进行转义处理
+	// 对值进行转义处理。不要改写 c.Value，它可能与上游 Query 被多个并发路由共享。
+	values := make([]string, len(c.Value))
 	for i, v := range c.Value {
-		c.Value[i] = d.valueTransform(v)
+		values[i] = d.valueTransform(v)
 	}
 
 	// doris 里面 array<int> 类型需要特殊处理
 	checkArrayIntByOp := func(o string) (string, string, error) {
-		if len(c.Value) != 1 {
+		if len(values) != 1 {
 			return "", "", fmt.Errorf("operator %s only support 1 value", o)
 		}
 		if d.isArray(c.DimensionName) {
-			val = fmt.Sprintf("ARRAY_MATCH_ANY(x -> x %s %s, %s)", o, c.Value[0], key)
+			val = fmt.Sprintf("ARRAY_MATCH_ANY(x -> x %s %s, %s)", o, values[0], key)
 			key = ""
 		} else {
-			val = c.Value[0]
+			val = values[0]
 		}
 		return key, val, nil
 	}
@@ -376,10 +377,10 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 	// doris 里面 array<string> 类型需要特殊处理
 	checkArrayStringByOp := func(op string) (string, string) {
 		if d.isArray(c.DimensionName) {
-			val = fmt.Sprintf("ARRAY_MATCH_ANY(x -> x %s '%s', %s)", op, strings.Join(c.Value, "|"), key)
+			val = fmt.Sprintf("ARRAY_MATCH_ANY(x -> x %s '%s', %s)", op, strings.Join(values, "|"), key)
 			key = ""
 		} else {
-			val = fmt.Sprintf("'%s'", strings.Join(c.Value, "|")) // 多个值用|连接
+			val = fmt.Sprintf("'%s'", strings.Join(values, "|")) // 多个值用|连接
 		}
 		return key, val
 	}
@@ -392,19 +393,19 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 		op = "IS NULL"
 	// 处理等于类操作符（=, IN, LIKE）
 	case metadata.ConditionEqual, metadata.ConditionExact, metadata.ConditionContains:
-		if len(c.Value) == 1 && c.Value[0] == "" {
+		if len(values) == 1 && values[0] == "" {
 			op = "IS NULL"
 			break
 		}
 
-		if len(c.Value) > 1 && !c.IsWildcard && !d.isAnalyzed(c.DimensionName) && !d.isArray(c.DimensionName) && c.Operator != metadata.ConditionContains {
+		if len(values) > 1 && !c.IsWildcard && !d.isAnalyzed(c.DimensionName) && !d.isArray(c.DimensionName) && c.Operator != metadata.ConditionContains {
 			op = "IN"
-			val = fmt.Sprintf("('%s')", strings.Join(c.Value, "', '"))
+			val = fmt.Sprintf("('%s')", strings.Join(values, "', '"))
 			break
 		}
 
 		if d.isArray(c.DimensionName) {
-			for _, v := range c.Value {
+			for _, v := range values {
 				var value string
 				if c.IsWildcard {
 					value = fmt.Sprintf("ARRAY_MATCH_ANY(x -> x LIKE '%s', %s)", d.likeValue(v), key)
@@ -430,7 +431,7 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 				op = "="
 			}
 
-			for _, v := range c.Value {
+			for _, v := range values {
 				if c.IsWildcard {
 					v = d.likeValue(v)
 				} else if key == metadata.Null {
@@ -446,26 +447,26 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 		}
 
 		key = ""
-	if len(filter) == 1 {
-		val = filter[0]
-	} else {
-		val = fmt.Sprintf("(%s)", strings.Join(filter, " OR "))
-	}
+		if len(filter) == 1 {
+			val = filter[0]
+		} else {
+			val = fmt.Sprintf("(%s)", strings.Join(filter, " OR "))
+		}
 	// 处理不等于类操作符（!=, NOT IN, NOT LIKE）
 	case metadata.ConditionNotEqual, metadata.ConditionNotContains:
-		if len(c.Value) == 1 && c.Value[0] == "" {
+		if len(values) == 1 && values[0] == "" {
 			op = "IS NOT NULL"
 			break
 		}
 
-		if len(c.Value) > 1 && !c.IsWildcard && !d.isAnalyzed(c.DimensionName) && !d.isArray(c.DimensionName) && c.Operator != metadata.ConditionNotContains {
+		if len(values) > 1 && !c.IsWildcard && !d.isAnalyzed(c.DimensionName) && !d.isArray(c.DimensionName) && c.Operator != metadata.ConditionNotContains {
 			op = "NOT IN"
-			val = fmt.Sprintf("('%s')", strings.Join(c.Value, "', '"))
+			val = fmt.Sprintf("('%s')", strings.Join(values, "', '"))
 			break
 		}
 
 		if d.isArray(c.DimensionName) {
-			for _, v := range c.Value {
+			for _, v := range values {
 				var value string
 				if c.IsWildcard {
 					value = fmt.Sprintf("ARRAY_MATCH_ANY(x -> x NOT LIKE '%%%s%%', %s)", v, key)
@@ -491,7 +492,7 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 				op = "!="
 			}
 
-			for _, v := range c.Value {
+			for _, v := range values {
 				if c.IsWildcard {
 					v = d.likeValue(v)
 				}
@@ -500,11 +501,11 @@ func (d *DorisSQLExpr) buildCondition(c metadata.ConditionField) (string, error)
 		}
 
 		key = ""
-	if len(filter) == 1 {
-		val = filter[0]
-	} else {
-		val = fmt.Sprintf("(%s)", strings.Join(filter, " AND "))
-	}
+		if len(filter) == 1 {
+			val = filter[0]
+		} else {
+			val = fmt.Sprintf("(%s)", strings.Join(filter, " AND "))
+		}
 	// 处理正则表达式匹配
 	case metadata.ConditionRegEqual:
 		op = "REGEXP"


### PR DESCRIPTION
## 背景

线上 `unify-query` 在处理 `/query/ts` 的 BKSQL 查询时出现过进程崩溃，Pod 随后重启。通过容器前一次日志和 race 复现测试定位到，BKSQL 查询构造链路中存在共享 `*metadata.Query` 被并发写入的问题。

`metadata.Query` 来自 `QueryReference`，同一个 query 指针可能被多个查询 goroutine 复用。下游 BKSQL 查询入口如果为了本次 SQL 构造临时补充 `Orders`、`Size`、`SelectDistinct` 等字段，就会和其他并发查询产生读写竞态，也可能污染后续复用该 query 的查询语义。

已确认的问题包括：

- `QuerySeriesSet` 原地修改 `query.Orders`。
- `QueryLabelValues` 原地修改 `query.SelectDistinct`。
- `QueryLabelNames` 原地修改 `query.Size`。
- `QuerySeries` 原地修改 `query.SelectDistinct`，并在 defer 中置回 nil。
- `DefaultSQLExpr.buildCondition` 和 `DorisSQLExpr.buildCondition` 原地改写 `ConditionField.Value`。虽然 `ConditionField` 是值传递，但 `Value` 是 slice，修改元素仍会写入共享底层数组。

## 修复内容

- `QuerySeriesSet` 不再直接修改入参 `query.Orders`，改为复制 `metadata.Query` 后在本地副本上追加 `_time` 排序。
- `QueryLabelValues` 不再直接修改入参 `query.SelectDistinct`，改为复制 query 后在副本上设置当前 label name。
- `QueryLabelNames` 不再直接修改入参 `query.Size`，改为复制 query 后在副本上设置 `Size = 1`。
- `QuerySeries` 不再直接修改入参 `query.SelectDistinct`，也不再通过 defer 恢复原 query；改为复制 query 后在副本上设置 `SelectDistinct`，并基于副本创建 `QueryFactory`。
- `DefaultSQLExpr.buildCondition` 和 `DorisSQLExpr.buildCondition` 不再原地改写 `ConditionField.Value`，改为使用局部 `values` 完成转义和 SQL 拼接。
- 新增共享 query 并发调用 `QueryLabelValues` 的 race 回归测试，验证原始 query 不被污染。