### PR TITLE
fix(operator): 格式化 relation 文件

### DIFF
--- a/pkg/operator/operator/objectsref/relation.go
+++ b/pkg/operator/operator/objectsref/relation.go
@@ -399,17 +399,17 @@ func (oc *ObjectsController) WritePodRelations(w io.Writer) {
 				Labels: labels,
 			})
 
-	case kindStatefulSet, kindGameStatefulSet:
-		labels = append(labels, promfmt.Label{
-			Name:  "statefulset",
-			Value: ownerRef.Name,
-		})
-		promfmt.FmtBytes(w, promfmt.Metric{
-			Name:   relationPodStatefulset,
-			Labels: labels,
-		})
+		case kindStatefulSet, kindGameStatefulSet:
+			labels = append(labels, promfmt.Label{
+				Name:  "statefulset",
+				Value: ownerRef.Name,
+			})
+			promfmt.FmtBytes(w, promfmt.Metric{
+				Name:   relationPodStatefulset,
+				Labels: labels,
+			})
 
-	case kindDaemonSet:
+		case kindDaemonSet:
 			labels = append(labels, promfmt.Label{
 				Name:  "daemonset",
 				Value: ownerRef.Name,

--- a/pkg/operator/operator/objectsref/relation_test.go
+++ b/pkg/operator/operator/objectsref/relation_test.go
@@ -63,9 +63,9 @@ func TestWritePodRelationsWithStatefulSet(t *testing.T) {
 	defer cancel()
 
 	cases := []struct {
-		name       string
-		ownerKind  string
-		setupObjs  func() (*Objects, *Objects) // statefulSetObjs, gameStatefulSetObjs
+		name      string
+		ownerKind string
+		setupObjs func() (*Objects, *Objects) // statefulSetObjs, gameStatefulSetObjs
 	}{
 		{
 			name:      "standard StatefulSet",


### PR DESCRIPTION
## 变更说明

- 使用 gofmt 格式化 operator relation 相关代码。
- 同步修复 relation 测试文件中 gofmt 产生的字段对齐。