### PR TITLE
fix: (unify-query)修复逗号分隔条件值检索语义

### DIFF
--- a/pkg/unify-query/query/structured/condition_normalize.go
+++ b/pkg/unify-query/query/structured/condition_normalize.go
@@ -1,0 +1,87 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package structured
+
+import "strings"
+
+// normalizeCommaConditionValues 将结构化条件里的 eq/ne 单值逗号串规范化成多值数组。
+// 该逻辑只处理 conditions，不改变 query_string 的字面量检索语义。
+func normalizeCommaConditionValues(conditions AllConditions) AllConditions {
+	if len(conditions) == 0 {
+		return conditions
+	}
+
+	isCommaValueOperator := func(operator string) bool {
+		return operator == ConditionEqual || operator == ConditionNotEqual
+	}
+
+	var normalized AllConditions
+	for i, group := range conditions {
+		for j, condition := range group {
+			if !isCommaValueOperator(condition.Operator) {
+				continue
+			}
+			values, ok := splitSingleCommaValue(condition.Value)
+			if !ok {
+				continue
+			}
+			if normalized == nil {
+				normalized = cloneAllConditions(conditions)
+			}
+			normalized[i][j].Value = values
+		}
+	}
+
+	if normalized == nil {
+		return conditions
+	}
+	return normalized
+}
+
+// splitSingleCommaValue 只负责把形如 []string{"a,b,c"} 的值拆成 []string{"a", "b", "c"}。
+// operator 是否允许拆分由调用方判断；如果拆分后不足两个有效值，则保持原值不变。
+func splitSingleCommaValue(values []string) ([]string, bool) {
+	if len(values) != 1 || !strings.Contains(values[0], ",") {
+		return values, false
+	}
+
+	parts := strings.Split(values[0], ",")
+	splitValues := make([]string, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		splitValues = append(splitValues, value)
+	}
+
+	if len(splitValues) <= 1 {
+		return values, false
+	}
+	return splitValues, true
+}
+
+func cloneAllConditions(conditions AllConditions) AllConditions {
+	if conditions == nil {
+		return nil
+	}
+
+	clone := make(AllConditions, len(conditions))
+	for i, group := range conditions {
+		clone[i] = make([]ConditionField, len(group))
+		for j, condition := range group {
+			clone[i][j] = condition
+			if condition.Value != nil {
+				clone[i][j].Value = append([]string{}, condition.Value...)
+			}
+		}
+	}
+	return clone
+}

--- a/pkg/unify-query/query/structured/condition_normalize.go
+++ b/pkg/unify-query/query/structured/condition_normalize.go
@@ -45,6 +45,22 @@ func normalizeCommaConditionValues(conditions AllConditions) AllConditions {
 	return normalized
 }
 
+// normalizeCommaConditions 将 Conditions 中的 eq/ne 单值逗号串规范化成多值数组。
+func normalizeCommaConditions(conditions Conditions) Conditions {
+	normalized := cloneConditions(conditions)
+	for i, condition := range normalized.FieldList {
+		if condition.Operator != ConditionEqual && condition.Operator != ConditionNotEqual {
+			continue
+		}
+		values, ok := splitSingleCommaValue(condition.Value)
+		if !ok {
+			continue
+		}
+		normalized.FieldList[i].Value = values
+	}
+	return normalized
+}
+
 // splitSingleCommaValue 只负责把形如 []string{"a,b,c"} 的值拆成 []string{"a", "b", "c"}。
 // operator 是否允许拆分由调用方判断；如果拆分后不足两个有效值，则保持原值不变。
 func splitSingleCommaValue(values []string) ([]string, bool) {
@@ -82,6 +98,23 @@ func cloneAllConditions(conditions AllConditions) AllConditions {
 				clone[i][j].Value = append([]string{}, condition.Value...)
 			}
 		}
+	}
+	return clone
+}
+
+func cloneConditions(conditions Conditions) Conditions {
+	clone := Conditions{}
+	if conditions.FieldList != nil {
+		clone.FieldList = make([]ConditionField, len(conditions.FieldList))
+		for i, condition := range conditions.FieldList {
+			clone.FieldList[i] = condition
+			if condition.Value != nil {
+				clone.FieldList[i].Value = append([]string{}, condition.Value...)
+			}
+		}
+	}
+	if conditions.ConditionList != nil {
+		clone.ConditionList = append([]string{}, conditions.ConditionList...)
 	}
 	return clone
 }

--- a/pkg/unify-query/query/structured/condition_normalize.go
+++ b/pkg/unify-query/query/structured/condition_normalize.go
@@ -11,8 +11,8 @@ package structured
 
 import "strings"
 
-// normalizeCommaConditionValues 将结构化条件里的 eq/ne 单值逗号串规范化成多值数组。
-// 该逻辑只处理 conditions，不改变 query_string 的字面量检索语义。
+// normalizeCommaConditionValues 将结构化条件里的 eq/ne 单值逗号编码列表规范化成多值数组。
+// 只有调用方已确认输入来源使用逗号编码列表时才能调用；普通逗号字面值需要保留精确匹配语义。
 func normalizeCommaConditionValues(conditions AllConditions) AllConditions {
 	if len(conditions) == 0 {
 		return conditions

--- a/pkg/unify-query/query/structured/condition_normalize.go
+++ b/pkg/unify-query/query/structured/condition_normalize.go
@@ -45,22 +45,6 @@ func normalizeCommaConditionValues(conditions AllConditions) AllConditions {
 	return normalized
 }
 
-// normalizeCommaConditions 将 Conditions 中的 eq/ne 单值逗号串规范化成多值数组。
-func normalizeCommaConditions(conditions Conditions) Conditions {
-	normalized := cloneConditions(conditions)
-	for i, condition := range normalized.FieldList {
-		if condition.Operator != ConditionEqual && condition.Operator != ConditionNotEqual {
-			continue
-		}
-		values, ok := splitSingleCommaValue(condition.Value)
-		if !ok {
-			continue
-		}
-		normalized.FieldList[i].Value = values
-	}
-	return normalized
-}
-
 // splitSingleCommaValue 只负责把形如 []string{"a,b,c"} 的值拆成 []string{"a", "b", "c"}。
 // operator 是否允许拆分由调用方判断；如果拆分后不足两个有效值，则保持原值不变。
 func splitSingleCommaValue(values []string) ([]string, bool) {
@@ -98,23 +82,6 @@ func cloneAllConditions(conditions AllConditions) AllConditions {
 				clone[i][j].Value = append([]string{}, condition.Value...)
 			}
 		}
-	}
-	return clone
-}
-
-func cloneConditions(conditions Conditions) Conditions {
-	clone := Conditions{}
-	if conditions.FieldList != nil {
-		clone.FieldList = make([]ConditionField, len(conditions.FieldList))
-		for i, condition := range conditions.FieldList {
-			clone.FieldList[i] = condition
-			if condition.Value != nil {
-				clone.FieldList[i].Value = append([]string{}, condition.Value...)
-			}
-		}
-	}
-	if conditions.ConditionList != nil {
-		clone.ConditionList = append([]string{}, conditions.ConditionList...)
 	}
 	return clone
 }

--- a/pkg/unify-query/query/structured/condition_normalize.go
+++ b/pkg/unify-query/query/structured/condition_normalize.go
@@ -46,7 +46,7 @@ func normalizeCommaConditionValues(conditions AllConditions) AllConditions {
 }
 
 // splitSingleCommaValue 只负责把形如 []string{"a,b,c"} 的值拆成 []string{"a", "b", "c"}。
-// operator 是否允许拆分由调用方判断；如果拆分后不足两个有效值，则保持原值不变。
+// operator 是否允许拆分由调用方判断；空候选是有效查询值，需要保留。
 func splitSingleCommaValue(values []string) ([]string, bool) {
 	if len(values) != 1 || !strings.Contains(values[0], ",") {
 		return values, false
@@ -56,15 +56,9 @@ func splitSingleCommaValue(values []string) ([]string, bool) {
 	splitValues := make([]string, 0, len(parts))
 	for _, part := range parts {
 		value := strings.TrimSpace(part)
-		if value == "" {
-			continue
-		}
 		splitValues = append(splitValues, value)
 	}
 
-	if len(splitValues) <= 1 {
-		return values, false
-	}
 	return splitValues, true
 }
 

--- a/pkg/unify-query/query/structured/condition_normalize_test.go
+++ b/pkg/unify-query/query/structured/condition_normalize_test.go
@@ -1,0 +1,74 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package structured
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 验证结构化 addition 的单值逗号串规范化结果：eq/ne 会拆分，其他输入保持原样。
+func TestNormalizeCommaConditionValues(t *testing.T) {
+	for name, c := range map[string]struct {
+		condition ConditionField
+		wantValue []string
+	}{
+		"eq 单值逗号串拆成多值": {
+			condition: ConditionField{
+				DimensionName: "result",
+				Operator:      ConditionEqual,
+				Value:         []string{"-4000, -3999,-3888"},
+			},
+			wantValue: []string{"-4000", "-3999", "-3888"},
+		},
+		"ne 单值逗号串拆成多值": {
+			condition: ConditionField{
+				DimensionName: "result",
+				Operator:      ConditionNotEqual,
+				Value:         []string{"-4000,-3999,-3888"},
+			},
+			wantValue: []string{"-4000", "-3999", "-3888"},
+		},
+		"已是多值数组不拆分": {
+			condition: ConditionField{
+				DimensionName: "result",
+				Operator:      ConditionEqual,
+				Value:         []string{"-4000", "-3999", "-3888"},
+			},
+			wantValue: []string{"-4000", "-3999", "-3888"},
+		},
+		"contains 操作符不拆分": {
+			condition: ConditionField{
+				DimensionName: "result",
+				Operator:      ConditionContains,
+				Value:         []string{"-4000,-3999,-3888"},
+			},
+			wantValue: []string{"-4000,-3999,-3888"},
+		},
+		"拆分后不足两个有效值不拆分": {
+			condition: ConditionField{
+				DimensionName: "result",
+				Operator:      ConditionEqual,
+				Value:         []string{"-4000,"},
+			},
+			wantValue: []string{"-4000,"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			conditions := AllConditions{{c.condition}}
+			original := cloneAllConditions(conditions)
+			normalized := normalizeCommaConditionValues(conditions)
+
+			assert.Equal(t, c.wantValue, normalized[0][0].Value)
+			assert.Equal(t, original, conditions)
+		})
+	}
+}

--- a/pkg/unify-query/query/structured/condition_normalize_test.go
+++ b/pkg/unify-query/query/structured/condition_normalize_test.go
@@ -72,3 +72,28 @@ func TestNormalizeCommaConditionValues(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeCommaConditions(t *testing.T) {
+	conditions := Conditions{
+		FieldList: []ConditionField{
+			{
+				DimensionName: "result",
+				Operator:      ConditionEqual,
+				Value:         []string{"-4000,-3999"},
+			},
+			{
+				DimensionName: "message",
+				Operator:      ConditionContains,
+				Value:         []string{"a,b"},
+			},
+		},
+		ConditionList: []string{ConditionAnd},
+	}
+	original := cloneConditions(conditions)
+
+	normalized := normalizeCommaConditions(conditions)
+
+	assert.Equal(t, []string{"-4000", "-3999"}, normalized.FieldList[0].Value)
+	assert.Equal(t, []string{"a,b"}, normalized.FieldList[1].Value)
+	assert.Equal(t, original, conditions)
+}

--- a/pkg/unify-query/query/structured/condition_normalize_test.go
+++ b/pkg/unify-query/query/structured/condition_normalize_test.go
@@ -53,13 +53,13 @@ func TestNormalizeCommaConditionValues(t *testing.T) {
 			},
 			wantValue: []string{"-4000,-3999,-3888"},
 		},
-		"拆分后不足两个有效值不拆分": {
+		"保留空候选": {
 			condition: ConditionField{
 				DimensionName: "result",
 				Operator:      ConditionEqual,
 				Value:         []string{"-4000,"},
 			},
-			wantValue: []string{"-4000,"},
+			wantValue: []string{"-4000", ""},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/unify-query/query/structured/condition_normalize_test.go
+++ b/pkg/unify-query/query/structured/condition_normalize_test.go
@@ -72,28 +72,3 @@ func TestNormalizeCommaConditionValues(t *testing.T) {
 		})
 	}
 }
-
-func TestNormalizeCommaConditions(t *testing.T) {
-	conditions := Conditions{
-		FieldList: []ConditionField{
-			{
-				DimensionName: "result",
-				Operator:      ConditionEqual,
-				Value:         []string{"-4000,-3999"},
-			},
-			{
-				DimensionName: "message",
-				Operator:      ConditionContains,
-				Value:         []string{"a,b"},
-			},
-		},
-		ConditionList: []string{ConditionAnd},
-	}
-	original := cloneConditions(conditions)
-
-	normalized := normalizeCommaConditions(conditions)
-
-	assert.Equal(t, []string{"-4000", "-3999"}, normalized.FieldList[0].Value)
-	assert.Equal(t, []string{"a,b"}, normalized.FieldList[1].Value)
-	assert.Equal(t, original, conditions)
-}

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -307,8 +307,7 @@ func (q *QueryTs) ToPromQL(ctx context.Context) (promQLString string, checkErr e
 		}
 
 		// 保留查询条件
-		conditions := normalizeCommaConditions(ql.Conditions)
-		matcher, _, err := conditions.ToProm()
+		matcher, _, err := ql.Conditions.ToProm()
 		if err != nil {
 			checkErr = err
 			return promQLString, checkErr
@@ -597,10 +596,6 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 	if q.DataSource == "" {
 		q.DataSource = BkMonitor
 	}
-	// 检索 addition 可能把多值 eq/ne 传成单个逗号串，进入存储分发前先规范化为多值数组。
-	// 例如 result="-4000,-3999,-3888" 会被拆成多个候选值，后续 ES/Doris 按既有多值逻辑生成 OR 条件。
-	allConditions = normalizeCommaConditionValues(allConditions)
-
 	// 如果是 BkSql 查询无需获取 tsdb 路由关系
 	if q.DataSource == BkData {
 		// 判断空间跟业务是否匹配
@@ -703,6 +698,10 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 		queryMetric.QueryList = []*metadata.Query{query}
 		return queryMetric, nil
 	}
+
+	// 检索 addition 可能把多值 eq/ne 传成单个逗号串，进入存储分发前先规范化为多值数组。
+	// 例如 result="-4000,-3999,-3888" 会被拆成多个候选值，后续 ES/Doris 按既有多值逻辑生成 OR 条件。
+	allConditions = normalizeCommaConditionValues(allConditions)
 
 	isSkipField := false
 	if metricName == "" || q.DataSource == BkLog || q.DataSource == BkApm {

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -253,11 +253,11 @@ func (q *QueryTs) ToQueryClusterMetric(ctx context.Context) (*metadata.QueryClus
 
 	// 结构定义转换
 	allConditions, err := qry.Conditions.AnalysisConditions()
-	queryConditions := allConditions.MetaDataAllConditions()
-
 	if err != nil {
 		return nil, err
 	}
+	allConditions = normalizeCommaConditionValues(allConditions)
+	queryConditions := allConditions.MetaDataAllConditions()
 
 	agg, err := qry.AggregateMethodList.ToQry(qry.Timezone)
 	if err != nil {
@@ -596,6 +596,9 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 	if q.DataSource == "" {
 		q.DataSource = BkMonitor
 	}
+	// 检索 addition 可能把多值 eq/ne 传成单个逗号串，进入存储分发前先规范化为多值数组。
+	// 例如 result="-4000,-3999,-3888" 会被拆成多个候选值，后续 ES/Doris 按既有多值逻辑生成 OR 条件。
+	allConditions = normalizeCommaConditionValues(allConditions)
 
 	// 如果是 BkSql 查询无需获取 tsdb 路由关系
 	if q.DataSource == BkData {

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -307,7 +307,8 @@ func (q *QueryTs) ToPromQL(ctx context.Context) (promQLString string, checkErr e
 		}
 
 		// 保留查询条件
-		matcher, _, err := ql.Conditions.ToProm()
+		conditions := normalizeCommaConditions(ql.Conditions)
+		matcher, _, err := conditions.ToProm()
 		if err != nil {
 			checkErr = err
 			return promQLString, checkErr

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -256,7 +256,9 @@ func (q *QueryTs) ToQueryClusterMetric(ctx context.Context) (*metadata.QueryClus
 	if err != nil {
 		return nil, err
 	}
-	allConditions = normalizeCommaConditionValues(allConditions)
+	if shouldNormalizeCommaConditionValues(ctx) {
+		allConditions = normalizeCommaConditionValues(allConditions)
+	}
 	queryConditions := allConditions.MetaDataAllConditions()
 
 	agg, err := qry.AggregateMethodList.ToQry(qry.Timezone)
@@ -699,9 +701,11 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 		return queryMetric, nil
 	}
 
-	// 检索 addition 可能把多值 eq/ne 传成单个逗号串，进入存储分发前先规范化为多值数组。
-	// 例如 result="-4000,-3999,-3888" 会被拆成多个候选值，后续 ES/Doris 按既有多值逻辑生成 OR 条件。
-	allConditions = normalizeCommaConditionValues(allConditions)
+	if shouldNormalizeCommaConditionValues(ctx) {
+		// 策略侧 addition 可能把多值 eq/ne 传成单个逗号串，进入存储分发前先规范化为多值数组。
+		// 例如 result="-4000,-3999,-3888" 会被拆成多个候选值，后续 ES/Doris 按既有多值逻辑生成 OR 条件。
+		allConditions = normalizeCommaConditionValues(allConditions)
+	}
 
 	isSkipField := false
 	if metricName == "" || q.DataSource == BkLog || q.DataSource == BkApm {
@@ -845,6 +849,10 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 	span.Set("query_metric_length", len(queryMetric.QueryList))
 
 	return queryMetric, nil
+}
+
+func shouldNormalizeCommaConditionValues(ctx context.Context) bool {
+	return metadata.GetUser(ctx).Source == "strategy"
 }
 
 func (q *Query) BuildMetadataQuery(

--- a/pkg/unify-query/query/structured/query_ts.go
+++ b/pkg/unify-query/query/structured/query_ts.go
@@ -256,9 +256,6 @@ func (q *QueryTs) ToQueryClusterMetric(ctx context.Context) (*metadata.QueryClus
 	if err != nil {
 		return nil, err
 	}
-	if shouldNormalizeCommaConditionValues(ctx) {
-		allConditions = normalizeCommaConditionValues(allConditions)
-	}
 	queryConditions := allConditions.MetaDataAllConditions()
 
 	agg, err := qry.AggregateMethodList.ToQry(qry.Timezone)
@@ -701,12 +698,6 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 		return queryMetric, nil
 	}
 
-	if shouldNormalizeCommaConditionValues(ctx) {
-		// 策略侧 addition 可能把多值 eq/ne 传成单个逗号串，进入存储分发前先规范化为多值数组。
-		// 例如 result="-4000,-3999,-3888" 会被拆成多个候选值，后续 ES/Doris 按既有多值逻辑生成 OR 条件。
-		allConditions = normalizeCommaConditionValues(allConditions)
-	}
-
 	isSkipField := false
 	if metricName == "" || q.DataSource == BkLog || q.DataSource == BkApm {
 		isSkipField = true
@@ -741,7 +732,24 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 		storageIDs := tsDB.GetStorageIDs(qp.Start, qp.End)
 
 		for _, storageID := range storageIDs {
-			query := q.BuildMetadataQuery(ctx, tsDB, allConditions)
+			storageType := tsDB.StorageType
+			if storageType == "" {
+				stg, _ := tsdb.GetStorage(ctx, storageID)
+				if stg != nil {
+					storageType = stg.Type
+				}
+			}
+
+			queryConditions := allConditions
+			// 策略 addition 会把日志多值条件编码成单个逗号串；只在 BKLog 的 ES/Doris 日志查询里拆分，
+			// 避免影响其他数据源或存储的逗号字面值精确匹配。
+			if q.DataSource == BkLog &&
+				(storageType == metadata.ElasticsearchStorageType ||
+					(storageType == metadata.BkSqlStorageType && tsDB.Measurement == metadata.DorisStorageType)) {
+				queryConditions = normalizeCommaConditionValues(allConditions)
+			}
+
+			query := q.BuildMetadataQuery(ctx, tsDB, queryConditions)
 			if query == nil {
 				continue
 			}
@@ -753,10 +761,7 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 
 			// 如果没有指定查询类型，则通过 storageID 获取
 			if query.StorageType == "" {
-				stg, _ := tsdb.GetStorage(ctx, query.StorageID)
-				if stg != nil {
-					query.StorageType = stg.Type
-				}
+				query.StorageType = storageType
 			}
 			if query.StorageType == "" {
 				return nil, fmt.Errorf("storageType is empty with %v", query.StorageID)
@@ -849,10 +854,6 @@ func (q *Query) ToQueryMetric(ctx context.Context, spaceUid string, tsDBs TsDBs)
 	span.Set("query_metric_length", len(queryMetric.QueryList))
 
 	return queryMetric, nil
-}
-
-func shouldNormalizeCommaConditionValues(ctx context.Context) bool {
-	return metadata.GetUser(ctx).Source == "strategy"
 }
 
 func (q *Query) BuildMetadataQuery(

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -226,7 +226,7 @@ func TestQueryToMetric(t *testing.T) {
 		"test comma condition value query": {
 			querySource: "strategy:unit-test",
 			query: &Query{
-				DataSource:    BkMonitor,
+				DataSource:    BkLog,
 				FieldName:     field,
 				ReferenceName: "a",
 				Conditions: Conditions{
@@ -251,7 +251,7 @@ func TestQueryToMetric(t *testing.T) {
 			metric: &md.QueryMetric{
 				QueryList: md.QueryList{
 					{
-						DataSource:  BkMonitor,
+						DataSource:  BkLog,
 						TableID:     "result_table.es",
 						DB:          "es_index",
 						StorageType: md.ElasticsearchStorageType,
@@ -281,6 +281,7 @@ func TestQueryToMetric(t *testing.T) {
 			},
 		},
 		"test comma literal condition value query": {
+			querySource: "strategy:unit-test",
 			query: &Query{
 				DataSource:    BkMonitor,
 				FieldName:     field,

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -284,6 +284,15 @@ func TestQueryToMetric(t *testing.T) {
 				TableID:       "2_table_id",
 				FieldName:     "kube_.*",
 				ReferenceName: "a",
+				Conditions: Conditions{
+					FieldList: []ConditionField{
+						{
+							DimensionName: "result",
+							Value:         []string{"a,b"},
+							Operator:      ConditionEqual,
+						},
+					},
+				},
 			},
 			metric: &md.QueryMetric{
 				QueryList: md.QueryList{
@@ -293,6 +302,15 @@ func TestQueryToMetric(t *testing.T) {
 						StorageType: md.BkSqlStorageType,
 						DB:          "2_table_id",
 						Field:       "kube_.*",
+						AllConditions: md.AllConditions{
+							{
+								{
+									DimensionName: "result",
+									Value:         []string{"a,b"},
+									Operator:      ConditionEqual,
+								},
+							},
+						},
 					},
 				},
 				ReferenceName: "a",
@@ -560,7 +578,7 @@ func TestQueryTs_StructToPromQL_WithTableIDConditions(t *testing.T) {
 	})
 }
 
-func TestQueryTs_ToPromQL_NormalizeCommaConditionValues(t *testing.T) {
+func TestQueryTs_ToPromQL_PreserveCommaConditionValue(t *testing.T) {
 	ts := &QueryTs{
 		QueryList: []*Query{
 			{
@@ -582,8 +600,8 @@ func TestQueryTs_ToPromQL_NormalizeCommaConditionValues(t *testing.T) {
 
 	result, err := ts.ToPromQL(context.TODO())
 	require.NoError(t, err)
-	assert.Contains(t, result, `result=~"^(-4000|-3999)$"`)
-	assert.NotContains(t, result, `result="-4000,-3999"`)
+	assert.Contains(t, result, `result="-4000,-3999"`)
+	assert.NotContains(t, result, `result=~"^(-4000|-3999)$"`)
 }
 
 func TestQueryTs_ToQueryReference(t *testing.T) {

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -222,6 +222,62 @@ func TestQueryToMetric(t *testing.T) {
 				IsCount:       false,
 			},
 		},
+		"test comma condition value query": {
+			query: &Query{
+				DataSource:    BkMonitor,
+				FieldName:     field,
+				ReferenceName: "a",
+				Conditions: Conditions{
+					FieldList: []ConditionField{
+						{
+							DimensionName: "result",
+							Value:         []string{"-4000,-3999,-3888"},
+							Operator:      ConditionEqual,
+						},
+					},
+				},
+			},
+			tsDbs: TsDBs{
+				{
+					TableID:     "result_table.es",
+					StorageID:   storageID,
+					StorageType: md.ElasticsearchStorageType,
+					DB:          "es_index",
+					Measurement: field,
+				},
+			},
+			metric: &md.QueryMetric{
+				QueryList: md.QueryList{
+					{
+						DataSource:  BkMonitor,
+						TableID:     "result_table.es",
+						DB:          "es_index",
+						StorageType: md.ElasticsearchStorageType,
+						StorageID:   storageID,
+						Measurement: field,
+						Measurements: []string{
+							field,
+						},
+						Field: field,
+						AllConditions: md.AllConditions{
+							{
+								{
+									DimensionName: "result",
+									Value:         []string{"-4000", "-3999", "-3888"},
+									Operator:      ConditionEqual,
+								},
+							},
+						},
+						Condition:      `((result='-4000' or result='-3999') or result='-3888')`,
+						VmCondition:    `result=~"^(-4000|-3999|-3888)$", __name__="kube_pod_info_value"`,
+						VmConditionNum: 2,
+						Aggregates:     make(md.Aggregates, 0),
+					},
+				},
+				ReferenceName: "a",
+				MetricName:    field,
+			},
+		},
 		"test bk data match table id": {
 			query: &Query{
 				DataSource:    BkData,

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -45,10 +45,11 @@ func TestQueryToMetric(t *testing.T) {
 	end := "1741060043"
 
 	testCases := map[string]struct {
-		spaceUID string
-		query    *Query
-		metric   *md.QueryMetric
-		tsDbs    TsDBs
+		spaceUID    string
+		querySource string
+		query       *Query
+		metric      *md.QueryMetric
+		tsDbs       TsDBs
 	}{
 		"test table id query": {
 			query: &Query{
@@ -223,6 +224,7 @@ func TestQueryToMetric(t *testing.T) {
 			},
 		},
 		"test comma condition value query": {
+			querySource: "strategy:unit-test",
 			query: &Query{
 				DataSource:    BkMonitor,
 				FieldName:     field,
@@ -270,6 +272,62 @@ func TestQueryToMetric(t *testing.T) {
 						},
 						Condition:      `((result='-4000' or result='-3999') or result='-3888')`,
 						VmCondition:    `result=~"^(-4000|-3999|-3888)$", __name__="kube_pod_info_value"`,
+						VmConditionNum: 2,
+						Aggregates:     make(md.Aggregates, 0),
+					},
+				},
+				ReferenceName: "a",
+				MetricName:    field,
+			},
+		},
+		"test comma literal condition value query": {
+			query: &Query{
+				DataSource:    BkMonitor,
+				FieldName:     field,
+				ReferenceName: "a",
+				Conditions: Conditions{
+					FieldList: []ConditionField{
+						{
+							DimensionName: "result",
+							Value:         []string{"us-east,blue"},
+							Operator:      ConditionEqual,
+						},
+					},
+				},
+			},
+			tsDbs: TsDBs{
+				{
+					TableID:     "result_table.es",
+					StorageID:   storageID,
+					StorageType: md.ElasticsearchStorageType,
+					DB:          "es_index",
+					Measurement: field,
+				},
+			},
+			metric: &md.QueryMetric{
+				QueryList: md.QueryList{
+					{
+						DataSource:  BkMonitor,
+						TableID:     "result_table.es",
+						DB:          "es_index",
+						StorageType: md.ElasticsearchStorageType,
+						StorageID:   storageID,
+						Measurement: field,
+						Measurements: []string{
+							field,
+						},
+						Field: field,
+						AllConditions: md.AllConditions{
+							{
+								{
+									DimensionName: "result",
+									Value:         []string{"us-east,blue"},
+									Operator:      ConditionEqual,
+								},
+							},
+						},
+						Condition:      `result='us-east,blue'`,
+						VmCondition:    `result="us-east,blue", __name__="kube_pod_info_value"`,
 						VmConditionNum: 2,
 						Aggregates:     make(md.Aggregates, 0),
 					},
@@ -349,6 +407,9 @@ func TestQueryToMetric(t *testing.T) {
 			spaceUID := c.spaceUID
 			if spaceUID == "" {
 				spaceUID = influxdb.SpaceUid
+			}
+			if c.querySource != "" {
+				md.SetUser(ctx, &md.User{Key: c.querySource})
 			}
 
 			metric, err := c.query.ToQueryMetric(ctx, spaceUID, c.tsDbs)

--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -560,6 +560,32 @@ func TestQueryTs_StructToPromQL_WithTableIDConditions(t *testing.T) {
 	})
 }
 
+func TestQueryTs_ToPromQL_NormalizeCommaConditionValues(t *testing.T) {
+	ts := &QueryTs{
+		QueryList: []*Query{
+			{
+				FieldName:     "metric_name",
+				ReferenceName: "a",
+				Conditions: Conditions{
+					FieldList: []ConditionField{
+						{
+							DimensionName: "result",
+							Operator:      ConditionEqual,
+							Value:         []string{"-4000,-3999"},
+						},
+					},
+				},
+			},
+		},
+		MetricMerge: "a",
+	}
+
+	result, err := ts.ToPromQL(context.TODO())
+	require.NoError(t, err)
+	assert.Contains(t, result, `result=~"^(-4000|-3999)$"`)
+	assert.NotContains(t, result, `result="-4000,-3999"`)
+}
+
 func TestQueryTs_ToQueryReference(t *testing.T) {
 	mock.Init()
 	ctx := md.InitHashID(context.Background())


### PR DESCRIPTION
## 背景

检索 addition 中可能把多值条件传成单个逗号串，例如 `result="-4000,-3999,-3888"`。对于 keyword 字段，ES/BKLog 不会按逗号自动拆分，实际会按完整字符串匹配，和策略侧 `is one of ["-4000", "-3999", "-3888"]` 的语义不一致。

## 变更

- 在 structured 查询条件层统一归一化 `eq` / `ne` 的单值逗号串，拆成多值候选。
