### PR TITLE
feat: (unify-query)支持查询ES数据

### DIFF
--- a/pkg/unify-query/cmd/root.go
+++ b/pkg/unify-query/cmd/root.go
@@ -11,6 +11,7 @@ package cmd
 
 import (
 	"context"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/service/es"
 	"os"
 	"os/signal"
 	"syscall"
@@ -59,6 +60,7 @@ var rootCmd = &cobra.Command{
 			&promql.Service{},
 			&http.Service{},
 			&featureFlag.Service{},
+			&es.Service{},
 		}
 		log.Infof(context.TODO(), "http service started.")
 

--- a/pkg/unify-query/es/alias.go
+++ b/pkg/unify-query/es/alias.go
@@ -38,11 +38,26 @@ func AliasExist(tableID string, alias string) bool {
 
 // RefreshAllAlias 并发刷新整个别名map
 func RefreshAllAlias() {
-	// 根据table进行刷新，所以获取的是table的锁
+	type aliasRefreshTarget struct {
+		tableID   string
+		storageID int
+		indexName string
+	}
+
+	// 仅在复制当前表快照时持有读锁，避免慢 ES 请求阻塞配置重载。
 	tableLock.RLock()
-	defer tableLock.RUnlock()
-	wg := new(sync.WaitGroup)
+	targets := make([]aliasRefreshTarget, 0, len(tableMap))
 	for tableID, info := range tableMap {
+		targets = append(targets, aliasRefreshTarget{
+			tableID:   tableID,
+			storageID: info.StorageID,
+			indexName: ConvertTableIDToFuzzyIndexName(tableID),
+		})
+	}
+	tableLock.RUnlock()
+
+	wg := new(sync.WaitGroup)
+	for _, target := range targets {
 		wg.Add(1)
 		go func(tableID string, storageID int, indexName string) {
 			defer wg.Done()
@@ -51,7 +66,7 @@ func RefreshAllAlias() {
 				log.Errorf(context.TODO(), "refresh alias of tableid:%s failed,error:%v", tableID, err)
 				return
 			}
-		}(tableID, info.StorageID, ConvertTableIDToFuzzyIndexName(tableID))
+		}(target.tableID, target.storageID, target.indexName)
 
 	}
 	wg.Wait()

--- a/pkg/unify-query/es/table.go
+++ b/pkg/unify-query/es/table.go
@@ -22,8 +22,8 @@ var tableLock *sync.RWMutex
 
 // ReloadTableInfo
 func ReloadTableInfo(infos map[string]*TableInfo) error {
-	storageLock.Lock()
-	defer storageLock.Unlock()
+	tableLock.Lock()
+	defer tableLock.Unlock()
 
 	tableMap = infos
 	for tableID, info := range infos {


### PR DESCRIPTION
## 背景
在 unify-query 中注册启用 ES 查询服务，使 unify-query 能够接收并处理 ES 数据源的查询请求，为网络设备 Flow 流量数据的检索与分析提供查询能力。
## 变更内容
- 在 unify-query 服务启动链中注册 `es.Service`，启用 ES 查询路由