### PR TITLE
fix: (unify-query)修复 QueryReference 共享 Query 被临时参数污染的问题 --bug=158810948

### DIFF
--- a/pkg/unify-query/metadata/result_table_options.go
+++ b/pkg/unify-query/metadata/result_table_options.go
@@ -26,6 +26,41 @@ type ResultTableOption struct {
 	ResultSchema []map[string]any `json:"result_schema,omitempty"`
 }
 
+func (o *ResultTableOption) Clone() *ResultTableOption {
+	if o == nil {
+		return nil
+	}
+
+	clone := *o
+	if o.From != nil {
+		from := *o.From
+		clone.From = &from
+	}
+	if o.SearchAfter != nil {
+		clone.SearchAfter = append([]any(nil), o.SearchAfter...)
+	}
+	if o.FieldType != nil {
+		clone.FieldType = make(map[string]string, len(o.FieldType))
+		for k, v := range o.FieldType {
+			clone.FieldType[k] = v
+		}
+	}
+	if o.ResultSchema != nil {
+		clone.ResultSchema = make([]map[string]any, len(o.ResultSchema))
+		for i, schema := range o.ResultSchema {
+			if schema == nil {
+				continue
+			}
+			clone.ResultSchema[i] = make(map[string]any, len(schema))
+			for k, v := range schema {
+				clone.ResultSchema[i][k] = v
+			}
+		}
+	}
+
+	return &clone
+}
+
 func (o ResultTableOptions) SetOption(tableUUID string, option *ResultTableOption) {
 	if option == nil {
 		return

--- a/pkg/unify-query/metadata/struct_test.go
+++ b/pkg/unify-query/metadata/struct_test.go
@@ -79,6 +79,40 @@ func TestFieldAlias_AddAliasKeysWhenOriginalFieldPresent(t *testing.T) {
 	})
 }
 
+func TestResultTableOptionClone(t *testing.T) {
+	from := 1
+	option := &ResultTableOption{
+		From:        &from,
+		ScrollID:    "scroll",
+		SearchAfter: []any{"search", 1},
+		SliceIndex:  2,
+		SliceMax:    4,
+		FieldType: map[string]string{
+			"message": "text",
+		},
+		SQL: "select 1",
+		ResultSchema: []map[string]any{
+			{
+				"field_name": "message",
+				"field_type": "string",
+			},
+		},
+	}
+
+	cloned := option.Clone()
+	assert.Equal(t, option, cloned)
+
+	*cloned.From = 2
+	cloned.SearchAfter[0] = "changed"
+	cloned.FieldType["message"] = "keyword"
+	cloned.ResultSchema[0]["field_type"] = "text"
+
+	assert.Equal(t, 1, *option.From)
+	assert.Equal(t, []any{"search", 1}, option.SearchAfter)
+	assert.Equal(t, "text", option.FieldType["message"])
+	assert.Equal(t, "string", option.ResultSchema[0]["field_type"])
+}
+
 func cloneAnyMap(m map[string]any) map[string]any {
 	if m == nil {
 		return nil

--- a/pkg/unify-query/service/http/api.go
+++ b/pkg/unify-query/service/http/api.go
@@ -420,21 +420,22 @@ func HandlerSeries(c *gin.Context) {
 		_ = p.Submit(func() {
 			defer wg.Done()
 
+			seriesQuery := *qry
 			if params.Limit > 0 && len(data.Series) > params.Limit {
 				return
 			}
 
 			// 将用户指定的 keys 传递给 query.Source，让底层存储只查询指定字段
 			if len(params.Keys) > 0 {
-				qry.Source = params.Keys
+				seriesQuery.Source = params.Keys
 			}
 
-			instance := prometheus.GetTsDbInstance(ctx, qry)
+			instance := prometheus.GetTsDbInstance(ctx, &seriesQuery)
 			if instance == nil {
 				return
 			}
 
-			res, err := instance.QuerySeries(ctx, qry, qb.Start, qb.End)
+			res, err := instance.QuerySeries(ctx, &seriesQuery, qb.Start, qb.End)
 			if err != nil {
 				return
 			}

--- a/pkg/unify-query/service/http/handler_test.go
+++ b/pkg/unify-query/service/http/handler_test.go
@@ -317,6 +317,8 @@ func TestAPIHandler(t *testing.T) {
 
 		infoParams *Params
 		expected   string
+
+		assertQuerySourceEmpty bool
 	}{
 		"test label values in vm 1": {
 			handler: HandlerLabelValues,
@@ -528,7 +530,8 @@ func TestAPIHandler(t *testing.T) {
 				Limit:   1,
 				Keys:    []string{"bcs_cluster_id", "namespace"},
 			},
-			expected: `{"measurement":"container_cpu_usage_seconds_total_value","keys":["bcs_cluster_id","namespace"],"series":[["BCS-K8S-00000","default"],["BCS-K8S-00000","bkbase"]]}`,
+			expected:               `{"measurement":"container_cpu_usage_seconds_total_value","keys":["bcs_cluster_id","namespace"],"series":[["BCS-K8S-00000","default"],["BCS-K8S-00000","bkbase"]]}`,
+			assertQuerySourceEmpty: true,
 		},
 		"test series in prometheus direct": {
 			handler: HandlerSeries,
@@ -553,7 +556,8 @@ func TestAPIHandler(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"measurement":"container_cpu_usage_seconds_total_value","keys":["bcs_cluster_id","namespace"],"series":[["BCS-K8S-00000","default"],["BCS-K8S-00000","bkbase"]]}`,
+			expected:               `{"measurement":"container_cpu_usage_seconds_total_value","keys":["bcs_cluster_id","namespace"],"series":[["BCS-K8S-00000","default"],["BCS-K8S-00000","bkbase"]]}`,
+			assertQuerySourceEmpty: true,
 		},
 		"test field map in es": {
 			handler: HandlerFieldMap,
@@ -639,6 +643,13 @@ func TestAPIHandler(t *testing.T) {
 			if c.handler != nil {
 				c.handler(ginC)
 				assert.Equal(t, c.expected, w.body())
+				if c.assertQuerySourceEmpty {
+					queryRef := metadata.GetQueryReference(ctx)
+					assert.Greater(t, queryRef.Count(), 0)
+					queryRef.Range("", func(qry *metadata.Query) {
+						assert.Empty(t, qry.Source)
+					})
+				}
 			}
 		})
 	}

--- a/pkg/unify-query/service/http/query.go
+++ b/pkg/unify-query/service/http/query.go
@@ -323,17 +323,18 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 
 		qb := metadata.GetQueryParams(ctx)
 		queryRef.Range("", func(qry *metadata.Query) {
+			localQry := *qry
 			// SearchAfter 模式下，跳过已完成的 RT
 			// RT 不在 ResultTableOptions 中（nil）或 SearchAfter 为空，表示该 RT 数据已查完
 			if queryTs.IsSearchAfter && len(queryTs.ResultTableOptions) > 0 {
-				if qry.ResultTableOption == nil || len(qry.ResultTableOption.SearchAfter) == 0 {
+				if localQry.ResultTableOption == nil || len(localQry.ResultTableOption.SearchAfter) == 0 {
 					return
 				}
 			}
 
 			sendWg.Add(1)
 
-			labelMap := function.LabelMap(ctx, qry)
+			labelMap := function.LabelMap(ctx, &localQry)
 			// 合并 labelMap
 			lock.Lock()
 			for k, lm := range labelMap {
@@ -348,8 +349,8 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 			// 如果是多数据合并，为了保证排序和Limit 的准确性，需要查询原始的所有数据，所以这里对 from 和 size 进行重写
 			if queryRef.Count() > 1 {
 				if !queryTs.IsMultiFrom {
-					qry.Size += qry.From
-					qry.From = 0
+					localQry.Size += localQry.From
+					localQry.From = 0
 				}
 			}
 
@@ -358,7 +359,7 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 					sendWg.Done()
 				}()
 
-				instance := prometheus.GetTsDbInstance(ctx, qry)
+				instance := prometheus.GetTsDbInstance(ctx, &localQry)
 				if instance == nil {
 					errCh <- metadata.NewMessage(
 						metadata.MsgQueryRaw,
@@ -369,7 +370,7 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 
 				// 如果开启了高亮，收集字段映射信息用于判断大小写敏感性
 				if queryTs.HighLight != nil && queryTs.HighLight.Enable {
-					if fieldsMap, fmErr := instance.QueryFieldMap(ctx, qry, qb.Start, qb.End); fmErr == nil && fieldsMap != nil {
+					if fieldsMap, fmErr := instance.QueryFieldMap(ctx, &localQry, qb.Start, qb.End); fmErr == nil && fieldsMap != nil {
 						lock.Lock()
 						for k, v := range fieldsMap {
 							if _, ok := allFieldsMap[k]; !ok {
@@ -380,7 +381,7 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 					}
 				}
 
-				_, size, option, queryErr := instance.QueryRawData(ctx, qry, qb.Start, qb.End, dataCh)
+				_, size, option, queryErr := instance.QueryRawData(ctx, &localQry, qb.Start, qb.End, dataCh)
 				if queryErr != nil {
 					errCh <- queryErr
 					return
@@ -390,7 +391,7 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 
 				// 如果配置了 IsMultiFrom，则无需使用 scroll 和 searchAfter 配置
 				lock.Lock()
-				resultTableOptions.SetOption(qry.TableUUID(), option)
+				resultTableOptions.SetOption(localQry.TableUUID(), option)
 				lock.Unlock()
 
 				atomic.AddInt64(&total, size)

--- a/pkg/unify-query/service/http/query.go
+++ b/pkg/unify-query/service/http/query.go
@@ -324,6 +324,7 @@ func queryRawWithInstance(ctx context.Context, queryTs *structured.QueryTs) (tot
 		qb := metadata.GetQueryParams(ctx)
 		queryRef.Range("", func(qry *metadata.Query) {
 			localQry := *qry
+			localQry.ResultTableOption = qry.ResultTableOption.Clone()
 			// SearchAfter 模式下，跳过已完成的 RT
 			// RT 不在 ResultTableOptions 中（nil）或 SearchAfter 为空，表示该 RT 数据已查完
 			if queryTs.IsSearchAfter && len(queryTs.ResultTableOptions) > 0 {

--- a/pkg/unify-query/service/http/query_test.go
+++ b/pkg/unify-query/service/http/query_test.go
@@ -2442,13 +2442,8 @@ func TestQueryRawWithInstance(t *testing.T) {
 	})
 
 	t.Run("query raw does not mutate query reference result table option", func(t *testing.T) {
-		dorisSQL := "SELECT * FROM `2_bklog_bkunify_query_doris`.doris " +
-			"WHERE (`dtEventTimeStamp` >= 1723595000000 AND `dtEventTimeStamp` <= 1723595000000 " +
-			"AND `dtEventTime` >= '2024-08-14 08:23:20' AND `dtEventTime` <= '2024-08-14 08:23:21' " +
-			"AND `thedate` = '20240814') " +
-			"ORDER BY `dtEventTimeStamp` DESC, `gseIndex` DESC, `iterationIndex` DESC LIMIT 100"
 		mock.BkSQL.Set(map[string]any{
-			dorisSQL: `{"result":true,"message":"成功","code":"00","data":{"cluster":"doris-test","totalRecords":1,"source":"","list":[],"select_fields_order":[],"result_schema":[{"field_type":"string","field_name":"__c0","field_alias":"mock_field","field_index":0}],"device":"doris","result_table_ids":["2_bklog_bkunify_query_doris"]},"errors":null}`,
+			"SHOW CREATE TABLE `2_bklog_bkunify_query_doris`.doris": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int","Null":"NO","Key":"YES","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint","Null":"NO","Key":"YES","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"NO","Default":null,"Extra":""},{"Field":"gseIndex","Type":"double","Null":"YES","Key":"NO","Default":null,"Extra":""},{"Field":"iterationIndex","Type":"double","Null":"YES","Key":"NO","Default":null,"Extra":""}]},"errors":null}`,
 		})
 
 		from := 0
@@ -2474,8 +2469,9 @@ func TestQueryRawWithInstance(t *testing.T) {
 					SQL:        "SELECT * ORDER BY dtEventTimeStamp DESC, gseIndex DESC, iterationIndex DESC LIMIT 100",
 				},
 			},
-			Step: start,
-			End:  end,
+			Step:   start,
+			End:    end,
+			DryRun: true,
 			ResultTableOptions: metadata.ResultTableOptions{
 				"result_table.doris|4": originalOption,
 			},
@@ -2485,7 +2481,7 @@ func TestQueryRawWithInstance(t *testing.T) {
 		require.NoError(t, err)
 		option := options.GetOption("result_table.doris|4")
 		require.NotNil(t, option)
-		require.NotEmpty(t, option.ResultSchema)
+		require.Contains(t, option.SQL, "SELECT * FROM `2_bklog_bkunify_query_doris`.doris")
 
 		assert.Empty(t, originalOption.SQL)
 		assert.Equal(t, []any{"keep"}, originalOption.SearchAfter)

--- a/pkg/unify-query/service/http/query_test.go
+++ b/pkg/unify-query/service/http/query_test.go
@@ -2439,6 +2439,52 @@ func TestQueryRawWithInstance(t *testing.T) {
 			assert.Equal(t, 2, qry.Size)
 		})
 	})
+
+	t.Run("query raw does not mutate query reference result table option", func(t *testing.T) {
+		from := 0
+		originalOption := &metadata.ResultTableOption{
+			From:        &from,
+			SearchAfter: []any{"keep"},
+			FieldType: map[string]string{
+				"keep": "keyword",
+			},
+			ResultSchema: []map[string]any{
+				{
+					"field_name": "keep",
+					"field_type": "keyword",
+				},
+			},
+		}
+		queryTs := &structured.QueryTs{
+			SpaceUid: spaceUid,
+			QueryList: []*structured.Query{
+				{
+					DataSource: structured.BkLog,
+					TableID:    influxdb.ResultTableDoris,
+					SQL:        "SELECT * ORDER BY dtEventTimeStamp DESC, gseIndex DESC, iterationIndex DESC LIMIT 100",
+				},
+			},
+			Step: start,
+			End:  end,
+			ResultTableOptions: metadata.ResultTableOptions{
+				"result_table.doris|4": originalOption,
+			},
+		}
+
+		_, _, options, err := queryRawWithInstance(ctx, queryTs)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, options.GetOption("result_table.doris|4").ResultSchema)
+
+		assert.Empty(t, originalOption.SQL)
+		assert.Equal(t, []any{"keep"}, originalOption.SearchAfter)
+		assert.Equal(t, "keyword", originalOption.FieldType["keep"])
+		assert.Equal(t, []map[string]any{
+			{
+				"field_name": "keep",
+				"field_type": "keyword",
+			},
+		}, originalOption.ResultSchema)
+	})
 }
 
 // TestQueryExemplar comment lint rebel

--- a/pkg/unify-query/service/http/query_test.go
+++ b/pkg/unify-query/service/http/query_test.go
@@ -2409,6 +2409,36 @@ func TestQueryRawWithInstance(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("query raw does not mutate query reference size and from", func(t *testing.T) {
+		queryTs := &structured.QueryTs{
+			SpaceUid: spaceUid,
+			QueryList: []*structured.Query{
+				{
+					DataSource: structured.BkLog,
+					TableID:    "multi_es",
+				},
+			},
+			From:  2,
+			Limit: 2,
+			Step:  start,
+			End:   end,
+			OrderBy: structured.OrderBy{
+				"-time",
+				"__result_table",
+			},
+		}
+
+		_, _, _, err := queryRawWithInstance(ctx, queryTs)
+		assert.NoError(t, err)
+
+		queryRef := metadata.GetQueryReference(ctx)
+		assert.Equal(t, 2, queryRef.Count())
+		queryRef.Range("", func(qry *metadata.Query) {
+			assert.Equal(t, 2, qry.From)
+			assert.Equal(t, 2, qry.Size)
+		})
+	})
 }
 
 // TestQueryExemplar comment lint rebel

--- a/pkg/unify-query/service/http/query_test.go
+++ b/pkg/unify-query/service/http/query_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/bkapi"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/featureFlag"
@@ -2441,6 +2442,15 @@ func TestQueryRawWithInstance(t *testing.T) {
 	})
 
 	t.Run("query raw does not mutate query reference result table option", func(t *testing.T) {
+		dorisSQL := "SELECT * FROM `2_bklog_bkunify_query_doris`.doris " +
+			"WHERE (`dtEventTimeStamp` >= 1723595000000 AND `dtEventTimeStamp` <= 1723595000000 " +
+			"AND `dtEventTime` >= '2024-08-14 08:23:20' AND `dtEventTime` <= '2024-08-14 08:23:21' " +
+			"AND `thedate` = '20240814') " +
+			"ORDER BY `dtEventTimeStamp` DESC, `gseIndex` DESC, `iterationIndex` DESC LIMIT 100"
+		mock.BkSQL.Set(map[string]any{
+			dorisSQL: `{"result":true,"message":"成功","code":"00","data":{"cluster":"doris-test","totalRecords":1,"source":"","list":[],"select_fields_order":[],"result_schema":[{"field_type":"string","field_name":"__c0","field_alias":"mock_field","field_index":0}],"device":"doris","result_table_ids":["2_bklog_bkunify_query_doris"]},"errors":null}`,
+		})
+
 		from := 0
 		originalOption := &metadata.ResultTableOption{
 			From:        &from,
@@ -2472,8 +2482,10 @@ func TestQueryRawWithInstance(t *testing.T) {
 		}
 
 		_, _, options, err := queryRawWithInstance(ctx, queryTs)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, options.GetOption("result_table.doris|4").ResultSchema)
+		require.NoError(t, err)
+		option := options.GetOption("result_table.doris|4")
+		require.NotNil(t, option)
+		require.NotEmpty(t, option.ResultSchema)
 
 		assert.Empty(t, originalOption.SQL)
 		assert.Equal(t, []any{"keep"}, originalOption.SearchAfter)

--- a/pkg/unify-query/tsdb/prometheus/instance.go
+++ b/pkg/unify-query/tsdb/prometheus/instance.go
@@ -184,17 +184,18 @@ func (i *Instance) DirectLabelValues(ctx context.Context, name string, start, en
 
 	queryReference.Range(metricName, func(qry *metadata.Query) {
 		wg.Add(1)
-		qry.Size = limit
+		labelValuesQuery := *qry
+		labelValuesQuery.Size = limit
 		_ = p.Submit(func() {
 			defer func() {
 				wg.Done()
 			}()
-			instance := GetTsDbInstance(ctx, qry)
+			instance := GetTsDbInstance(ctx, &labelValuesQuery)
 			if instance == nil {
 				return
 			}
 
-			lbl, lvErr := instance.QueryLabelValues(ctx, qry, name, start, end)
+			lbl, lvErr := instance.QueryLabelValues(ctx, &labelValuesQuery, name, start, end)
 			if lvErr == nil {
 				for _, l := range lbl {
 					res.Add(l)


### PR DESCRIPTION
## 背景

`QueryReference` 是一次请求内展开后的查询路由集合，其中的 `*metadata.Query` 可能被多个 goroutine 或多个查询阶段复用。

此前部分 HTTP / Prometheus 编排逻辑会将任务级临时参数直接写回共享 `qry`，例如 `Size`、`From`、`Source`，可能导致并发 data race，或在串行复用时污染后续查询语义。

## 修复内容

本次修复将相关临时参数改为写入局部 `metadata.Query` 副本：

- `queryRawWithInstance` 中多路 raw 查询的 `Size` / `From` 调整改为作用于 `localQry`。
- `HandlerSeries` 中用户指定的 `params.Keys` 改为写入 `seriesQuery.Source`。
- `DirectLabelValues` 中 label values 的 `limit` 改为写入 `labelValuesQuery.Size`。

修复后，编排层不再原地修改 `QueryReference` 中的共享 `*metadata.Query`，避免请求级 query 被任务级参数污染。