### PR TITLE
feat: (unify-query)增加 ES 分片执行状态观测 --story=134822931

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -408,6 +408,7 @@ const (
 type esShardFailureSample struct {
 	Shard  int    `json:"shard"`
 	Index  string `json:"index"`
+	Status string `json:"status,omitempty"`
 	Reason string `json:"reason,omitempty"`
 }
 
@@ -475,6 +476,7 @@ func buildESShardFailureSample(failures []*elastic.ShardOperationFailedException
 		samples = append(samples, esShardFailureSample{
 			Shard:  failure.Shard,
 			Index:  failure.Index,
+			Status: failure.Status,
 			Reason: truncateString(marshalESShardFailureReason(failure.Reason), esShardFailureReasonMaxLength),
 		})
 		if len(samples) >= esShardFailureSampleLimit {

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -436,16 +436,16 @@ func recordESQueryShards(ctx context.Context, span *trace.Span, qo *queryOption,
 
 	failuresCount := countESShardFailures(res.Shards.Failures)
 	span.Set("shards_failures_count", failuresCount)
-	if failuresSample := buildESShardFailureSample(res.Shards.Failures); len(failuresSample) > 0 {
-		if failuresSampleJson, marshalErr := json.Marshal(failuresSample); marshalErr == nil {
-			span.Set("shards_failures_sample", string(failuresSampleJson))
-		}
+	failuresSample := buildESShardFailureSample(res.Shards.Failures)
+	failuresSampleJson := marshalESShardFailureSample(failuresSample)
+	if len(failuresSample) > 0 {
+		span.Set("shards_failures_sample", failuresSampleJson)
 	}
 
 	log.Warnf(
 		ctx,
-		"es query shard abnormal index: %+v, timed_out: %v, shards_total: %d, shards_successful: %d, shards_failed: %d, shards_skipped: %d, failures: %s",
-		esQueryIndexes(qo), res.TimedOut, res.Shards.Total, res.Shards.Successful, res.Shards.Failed, res.Shards.Skipped, marshalESShardFailures(res.Shards.Failures),
+		"es query shard abnormal index: %+v, timed_out: %v, shards_total: %d, shards_successful: %d, shards_failed: %d, shards_skipped: %d, failures_count: %d, failures_sample: %s",
+		esQueryIndexes(qo), res.TimedOut, res.Shards.Total, res.Shards.Successful, res.Shards.Failed, res.Shards.Skipped, failuresCount, failuresSampleJson,
 	)
 }
 
@@ -495,10 +495,10 @@ func marshalESShardFailureReason(reason map[string]interface{}) string {
 	return string(reasonJson)
 }
 
-func marshalESShardFailures(failures []*elastic.ShardOperationFailedException) string {
-	failuresJson, err := json.Marshal(failures)
+func marshalESShardFailureSample(failuresSample []esShardFailureSample) string {
+	failuresJson, err := json.Marshal(failuresSample)
 	if err != nil {
-		return fmt.Sprintf("%+v", failures)
+		return fmt.Sprintf("%+v", failuresSample)
 	}
 	return string(failuresJson)
 }

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -28,6 +28,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/function"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metric"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/query/structured"
@@ -380,6 +381,7 @@ func (i *Instance) esQuery(ctx context.Context, qo *queryOption, fact *FormatFac
 		}
 	}()
 
+	recordESQueryShards(ctx, span, qo, res)
 	if err = handleESError(ctx, qo.conn.Address, err, res); err != nil {
 		return nil, err
 	}
@@ -396,6 +398,120 @@ func (i *Instance) esQuery(ctx context.Context, qo *queryOption, fact *FormatFac
 		ctx, queryCost, metadata.ElasticsearchStorageType, qo.conn.Address,
 	)
 	return res, err
+}
+
+const (
+	esShardFailureSampleLimit     = 3
+	esShardFailureReasonMaxLength = 512
+)
+
+type esShardFailureSample struct {
+	Shard  int    `json:"shard"`
+	Index  string `json:"index"`
+	Reason string `json:"reason,omitempty"`
+}
+
+func recordESQueryShards(ctx context.Context, span *trace.Span, qo *queryOption, res *elastic.SearchResult) {
+	if res == nil {
+		return
+	}
+
+	span.Set("timed_out", res.TimedOut)
+	if res.Shards == nil {
+		if res.TimedOut {
+			span.Set("shards_failures_count", 0)
+			log.Warnf(ctx, "es query shard abnormal index: %+v, timed_out: %v, shards info is nil", esQueryIndexes(qo), res.TimedOut)
+		}
+		return
+	}
+
+	span.Set("shards_total", res.Shards.Total)
+	span.Set("shards_successful", res.Shards.Successful)
+	span.Set("shards_failed", res.Shards.Failed)
+	span.Set("shards_skipped", res.Shards.Skipped)
+
+	if res.Shards.Failed <= 0 && !res.TimedOut {
+		return
+	}
+
+	failuresCount := countESShardFailures(res.Shards.Failures)
+	span.Set("shards_failures_count", failuresCount)
+	if failuresSample := buildESShardFailureSample(res.Shards.Failures); len(failuresSample) > 0 {
+		if failuresSampleJson, marshalErr := json.Marshal(failuresSample); marshalErr == nil {
+			span.Set("shards_failures_sample", string(failuresSampleJson))
+		}
+	}
+
+	log.Warnf(
+		ctx,
+		"es query shard abnormal index: %+v, timed_out: %v, shards_total: %d, shards_successful: %d, shards_failed: %d, shards_skipped: %d, failures: %s",
+		esQueryIndexes(qo), res.TimedOut, res.Shards.Total, res.Shards.Successful, res.Shards.Failed, res.Shards.Skipped, marshalESShardFailures(res.Shards.Failures),
+	)
+}
+
+func esQueryIndexes(qo *queryOption) []string {
+	if qo == nil {
+		return nil
+	}
+	return qo.indexes
+}
+
+func countESShardFailures(failures []*elastic.ShardOperationFailedException) int {
+	count := 0
+	for _, failure := range failures {
+		if failure != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func buildESShardFailureSample(failures []*elastic.ShardOperationFailedException) []esShardFailureSample {
+	samples := make([]esShardFailureSample, 0, esShardFailureSampleLimit)
+	for _, failure := range failures {
+		if failure == nil {
+			continue
+		}
+		samples = append(samples, esShardFailureSample{
+			Shard:  failure.Shard,
+			Index:  failure.Index,
+			Reason: truncateString(marshalESShardFailureReason(failure.Reason), esShardFailureReasonMaxLength),
+		})
+		if len(samples) >= esShardFailureSampleLimit {
+			break
+		}
+	}
+	return samples
+}
+
+func marshalESShardFailureReason(reason map[string]interface{}) string {
+	if len(reason) == 0 {
+		return ""
+	}
+	reasonJson, err := json.Marshal(reason)
+	if err != nil {
+		return fmt.Sprintf("%+v", reason)
+	}
+	return string(reasonJson)
+}
+
+func marshalESShardFailures(failures []*elastic.ShardOperationFailedException) string {
+	failuresJson, err := json.Marshal(failures)
+	if err != nil {
+		return fmt.Sprintf("%+v", failures)
+	}
+	return string(failuresJson)
+}
+
+func truncateString(s string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLength {
+		return s
+	}
+	return string(runes[:maxLength])
 }
 
 func (i *Instance) queryWithAgg(ctx context.Context, qo *queryOption, fact *FormatFactory) storage.SeriesSet {

--- a/pkg/unify-query/tsdb/elasticsearch/instance_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance_test.go
@@ -1564,7 +1564,7 @@ func TestRecordESQueryShards(t *testing.T) {
 				Successful: 1,
 				Failed:     4,
 				Failures: []*elastic.ShardOperationFailedException{
-					{Shard: 1, Index: "index-1", Reason: map[string]interface{}{"type": "illegal_argument_exception", "reason": longReason}},
+					{Shard: 1, Index: "index-1", Status: "INTERNAL_SERVER_ERROR", Reason: map[string]interface{}{"type": "illegal_argument_exception", "reason": longReason}},
 					{Shard: 2, Index: "index-2", Reason: map[string]interface{}{"reason": "second"}},
 					{Shard: 3, Index: "index-3", Reason: map[string]interface{}{"reason": "third"}},
 					{Shard: 4, Index: "index-4", Reason: map[string]interface{}{"reason": "fourth"}},
@@ -1590,6 +1590,7 @@ func TestRecordESQueryShards(t *testing.T) {
 		require.Len(t, failuresSample, esShardFailureSampleLimit)
 		assert.Equal(t, 1, failuresSample[0].Shard)
 		assert.Equal(t, "index-1", failuresSample[0].Index)
+		assert.Equal(t, "INTERNAL_SERVER_ERROR", failuresSample[0].Status)
 		assert.LessOrEqual(t, len([]rune(failuresSample[0].Reason)), esShardFailureReasonMaxLength)
 	})
 

--- a/pkg/unify-query/tsdb/elasticsearch/instance_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance_test.go
@@ -11,14 +11,22 @@ package elasticsearch
 
 import (
 	"context"
+	stdjson "encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/jarcoal/httpmock"
+	elastic "github.com/olivere/elastic/v7"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/function"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/json"
@@ -26,6 +34,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/mock"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/query/structured"
+	uqtrace "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
 )
 
 func TestInstance_getAlias(t *testing.T) {
@@ -1507,4 +1516,178 @@ func TestInstance_QuerySeries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRecordESQueryShards(t *testing.T) {
+	log.InitTestLogger()
+
+	t.Run("records shard counters on healthy response", func(t *testing.T) {
+		rec := setupESTraceRecorder(t)
+		_, span := uqtrace.NewSpan(context.Background(), "test-span")
+
+		recordESQueryShards(context.Background(), span, &queryOption{indexes: []string{"index-1"}}, &elastic.SearchResult{
+			TimedOut: false,
+			Shards: &elastic.ShardsInfo{
+				Total:      4,
+				Successful: 4,
+				Failed:     0,
+				Skipped:    1,
+			},
+		})
+		var err error
+		span.End(&err)
+
+		attrs := endedSpanAttrs(t, rec)
+		timedOut, ok := esSpanAttrBool(attrs, "timed_out")
+		require.True(t, ok)
+		assert.False(t, timedOut)
+		shardsTotal, ok := esSpanAttrInt(attrs, "shards_total")
+		require.True(t, ok)
+		assert.Equal(t, int64(4), shardsTotal)
+		shardsSkipped, ok := esSpanAttrInt(attrs, "shards_skipped")
+		require.True(t, ok)
+		assert.Equal(t, int64(1), shardsSkipped)
+		_, ok = esSpanAttrInt(attrs, "shards_failures_count")
+		assert.False(t, ok)
+		_, ok = esSpanAttrString(attrs, "shards_failures_sample")
+		assert.False(t, ok)
+	})
+
+	t.Run("records bounded failure sample", func(t *testing.T) {
+		rec := setupESTraceRecorder(t)
+		_, span := uqtrace.NewSpan(context.Background(), "test-span")
+		longReason := strings.Repeat("x", esShardFailureReasonMaxLength+64)
+
+		recordESQueryShards(context.Background(), span, &queryOption{indexes: []string{"index-*"}}, &elastic.SearchResult{
+			Shards: &elastic.ShardsInfo{
+				Total:      5,
+				Successful: 1,
+				Failed:     4,
+				Failures: []*elastic.ShardOperationFailedException{
+					{Shard: 1, Index: "index-1", Reason: map[string]interface{}{"type": "illegal_argument_exception", "reason": longReason}},
+					{Shard: 2, Index: "index-2", Reason: map[string]interface{}{"reason": "second"}},
+					{Shard: 3, Index: "index-3", Reason: map[string]interface{}{"reason": "third"}},
+					{Shard: 4, Index: "index-4", Reason: map[string]interface{}{"reason": "fourth"}},
+				},
+			},
+		})
+		var err error
+		span.End(&err)
+
+		attrs := endedSpanAttrs(t, rec)
+		shardsFailed, ok := esSpanAttrInt(attrs, "shards_failed")
+		require.True(t, ok)
+		assert.Equal(t, int64(4), shardsFailed)
+		failuresCount, ok := esSpanAttrInt(attrs, "shards_failures_count")
+		require.True(t, ok)
+		assert.Equal(t, int64(4), failuresCount)
+		failuresSampleJson, ok := esSpanAttrString(attrs, "shards_failures_sample")
+		require.True(t, ok)
+		assert.NotContains(t, failuresSampleJson, "index-4")
+
+		var failuresSample []esShardFailureSample
+		require.NoError(t, stdjson.Unmarshal([]byte(failuresSampleJson), &failuresSample))
+		require.Len(t, failuresSample, esShardFailureSampleLimit)
+		assert.Equal(t, 1, failuresSample[0].Shard)
+		assert.Equal(t, "index-1", failuresSample[0].Index)
+		assert.LessOrEqual(t, len([]rune(failuresSample[0].Reason)), esShardFailureReasonMaxLength)
+	})
+
+	t.Run("records timeout without failures", func(t *testing.T) {
+		rec := setupESTraceRecorder(t)
+		_, span := uqtrace.NewSpan(context.Background(), "test-span")
+
+		recordESQueryShards(context.Background(), span, &queryOption{indexes: []string{"index-1"}}, &elastic.SearchResult{
+			TimedOut: true,
+			Shards: &elastic.ShardsInfo{
+				Total:      2,
+				Successful: 2,
+			},
+		})
+		var err error
+		span.End(&err)
+
+		attrs := endedSpanAttrs(t, rec)
+		timedOut, ok := esSpanAttrBool(attrs, "timed_out")
+		require.True(t, ok)
+		assert.True(t, timedOut)
+		failuresCount, ok := esSpanAttrInt(attrs, "shards_failures_count")
+		require.True(t, ok)
+		assert.Equal(t, int64(0), failuresCount)
+		_, ok = esSpanAttrString(attrs, "shards_failures_sample")
+		assert.False(t, ok)
+	})
+
+	t.Run("handles nil result and nil shards", func(t *testing.T) {
+		rec := setupESTraceRecorder(t)
+		_, span := uqtrace.NewSpan(context.Background(), "test-span")
+		assert.NotPanics(t, func() {
+			recordESQueryShards(context.Background(), span, nil, nil)
+		})
+		var err error
+		span.End(&err)
+		assert.Empty(t, endedSpanAttrs(t, rec))
+
+		rec = setupESTraceRecorder(t)
+		_, span = uqtrace.NewSpan(context.Background(), "test-span")
+		assert.NotPanics(t, func() {
+			recordESQueryShards(context.Background(), span, nil, &elastic.SearchResult{TimedOut: true})
+		})
+		span.End(&err)
+
+		attrs := endedSpanAttrs(t, rec)
+		timedOut, ok := esSpanAttrBool(attrs, "timed_out")
+		require.True(t, ok)
+		assert.True(t, timedOut)
+		failuresCount, ok := esSpanAttrInt(attrs, "shards_failures_count")
+		require.True(t, ok)
+		assert.Equal(t, int64(0), failuresCount)
+	})
+}
+
+func setupESTraceRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	prevTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prevTP)
+	})
+	return rec
+}
+
+func endedSpanAttrs(t *testing.T, rec *tracetest.SpanRecorder) []attribute.KeyValue {
+	t.Helper()
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+	return ended[0].Attributes()
+}
+
+func esSpanAttrBool(attrs []attribute.KeyValue, key string) (bool, bool) {
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			return kv.Value.AsBool(), true
+		}
+	}
+	return false, false
+}
+
+func esSpanAttrInt(attrs []attribute.KeyValue, key string) (int64, bool) {
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			return kv.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+func esSpanAttrString(attrs []attribute.KeyValue, key string) (string, bool) {
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
## 背景
unify-query 的 ES 查询链路中补充 `_shards` 与 `timed_out` 观测信息，用于排查 bklog 聚合查询出现静默退化时，是否由 ES shard failure 或 timeout 导致。

## 主要改动
- 在 `handleESError` 前记录 ES shard 状态，避免失败场景提前返回后漏记诊断信息。
- span 新增 `timed_out`、`shards_total`、`shards_successful`、`shards_failed`、`shards_skipped`。
- 异常路径新增 `shards_failures_count` 与有界 `shards_failures_sample`，sample 最多保留 3 条，每条 reason 做长度截断，控制 trace attribute 高基数和大字段风险。
- `shards_failures_sample` 采集 `Shard`、`Index`、`Status`、`Reason`，便于直接区分单分片失败状态。
- WARN 日志同步打印 shard 计数、`timed_out` 与同一份有界 `failures_sample`；不打印完整 `res.Shards.Failures`，避免失败分片较多或 reason 较长时放大日志体积。
- 补充单元测试覆盖正常响应、shard failure、timeout 和 nil 防御场景。
