### PR TITLE
fix: (unify-query)稳定 relation path 排序

### DIFF
--- a/pkg/unify-query/cmdb/v1beta1/v1beta1.go
+++ b/pkg/unify-query/cmdb/v1beta1/v1beta1.go
@@ -319,7 +319,10 @@ func (r *model) getPaths(ctx context.Context, source, target cmdb.Resource, path
 	}
 	// 从最短路径开始验证
 	sort.SliceStable(allGraphPaths, func(i, j int) bool {
-		return len(allGraphPaths[i]) < len(allGraphPaths[j])
+		if len(allGraphPaths[i]) != len(allGraphPaths[j]) {
+			return len(allGraphPaths[i]) < len(allGraphPaths[j])
+		}
+		return fmt.Sprint(allGraphPaths[i]) < fmt.Sprint(allGraphPaths[j])
 	})
 
 	// 兼容原来的节点屏蔽功能，因为没有指定路径，原路径 pod -> node -> system, 最短路径可能会命中：pod -> apm_service_instance -> system，所以需要多路径查询匹配

--- a/pkg/unify-query/cmdb/v1beta1/v1beta1_test.go
+++ b/pkg/unify-query/cmdb/v1beta1/v1beta1_test.go
@@ -402,6 +402,28 @@ func TestModel_GetPath(t *testing.T) {
 	}
 }
 
+func TestModel_GetPathsOrderIsStableForSameLengthPaths(t *testing.T) {
+	mock.Init()
+	ctx := metadata.InitHashID(context.Background())
+
+	orders := make(map[string]struct{})
+	for i := 0; i < 1000; i++ {
+		model, err := newModel(ctx, buildConfigData())
+		require.NoError(t, err)
+
+		paths, err := model.getPaths(ctx, "system", "statefulset", nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, paths)
+
+		orders[strings.Join(paths[0], "->")] = struct{}{}
+		if len(orders) > 1 {
+			break
+		}
+	}
+
+	require.Lenf(t, orders, 1, "same-length paths should have stable ordering, got first paths: %v", orders)
+}
+
 func TestModel_GetResourceMatcher(t *testing.T) {
 	mock.Init()
 	ctx := metadata.InitHashID(context.Background())


### PR DESCRIPTION
## 变更说明
- 为同长度的 relation path 增加确定性的二级排序，避免依赖 `graph.AllPathsBetween` 内部 map 遍历顺序。
- 增加 `system -> statefulset` 场景的回归测试，覆盖同长度 path 顺序漂移问题。

## 问题原因
`getPaths` 原先只按 path 长度排序；当 `graph.AllPathsBetween` 返回多条同长度路径时，路径顺序会受 map 遍历影响。同一个请求在不同 model 构建过程中可能命中不同 relation path，导致后续生成的查询语句不稳定。
