### PR TITLE
fix: (unify-query)修复 ES 查询入口共享 metadata.Query 副作用风险 --bug=158810371

### DIFF
--- a/pkg/unify-query/metadata/result_table_options.go
+++ b/pkg/unify-query/metadata/result_table_options.go
@@ -26,6 +26,42 @@ type ResultTableOption struct {
 	ResultSchema []map[string]any `json:"result_schema,omitempty"`
 }
 
+func (o *ResultTableOption) Clone() *ResultTableOption {
+	if o == nil {
+		return nil
+	}
+
+	clone := *o
+	if o.From != nil {
+		from := *o.From
+		clone.From = &from
+	}
+	if o.SearchAfter != nil {
+		clone.SearchAfter = make([]any, len(o.SearchAfter))
+		copy(clone.SearchAfter, o.SearchAfter)
+	}
+	if o.FieldType != nil {
+		clone.FieldType = make(map[string]string, len(o.FieldType))
+		for k, v := range o.FieldType {
+			clone.FieldType[k] = v
+		}
+	}
+	if o.ResultSchema != nil {
+		clone.ResultSchema = make([]map[string]any, len(o.ResultSchema))
+		for i, schema := range o.ResultSchema {
+			if schema == nil {
+				continue
+			}
+			clone.ResultSchema[i] = make(map[string]any, len(schema))
+			for k, v := range schema {
+				clone.ResultSchema[i][k] = v
+			}
+		}
+	}
+
+	return &clone
+}
+
 func (o ResultTableOptions) SetOption(tableUUID string, option *ResultTableOption) {
 	if option == nil {
 		return

--- a/pkg/unify-query/metadata/struct.go
+++ b/pkg/unify-query/metadata/struct.go
@@ -560,6 +560,7 @@ func (a Aggregates) Copy() Aggregates {
 			Name:           agg.Name,
 			Field:          agg.Field,
 			Dimensions:     append([]string{}, agg.Dimensions...),
+			Without:        agg.Without,
 			Window:         agg.Window,
 			TimeZone:       agg.TimeZone,
 			TimeZoneOffset: agg.TimeZoneOffset,

--- a/pkg/unify-query/metadata/struct_test.go
+++ b/pkg/unify-query/metadata/struct_test.go
@@ -79,6 +79,65 @@ func TestFieldAlias_AddAliasKeysWhenOriginalFieldPresent(t *testing.T) {
 	})
 }
 
+func TestResultTableOption_Clone(t *testing.T) {
+	t.Parallel()
+
+	from := 3
+	for name, c := range map[string]struct {
+		option *ResultTableOption
+		check  func(t *testing.T, option, clone *ResultTableOption)
+	}{
+		"nil option": {
+			option: nil,
+			check: func(t *testing.T, option, clone *ResultTableOption) {
+				assert.Nil(t, clone)
+			},
+		},
+		"copy pointer slice and maps": {
+			option: &ResultTableOption{
+				From:        &from,
+				ScrollID:    "scroll-id",
+				SearchAfter: []any{int64(1), "next"},
+				SliceIndex:  1,
+				SliceMax:    4,
+				FieldType: map[string]string{
+					"field": "keyword",
+				},
+				SQL: "select * from t",
+				ResultSchema: []map[string]any{
+					{
+						"name": "field",
+						"type": "keyword",
+					},
+					nil,
+				},
+			},
+			check: func(t *testing.T, option, clone *ResultTableOption) {
+				assert.Equal(t, option, clone)
+				assert.NotSame(t, option, clone)
+				assert.NotSame(t, option.From, clone.From)
+
+				*clone.From = 10
+				clone.SearchAfter[0] = int64(2)
+				clone.FieldType["field"] = "text"
+				clone.ResultSchema[0]["type"] = "text"
+
+				assert.Equal(t, 3, *option.From)
+				assert.Equal(t, []any{int64(1), "next"}, option.SearchAfter)
+				assert.Equal(t, map[string]string{"field": "keyword"}, option.FieldType)
+				assert.Equal(t, "keyword", option.ResultSchema[0]["type"])
+				assert.Nil(t, option.ResultSchema[1])
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			clone := c.option.Clone()
+			c.check(t, c.option, clone)
+		})
+	}
+}
+
 func cloneAnyMap(m map[string]any) map[string]any {
 	if m == nil {
 		return nil

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -864,6 +864,23 @@ func TestFormatFactory_RangeQueryAndAggregates(t *testing.T) {
 			},
 			expected: `{"aggregations":{"gseIndex":{"aggregations":{"time":{"aggregations":{"_value":{"value_count":{"field":"value"}}},"date_histogram":{"extended_bounds":{"max":1721046420,"min":1721024820},"field":"time","interval":"1h","min_doc_count":0,"time_zone":"Asia/Shanghai"}}},"terms":{"field":"gseIndex","missing":" "}}},"query":{"range":{"time":{"format":"epoch_second","from":1721024820,"include_lower":true,"include_upper":true,"to":1721046420}}}}`,
 		},
+		"aggregate copy preserves without with window": {
+			timeField: metadata.TimeField{
+				Name: "time",
+				Type: TimeFieldTypeTime,
+				Unit: function.Second,
+			},
+			aggregates: metadata.Aggregates{
+				{
+					Name:       "count",
+					Dimensions: []string{"gseIndex"},
+					Without:    true,
+					Window:     time.Hour,
+					TimeZone:   "Asia/Shanghai",
+				},
+			}.Copy(),
+			expected: `{"aggregations":{"gseIndex":{"aggregations":{"_value":{"value_count":{"field":"value"}}},"terms":{"field":"gseIndex","missing":" "}}},"query":{"range":{"time":{"format":"epoch_second","from":1721024820,"include_lower":true,"include_upper":true,"to":1721046420}}}}`,
+		},
 		"aggregate 1h2m": {
 			timeField: metadata.TimeField{
 				Name: "time",

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -88,6 +88,25 @@ type queryOption struct {
 	query *metadata.Query
 }
 
+func cloneAllConditions(conditions metadata.AllConditions) metadata.AllConditions {
+	if conditions == nil {
+		return nil
+	}
+
+	clone := make(metadata.AllConditions, len(conditions))
+	for i, group := range conditions {
+		clone[i] = make([]metadata.ConditionField, len(group))
+		for j, condition := range group {
+			clone[i][j] = condition
+			if condition.Value != nil {
+				clone[i][j].Value = append([]string{}, condition.Value...)
+			}
+		}
+	}
+
+	return clone
+}
+
 func NewInstance(ctx context.Context, opt *InstanceOption) (*Instance, error) {
 	ins := &Instance{
 		ctx:     ctx,
@@ -580,7 +599,10 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 		return size, total, option, err
 	}
 
-	aliases, err := i.getAlias(ctx, query, start, end)
+	rawQuery := *query
+	rawQuery.ResultTableOption = query.ResultTableOption.Clone()
+
+	aliases, err := i.getAlias(ctx, &rawQuery, start, end)
 	if err != nil {
 		return size, total, option, err
 	}
@@ -592,11 +614,11 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 		indexes: aliases,
 		start:   start,
 		end:     end,
-		query:   query,
+		query:   &rawQuery,
 		conn:    i.connect,
 	}
 
-	fieldMap, err := i.fieldMap(ctx, query.FieldAlias, aliases...)
+	fieldMap, err := i.fieldMap(ctx, rawQuery.FieldAlias, aliases...)
 	if err != nil {
 		return size, total, option, metadata.NewMessage(
 			metadata.MsgQueryES,
@@ -606,20 +628,20 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 	}
 	span.Set("field-map-length", len(fieldMap))
 
-	if i.maxSize > 0 && query.Size > i.maxSize {
-		query.Size = i.maxSize
+	if i.maxSize > 0 && rawQuery.Size > i.maxSize {
+		rawQuery.Size = i.maxSize
 	}
 
-	option = query.ResultTableOption
+	option = rawQuery.ResultTableOption
 	if option != nil {
 		if option.From != nil {
-			query.From = *option.From
+			rawQuery.From = *option.From
 		}
 	}
 
-	labelMap := function.LabelMap(ctx, query)
-	reverseAlias := make(map[string]string, len(query.FieldAlias))
-	for k, v := range query.FieldAlias {
+	labelMap := function.LabelMap(ctx, &rawQuery)
+	reverseAlias := make(map[string]string, len(rawQuery.FieldAlias))
+	for k, v := range rawQuery.FieldAlias {
 		reverseAlias[v] = k
 	}
 
@@ -642,16 +664,16 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 			ns := s
 
 			// 别名替换
-			if alias, ok := query.FieldAlias[s]; ok {
+			if alias, ok := rawQuery.FieldAlias[s]; ok {
 				ns = alias
 			}
 			return ns
 		},
 		).
 		WithIsReference(metadata.GetQueryParams(ctx).IsReference).
-		WithQuery(query.Field, query.TimeField, qo.start, qo.end, unit, query.Size).
+		WithQuery(rawQuery.Field, rawQuery.TimeField, qo.start, qo.end, unit, rawQuery.Size).
 		WithFieldMap(fieldMap).
-		WithOrders(query.Orders).
+		WithOrders(rawQuery.Orders).
 		WithIncludeValues(labelMap)
 
 	sr, err := i.esQuery(ctx, qo, fact)
@@ -662,9 +684,10 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 		).Error(ctx, err)
 	}
 
+	from := rawQuery.From
 	option = &metadata.ResultTableOption{
 		FieldType: fact.FieldType(),
-		From:      &query.From,
+		From:      &from,
 	}
 
 	if sr != nil {
@@ -682,11 +705,11 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 				fact.SetData(data)
 
 				// 注入别名：命中原始字段 key 后补写别名字段 key（与 bksql 语义保持一致）
-				query.FieldAlias.AddAliasKeysWhenOriginalFieldPresent(fact.data)
+				rawQuery.FieldAlias.AddAliasKeysWhenOriginalFieldPresent(fact.data)
 
 				fact.data[metadata.KeyDocID] = d.Id
 				fact.data[metadata.KeyIndex] = d.Index
-				query.DataReload(fact.data)
+				rawQuery.DataReload(fact.data)
 
 				if timeValue, ok := data[fact.GetTimeField().Name]; ok {
 					fact.data[FieldTime] = timeValue
@@ -705,9 +728,9 @@ func (i *Instance) QueryRawData(ctx context.Context, query *metadata.Query, star
 			size = int64(len(sr.Hits.Hits))
 		}
 
-		if query.Scroll != "" {
+		if rawQuery.Scroll != "" {
 			var originalOption *metadata.ResultTableOption
-			originalOption = query.ResultTableOption
+			originalOption = rawQuery.ResultTableOption
 
 			option.ScrollID = sr.ScrollId
 
@@ -881,7 +904,11 @@ func (i *Instance) QueryLabelValues(ctx context.Context, query *metadata.Query, 
 	ctx, span := trace.NewSpan(ctx, "elasticsearch-query-label-values")
 	defer span.End(&err)
 
-	aliases, err := i.getAlias(ctx, query, start, end)
+	labelValuesQuery := *query
+	labelValuesQuery.AllConditions = cloneAllConditions(query.AllConditions)
+	labelValuesQuery.Aggregates = query.Aggregates.Copy()
+
+	aliases, err := i.getAlias(ctx, &labelValuesQuery, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -890,22 +917,22 @@ func (i *Instance) QueryLabelValues(ctx context.Context, query *metadata.Query, 
 		indexes: aliases,
 		start:   start,
 		end:     end,
-		query:   query,
+		query:   &labelValuesQuery,
 		conn:    i.connect,
 	}
 
-	fieldMap, err := i.QueryFieldMap(ctx, query, start, end)
+	fieldMap, err := i.QueryFieldMap(ctx, &labelValuesQuery, start, end)
 	if err != nil {
 		return nil, err
 	}
 
 	unit := metadata.GetQueryParams(ctx).TimeUnit
 	fact := NewFormatFactory(ctx).
-		WithQuery(name, query.TimeField, start, end, unit, 0).
+		WithQuery(name, labelValuesQuery.TimeField, start, end, unit, 0).
 		WithFieldMap(fieldMap)
 
 	// 添加 exists 条件确保字段存在
-	query.AllConditions = append(query.AllConditions, []metadata.ConditionField{
+	labelValuesQuery.AllConditions = append(labelValuesQuery.AllConditions, []metadata.ConditionField{
 		{
 			DimensionName: name,
 			Value:         []string{},
@@ -913,7 +940,7 @@ func (i *Instance) QueryLabelValues(ctx context.Context, query *metadata.Query, 
 		},
 	})
 
-	query.Aggregates = append(query.Aggregates, metadata.Aggregate{
+	labelValuesQuery.Aggregates = append(labelValuesQuery.Aggregates, metadata.Aggregate{
 		Name:       Cardinality,
 		Field:      name,
 		Dimensions: []string{name},

--- a/pkg/unify-query/tsdb/elasticsearch/instance_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance_test.go
@@ -1301,6 +1301,61 @@ func TestInstance_queryRawData(t *testing.T) {
 	}
 }
 
+func TestInstance_QueryRawDataSharedQueryDoesNotMutate(t *testing.T) {
+	mock.Init()
+	ctx := metadata.InitHashID(context.Background())
+
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		mock.EsUrl+"/es_index/_search",
+		httpmock.NewStringResponder(http.StatusOK, `{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}`),
+	)
+
+	ins, err := NewInstance(ctx, &InstanceOption{
+		Connect: Connect{
+			Address: mock.EsUrl,
+		},
+		MaxSize: 1,
+		Timeout: 3 * time.Second,
+	})
+	assert.NoError(t, err)
+
+	optionFrom := 7
+	query := &metadata.Query{
+		DB:    "es_index",
+		Field: "a",
+		From:  3,
+		Size:  10,
+		TimeField: metadata.TimeField{
+			Name: "dtEventTimeStamp",
+			Type: TimeFieldTypeTime,
+			Unit: "millisecond",
+		},
+		TableID:     "es_index",
+		StorageType: metadata.ElasticsearchStorageType,
+		Source:      []string{"a"},
+		ResultTableOption: &metadata.ResultTableOption{
+			From: &optionFrom,
+		},
+	}
+	originalOption := query.ResultTableOption.Clone()
+
+	dataCh := make(chan map[string]any)
+	size, total, resultOption, err := ins.QueryRawData(ctx, query, time.UnixMilli(1723593608000), time.UnixMilli(1723679962000), dataCh)
+	close(dataCh)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), size)
+	assert.Equal(t, int64(0), total)
+	assert.Equal(t, 10, query.Size)
+	assert.Equal(t, 3, query.From)
+	assert.Equal(t, originalOption, query.ResultTableOption)
+	assert.NotSame(t, query.ResultTableOption, resultOption)
+	assert.NotSame(t, query.ResultTableOption.From, resultOption.From)
+	assert.Equal(t, 7, *query.ResultTableOption.From)
+	assert.Equal(t, 7, *resultOption.From)
+}
+
 func TestInstance_fieldMap(t *testing.T) {
 	mock.Init()
 
@@ -1394,6 +1449,94 @@ func TestInstance_QueryLabelNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInstance_QueryLabelValuesConcurrentSharedQueryDoesNotMutate(t *testing.T) {
+	mock.Init()
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		mock.EsUrl+"/es_index/_search",
+		httpmock.NewStringResponder(http.StatusOK, `{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"a":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"a-value","doc_count":1,"_value":{"value":1}}]},"b":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"b-value","doc_count":1,"_value":{"value":1}}]},"level":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"INFO","doc_count":1,"_value":{"value":1}}]}}}`),
+	)
+
+	inst, err := NewInstance(ctx, &InstanceOption{
+		Connect: Connect{
+			Address: mock.EsUrl,
+		},
+		Timeout: time.Minute,
+	})
+	assert.NoError(t, err)
+
+	query := &metadata.Query{
+		DB:    "es_index",
+		Field: "a",
+		TimeField: metadata.TimeField{
+			Name: "dtEventTimeStamp",
+			Type: TimeFieldTypeTime,
+			Unit: "millisecond",
+		},
+		TableID:     "test_table",
+		StorageType: metadata.ElasticsearchStorageType,
+		AllConditions: metadata.AllConditions{
+			{
+				{
+					DimensionName: "level",
+					Operator:      "eq",
+					Value:         []string{"INFO"},
+				},
+			},
+		},
+		Aggregates: metadata.Aggregates{
+			{
+				Name:       Count,
+				Field:      "a",
+				Dimensions: []string{"level"},
+			},
+		},
+	}
+	originalAllConditions := cloneAllConditions(query.AllConditions)
+	originalAggregates := make(metadata.Aggregates, len(query.Aggregates))
+	for i, aggregate := range query.Aggregates {
+		originalAggregates[i] = aggregate
+		originalAggregates[i].Dimensions = append([]string{}, aggregate.Dimensions...)
+		if aggregate.Args != nil {
+			originalAggregates[i].Args = append([]any{}, aggregate.Args...)
+		}
+	}
+
+	start := time.UnixMilli(1723593608000)
+	end := time.UnixMilli(1723679962000)
+	labelNames := []string{"a", "b", "level"}
+	errCh := make(chan error, len(labelNames)*10)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		for _, labelName := range labelNames {
+			wg.Add(1)
+			go func(labelName string) {
+				defer wg.Done()
+				values, err := inst.QueryLabelValues(ctx, query, labelName, start, end)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if len(values) == 0 {
+					errCh <- fmt.Errorf("empty label values for %s", labelName)
+				}
+			}(labelName)
+		}
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, originalAllConditions, query.AllConditions)
+	assert.Equal(t, originalAggregates, query.Aggregates)
 }
 
 func TestInstance_QuerySeries(t *testing.T) {


### PR DESCRIPTION
## 背景

ES 查询入口会复用请求级 `metadata.Query`，但部分查询执行逻辑会临时写入 `Size`、`From`、`AllConditions`、`Aggregates` 等字段，存在并发读写竞态和污染后续查询语义的风险。

## 修复内容

- `QueryLabelValues` 改为使用本地 query 副本追加 exists 条件和 cardinality 聚合。
- `QueryRawData` 改为使用本地 query 副本处理 `Size`、`From` 和返回 option。
- 新增 `ResultTableOption.Clone()`，避免共享 option 指针带来的副作用。
- 修复 `Aggregates.Copy()` 未复制 `Without` 的问题，避免副本查询改变 ES 聚合结构。
- 补充共享 query 并发回归测试、option clone 单测和 `Without` 聚合回归测试。