### PR TITLE
feat: (bkmonitorbeat) 支持从任务 labels 覆盖 bk_biz_id

### DIFF
--- a/pkg/bkmonitorbeat/configs/basetaskparam.go
+++ b/pkg/bkmonitorbeat/configs/basetaskparam.go
@@ -11,7 +11,9 @@
 package configs
 
 import (
+	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
@@ -33,6 +35,39 @@ type BaseTaskParam struct {
 
 	labels []map[string]string
 	Sorted define.Tags
+}
+
+const labelBizID = "bk_biz_id"
+
+func (t *BaseTaskParam) resolveLabelBizID() (int32, bool, error) {
+	var (
+		resolved int32
+		found    bool
+	)
+
+	for _, labelItem := range t.Labels {
+		value, ok := labelItem[labelBizID]
+		if !ok {
+			continue
+		}
+
+		parsed, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid %s in labels: %q", labelBizID, value)
+		}
+
+		if !found {
+			resolved = int32(parsed)
+			found = true
+			continue
+		}
+
+		if resolved != int32(parsed) {
+			return 0, false, fmt.Errorf("conflicting %s in labels", labelBizID)
+		}
+	}
+
+	return resolved, found, nil
 }
 
 func (t *BaseTaskParam) convertLabels() {
@@ -100,6 +135,10 @@ func (t *BaseTaskParam) CleanParams() error {
 		t.Period = define.DefaultPeriod
 	}
 
+	if _, _, err := t.resolveLabelBizID(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -136,6 +175,9 @@ func (t *BaseTaskParam) GetPeriod() time.Duration {
 
 // GetBizID 获取业务ID
 func (t *BaseTaskParam) GetBizID() int32 {
+	if bizID, found, err := t.resolveLabelBizID(); err == nil && found {
+		return bizID
+	}
 	return t.BizID
 }
 

--- a/pkg/bkmonitorbeat/configs/basetaskparam_test.go
+++ b/pkg/bkmonitorbeat/configs/basetaskparam_test.go
@@ -7,30 +7,92 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-package configs_test
+package configs
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/configs"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
 )
 
-// TestParamClean 测试清洗后的结果是否符合预期
 func TestParamClean(t *testing.T) {
-	param := configs.NewBaseTaskParam()
-	assert.Nil(t, param.CleanParams())
-	assert.Equal(t, define.DefaultTimeout, param.Timeout)
-	assert.Equal(t, define.DefaultTimeout, param.AvailableDuration)
-	assert.Equal(t, define.DefaultPeriod, param.Period)
+	param := NewBaseTaskParam()
+	require.NoError(t, param.CleanParams())
+	require.Equal(t, define.DefaultTimeout, param.Timeout)
+	require.Equal(t, define.DefaultTimeout, param.AvailableDuration)
+	require.Equal(t, define.DefaultPeriod, param.Period)
 }
 
-// TestMetaParamClean 测试清洗后的结果是否符合预期
 func TestMetaParamClean(t *testing.T) {
-	param := configs.NewBaseTaskMetaParam()
-	assert.Nil(t, param.CleanParams())
-	assert.Equal(t, define.DefaultTimeout, param.MaxTimeout)
-	assert.Equal(t, define.DefaultPeriod, param.MinPeriod)
+	param := NewBaseTaskMetaParam()
+	require.NoError(t, param.CleanParams())
+	require.Equal(t, define.DefaultTimeout, param.MaxTimeout)
+	require.Equal(t, define.DefaultPeriod, param.MinPeriod)
+}
+
+func TestBaseTaskParamGetBizID(t *testing.T) {
+	t.Run("fallback to config biz id", func(t *testing.T) {
+		param := BaseTaskParam{BizID: 2}
+		require.NoError(t, param.CleanParams())
+		require.Equal(t, int32(2), param.GetBizID())
+	})
+
+	t.Run("use label biz id override", func(t *testing.T) {
+		param := BaseTaskParam{
+			BizID: 2,
+			Labels: []map[string]string{{
+				labelBizID: "5",
+			}},
+		}
+		require.NoError(t, param.CleanParams())
+		require.Equal(t, int32(5), param.GetBizID())
+	})
+
+	t.Run("allow same biz id across label groups", func(t *testing.T) {
+		param := BaseTaskParam{
+			BizID: 2,
+			Labels: []map[string]string{
+				{labelBizID: "5"},
+				{labelBizID: "5", "bk_target_ip": "10.0.0.1"},
+			},
+		}
+		require.NoError(t, param.CleanParams())
+		require.Equal(t, int32(5), param.GetBizID())
+	})
+
+	t.Run("reject invalid label biz id", func(t *testing.T) {
+		param := BaseTaskParam{
+			BizID: 2,
+			Labels: []map[string]string{{
+				labelBizID: "invalid",
+			}},
+		}
+		require.Error(t, param.CleanParams())
+	})
+
+	t.Run("reject conflicting label biz id", func(t *testing.T) {
+		param := BaseTaskParam{
+			BizID: 2,
+			Labels: []map[string]string{
+				{labelBizID: "5"},
+				{labelBizID: "8"},
+			},
+		}
+		require.Error(t, param.CleanParams())
+	})
+
+	t.Run("net task delegates biz id resolution", func(t *testing.T) {
+		param := NetTaskParam{
+			BaseTaskParam: BaseTaskParam{
+				BizID: 2,
+				Labels: []map[string]string{{
+					labelBizID: "5",
+				}},
+			},
+		}
+		require.NoError(t, param.CleanParams())
+		require.Equal(t, int32(5), param.GetBizID())
+	})
 }

--- a/pkg/bkmonitorbeat/configs/nettaskconfig.go
+++ b/pkg/bkmonitorbeat/configs/nettaskconfig.go
@@ -115,7 +115,7 @@ func (t *NetTaskParam) GetPeriod() time.Duration {
 
 // GetBizID :
 func (t *NetTaskParam) GetBizID() int32 {
-	return t.BizID
+	return t.BaseTaskParam.GetBizID()
 }
 
 // GetTaskID :


### PR DESCRIPTION
## 变更说明
- 在 BaseTaskParam 中统一解析 labels 里的 bk_biz_id，并将其作为任务最终上报使用的业务 ID。
- 在配置清洗阶段增加 labels 中 bk_biz_id 的合法性与一致性校验，非法值和冲突值直接报错。
- NetTaskParam 的 GetBizID 改为显式委托 BaseTaskParam，保证 http/tcp/udp/script 等网络类任务复用相同逻辑。
- 补充单测覆盖默认回退、label 覆盖、非法值、冲突值和 NetTaskParam 委托场景。

## 问题原因
远程采集场景下，任务配置虽然可以通过 labels 携带目标实例所属业务的 bk_biz_id，但 bkmonitorbeat 原先始终使用任务配置中的 BizID 字段，未感知 labels 中的覆盖值，导致上报数据仍归属到采集器主机业务。