### PR TITLE
fix(bk-log-sidecar): 软链采集路径解析，修复卷内日志 mounts 为空采集不到

### DIFF
--- a/pkg/bk-log-sidecar/define/container_path.go
+++ b/pkg/bk-log-sidecar/define/container_path.go
@@ -13,13 +13,15 @@ package define
 import (
 	"errors"
 	"fmt"
-	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-log-sidecar/config"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/docker/docker/api/types/container"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-log-sidecar/config"
 )
 
 // ContainerRootPath gey container root path
@@ -37,8 +39,50 @@ func ToHostPath(path string) string {
 	return filepath.Join(config.HostPath, path)
 }
 
-// EvalSymlinks 从容器内递归转换软链，获取日志指向的真实路径
+// EvalSymlinks 从容器内递归转换软链，获取日志指向的真实路径。
+// 解析相对宿主机根(config.HostPath)，遇到无法 lstat 的路径段直接报错。
 func EvalSymlinks(path string) (string, error) {
+	return evalSymlinks(path, ToHostPath, false)
+}
+
+// splitGlobPrefix 以首个通配符(* ? [)所在路径段为界，拆出可解析的目录前缀与剩余(含通配)后缀。
+// 无通配符时返回 (path, "")；通配符出现在第一段时返回 ("", path)。
+func splitGlobPrefix(path string) (prefix, suffix string) {
+	idx := strings.IndexAny(path, "*?[")
+	if idx < 0 {
+		return path, ""
+	}
+	sep := strings.LastIndex(path[:idx], string(filepath.Separator))
+	if sep <= 0 {
+		return "", path
+	}
+	return path[:sep], path[sep:]
+}
+
+// ResolveSymlinkForMatch 解析采集路径(首个通配符前的目录前缀)在容器 rootfs 内的软链，
+// 返回容器视角的真实路径，用于与容器卷挂载重新匹配。无软链或解析失败时原样返回 path。
+// rootFs 为容器 rootfs 在宿主机上的路径(已含 config.HostPath 前缀)。
+// 采用容错解析：当软链目标落在卷(如 PVC)上、overlay 内 lstat 不到时，停在已解析的目标路径，
+// 而非报错，从而得到可用于卷匹配的真实路径。
+func ResolveSymlinkForMatch(path, rootFs string) string {
+	if rootFs == "" || !filepath.IsAbs(path) {
+		return path
+	}
+	prefix, suffix := splitGlobPrefix(path)
+	if prefix == "" {
+		return path
+	}
+	resolved, err := evalSymlinks(prefix, func(p string) string { return filepath.Join(rootFs, p) }, true)
+	if err != nil || resolved == "" || resolved == prefix {
+		return path
+	}
+	return resolved + suffix
+}
+
+// evalSymlinks 递归解析 path 中的软链。
+// toHost 将容器视角路径映射为 sidecar 可访问的宿主机路径；
+// tolerant 为 true 时，遇到无法 lstat 的路径段会停止解析并按字面拼接剩余部分(用于卷内目标)。
+func evalSymlinks(path string, toHost func(string) string, tolerant bool) (string, error) {
 	volLen := 0
 	pathSeparator := string(os.PathSeparator)
 
@@ -102,13 +146,22 @@ func EvalSymlinks(path string) (string, error) {
 
 		// Resolve symlink.
 
-		fi, err := os.Lstat(ToHostPath(dest))
+		fi, err := os.Lstat(toHost(dest))
 		if err != nil {
+			if tolerant {
+				// 无法继续 lstat(如目标落在卷内、overlay 不可见)，剩余部分按字面拼接后返回。
+				dest += path[end:]
+				return filepath.Clean(dest), nil
+			}
 			return "", err
 		}
 
 		if fi.Mode()&fs.ModeSymlink == 0 {
 			if !fi.Mode().IsDir() && end < len(path) {
+				if tolerant {
+					dest += path[end:]
+					return filepath.Clean(dest), nil
+				}
 				return "", syscall.ENOTDIR
 			}
 			continue
@@ -121,8 +174,12 @@ func EvalSymlinks(path string) (string, error) {
 			return "", errors.New("EvalSymlinks: too many links")
 		}
 
-		link, err := os.Readlink(ToHostPath(dest))
+		link, err := os.Readlink(toHost(dest))
 		if err != nil {
+			if tolerant {
+				dest += path[end:]
+				return filepath.Clean(dest), nil
+			}
 			return "", err
 		}
 

--- a/pkg/bk-log-sidecar/define/log_config_type.go
+++ b/pkg/bk-log-sidecar/define/log_config_type.go
@@ -19,7 +19,10 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-log-sidecar/config"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-log-sidecar/utils"
 	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+var log = ctrl.Log.WithName("define")
 
 // LogConfigType log config type
 type LogConfigType interface {
@@ -223,10 +226,27 @@ func (s *ContainerLogConfig) Config() []byte {
 
 	mountMap := make(map[string]string)
 	mounts := make([]Mount, 0)
-	for _, path := range local.Path {
+	for i, path := range local.Path {
 		newMountMap, err := GetContainerMount(path, s.Container)
 		if utils.NotNil(err) {
 			continue
+		}
+		// 采集路径为软链时，字面前缀匹配无法命中容器卷挂载，导致 mounts 为空、卷内日志采集不到。
+		// 兜底：解析容器 rootfs 内的软链，用真实路径重新匹配卷；命中则改写下发 path(保证采集器
+		// 按 container_path 裁剪时能对上 host_path)。仅在原路径未命中任何卷时触发，保持原行为不变。
+		if len(newMountMap) == 0 {
+			if resolved := ResolveSymlinkForMatch(path, local.RootFs); resolved != path {
+				if m, e := GetContainerMount(resolved, s.Container); utils.IsNil(e) && len(m) > 0 {
+					log.Info("resolved symlink collect path to match container mount",
+						"origin", path, "resolved", resolved, "container", s.Container.ID)
+					newMountMap = m
+					local.Path[i] = resolved
+				} else {
+					log.Info("collect path is a symlink but still matches no container mount, "+
+						"please configure the real path under the volume",
+						"origin", path, "resolved", resolved, "container", s.Container.ID)
+				}
+			}
 		}
 		// 更新 mountMap
 		for k, v := range newMountMap {


### PR DESCRIPTION
## 背景 / 现象

某 Pod 已确认有日志打印但采集不到。环境：

- `apphome` 是软链：`/data/home/user00/apphome` → `/data/home/user00/release/qsshome/`
- `/data/home/user00/release/` 由 PVC(CBS) 挂载
- 采集路径配软链 `/data/home/user00/apphome/...` 时：**采集不到**，且 sidecar 生成的子配置 `mounts`(挂载路径) 为空
- 改为卷内真实路径 `/data/home/user00/release/qsshome/*/log/*.log*` 后：有数据上报

## 根因

`ContainerLogConfig.Config()` 遍历采集 path 调 `GetContainerMount` 匹配容器卷，**只对字面路径做前缀匹配(`filepath.Rel`)，不解析软链**。软链路径 `apphome` 不落在任何卷 `ContainerPath`(`/data/home/user00/release`) 下 → 匹配为空 → `local.Mounts` 留空。

`mounts` 的作用是告诉宿主机采集器"这段容器路径的文件实际在宿主机 `host_path`"。PVC/hostPath/emptyDir 卷里的日志不在容器 overlay rootfs 里，`mounts` 为空时采集器只按 `root_fs + path` 去 overlay 找 → 卷内文件读不到。

> 说明：PVC/CBS 本身支持采集(CRI 会上报卷 `host_path`)，卡点是软链而非 PVC 类型。

## 改动

- 卷匹配为空时兜底：解析容器 rootfs 内的软链，用真实路径重新匹配卷；命中则补 `mounts` 并改写下发 `path`(保证采集器按 `container_path` 裁剪时能对上 `host_path`)
- `evalSymlinks` 增加容错模式：软链目标落在卷内、overlay 内 `lstat` 不到时停在已解析的目标路径而非报错；glob 通配符只解析首个通配符前的目录前缀
- **仅在原路径未命中任何卷时触发，保持原有行为不变(零回归)**；命中软链时打印 info 日志，软链仍无法匹配卷时打印提示日志

## 验证

- 在独立模块复刻 linux 版 `GetContainerMount` + 新增解析逻辑，用真实 temp-dir 软链跑单测全部通过：
  - 绝对/相对软链目标均能解析为真实路径
  - 非软链路径保持不变
  - 软链原路径不命中卷(复现 bug) → 解析后命中 PVC 卷(修复生效)
  - glob 前缀拆分边界用例
- `GOOS=linux go build ./define/` 通过

## 备注

`pkg/bk-log-sidecar/define` 测试包在 master 上存在历史遗留问题(`container_path_test.go` 引用已删除的 `ContainerActualPath` 致编译不过、`TestBkunifylogbeat*` 期望陈旧)，本 PR 不涉及、保持最小改动，未在仓库内新增测试文件以免卷入；如需我另开 PR 修复测试包可告知。

Made with [Cursor](https://cursor.com)