### PR TITLE
fix: (unify-query)修复 ES 正则条件兼容语义

### DIFF
--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -12,6 +12,9 @@ package esregexpcompat
 import "strings"
 
 const (
+	// negativeLookaheadPrefix/negativeLookaheadSuffix 只识别用于表达“字段值不包含某段内容”的
+	// 固定前缀/后缀形式，例如 ^(?!.*foo).* 或 ^(?!.*foo).*$。
+	// ES regexp 不支持 lookahead，命中该形态后会改写为字段存在且不匹配 .*foo.*。
 	negativeLookaheadPrefix = `^(?!.*`
 	negativeLookaheadSuffix = `).*`
 )
@@ -119,15 +122,15 @@ func splitTopLevelAlternation(pattern string) ([]string, bool) {
 	return alternatives, true
 }
 
-// extractNegativeLookahead 提取历史策略中出现的基础负向前瞻形式。
-// 返回的 inner 是被排除的内容，例如 ^(?!.*foo).* 返回 foo；
-// 更复杂的负向前瞻不在当前兼容范围内，会返回 ok=false 并走普通正则改写。
+// extractNegativeLookahead 提取“字段值不包含某段内容”的固定前缀/后缀形式。
+// 例如 ^(?!.*foo).* 返回 foo；其他不满足固定形态的表达式返回 ok=false，
+// 继续走普通正则改写，避免把更复杂的正则误改成反向匹配。
 func extractNegativeLookahead(pattern string) (string, bool) {
 	if !strings.HasPrefix(pattern, negativeLookaheadPrefix) {
 		return "", false
 	}
 
-	// 当前只兼容历史策略中出现的基础形式：^(?!.*foo).* 或 ^(?!.*foo).*$。
+	// 只处理 ^(?!.*foo).* 或 ^(?!.*foo).*$ 这两种固定形态。
 	body := strings.TrimPrefix(pattern, negativeLookaheadPrefix)
 	switch {
 	case strings.HasSuffix(body, negativeLookaheadSuffix+"$"):

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -16,9 +16,13 @@ const (
 	negativeLookaheadSuffix = `).*`
 )
 
-// RewriteResult 表示 ES regexp 兼容改写后的表达式，以及是否需要改成反向正则条件。
+// RewriteResult 表示 ES regexp 兼容改写结果。
 type RewriteResult struct {
-	Pattern  string
+	// Pattern 是可以下发给 ES regexp query 的表达式。
+	Pattern string
+	// Negative 表示 Pattern 需要作为反向 regexp 条件使用。
+	// 例如 ^(?!.*foo).* 会被改写成 Pattern=.*foo.* 且 Negative=true；
+	// 调用方应表达为“字段存在且不匹配 Pattern”，以保留原正则“字段值不包含 foo”的语义。
 	Negative bool
 }
 
@@ -42,6 +46,8 @@ func Rewrite(pattern string) RewriteResult {
 	return RewriteResult{Pattern: rewriteSinglePattern(pattern)}
 }
 
+// rewriteSinglePattern 改写不含顶层 | 的单个正则分支。
+// 未显式锚定的分支会补齐 .* 以模拟历史包含匹配；^/$ 锚点会被转换成 ES 整值匹配下的前缀/后缀约束。
 func rewriteSinglePattern(pattern string) string {
 	if isExplicitContains(pattern) {
 		return pattern
@@ -62,8 +68,9 @@ func rewriteSinglePattern(pattern string) string {
 	}
 }
 
+// splitTopLevelAlternation 按最外层未转义的 | 拆分正则。
+// 括号、字符类和转义后的 | 不拆分，避免破坏原有正则结构。
 func splitTopLevelAlternation(pattern string) ([]string, bool) {
-	// 只识别最外层未转义的 |；括号、字符类或转义后的 | 都保持原有正则语义。
 	var (
 		alternatives []string
 		start        int
@@ -112,6 +119,9 @@ func splitTopLevelAlternation(pattern string) ([]string, bool) {
 	return alternatives, true
 }
 
+// extractNegativeLookahead 提取历史策略中出现的基础负向前瞻形式。
+// 返回的 inner 是被排除的内容，例如 ^(?!.*foo).* 返回 foo；
+// 更复杂的负向前瞻不在当前兼容范围内，会返回 ok=false 并走普通正则改写。
 func extractNegativeLookahead(pattern string) (string, bool) {
 	if !strings.HasPrefix(pattern, negativeLookaheadPrefix) {
 		return "", false
@@ -134,10 +144,12 @@ func extractNegativeLookahead(pattern string) (string, bool) {
 	return body, true
 }
 
+// hasUnescapedPrefixAnchor 判断正则是否以未转义的 ^ 锚定开头。
 func hasUnescapedPrefixAnchor(pattern string) bool {
 	return strings.HasPrefix(pattern, "^")
 }
 
+// hasUnescapedSuffixAnchor 判断正则是否以未转义的 $ 锚定结尾。
 func hasUnescapedSuffixAnchor(pattern string) bool {
 	if !strings.HasSuffix(pattern, "$") {
 		return false
@@ -151,10 +163,12 @@ func hasUnescapedSuffixAnchor(pattern string) bool {
 	return backslashes%2 == 0
 }
 
+// isExplicitContains 判断表达式是否已经显式写成 .*foo.* 这类包含匹配。
 func isExplicitContains(pattern string) bool {
 	return hasUnescapedPrefixLiteral(pattern, ".*") && hasUnescapedSuffixLiteral(pattern, ".*")
 }
 
+// addContainsPrefix 在缺少前置 .* 时补齐包含匹配前缀。
 func addContainsPrefix(pattern string) string {
 	if hasUnescapedPrefixLiteral(pattern, ".*") {
 		return pattern
@@ -162,6 +176,7 @@ func addContainsPrefix(pattern string) string {
 	return ".*" + pattern
 }
 
+// addContainsSuffix 在缺少后置 .* 时补齐包含匹配后缀。
 func addContainsSuffix(pattern string) string {
 	if hasUnescapedSuffixLiteral(pattern, ".*") {
 		return pattern
@@ -169,10 +184,12 @@ func addContainsSuffix(pattern string) string {
 	return pattern + ".*"
 }
 
+// hasUnescapedPrefixLiteral 判断 pattern 是否以指定 literal 开头。
 func hasUnescapedPrefixLiteral(pattern string, literal string) bool {
 	return strings.HasPrefix(pattern, literal)
 }
 
+// hasUnescapedSuffixLiteral 判断 pattern 是否以未转义的指定 literal 结尾。
 func hasUnescapedSuffixLiteral(pattern string, literal string) bool {
 	if !strings.HasSuffix(pattern, literal) {
 		return false
@@ -190,10 +207,12 @@ func hasUnescapedSuffixLiteral(pattern string, literal string) bool {
 	return backslashes%2 == 0
 }
 
+// trimPrefixAnchor 去掉开头的 ^ 锚点。
 func trimPrefixAnchor(pattern string) string {
 	return strings.TrimPrefix(pattern, "^")
 }
 
+// trimSuffixAnchor 去掉未转义的结尾 $ 锚点。
 func trimSuffixAnchor(pattern string) string {
 	if hasUnescapedSuffixAnchor(pattern) {
 		return pattern[:len(pattern)-1]

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -33,20 +33,25 @@ type RewriteResult struct {
 func Rewrite(pattern string) RewriteResult {
 	if inner, ok := extractNegativeLookahead(pattern); ok {
 		return RewriteResult{
-			Pattern:  ".*" + inner + ".*",
+			Pattern:  rewritePositivePattern(inner),
 			Negative: true,
 		}
 	}
 
+	return RewriteResult{Pattern: rewritePositivePattern(pattern)}
+}
+
+// rewritePositivePattern 将正向 regexp 改写为 ES 整值匹配下的等价 pattern。
+func rewritePositivePattern(pattern string) string {
 	if alternatives, ok := splitTopLevelAlternation(pattern); ok {
 		rewritten := make([]string, 0, len(alternatives))
 		for _, alternative := range alternatives {
 			rewritten = append(rewritten, rewriteSinglePattern(alternative))
 		}
-		return RewriteResult{Pattern: "(" + strings.Join(rewritten, "|") + ")"}
+		return "(" + strings.Join(rewritten, "|") + ")"
 	}
 
-	return RewriteResult{Pattern: rewriteSinglePattern(pattern)}
+	return rewriteSinglePattern(pattern)
 }
 
 // rewriteSinglePattern 改写不含顶层 | 的单个正则分支。

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -14,7 +14,7 @@ import "strings"
 const (
 	// negativeLookaheadPrefix/negativeLookaheadSuffix 只识别用于表达“字段值不包含某段内容”的
 	// 固定前缀/后缀形式，例如 ^(?!.*foo).* 或 ^(?!.*foo).*$。
-	// ES regexp 不支持 lookahead，命中该形态后会改写为字段存在且不匹配 .*foo.*。
+	// ES regexp 不支持该不包含前缀形式，命中该形态后会改写为字段存在且不匹配 .*foo.*。
 	negativeLookaheadPrefix = `^(?!.*`
 	negativeLookaheadSuffix = `).*`
 )

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -46,8 +46,59 @@ func Rewrite(pattern string) RewriteResult {
 	case hasSuffix:
 		return RewriteResult{Pattern: ".*" + trimSuffixAnchor(pattern)}
 	default:
-		return RewriteResult{Pattern: ".*" + pattern + ".*"}
+		return RewriteResult{Pattern: ".*" + wrapTopLevelAlternation(pattern) + ".*"}
 	}
+}
+
+func wrapTopLevelAlternation(pattern string) string {
+	if !hasTopLevelAlternation(pattern) {
+		return pattern
+	}
+	// ES regexp 是整值匹配，补齐前后 .* 时需要把顶层或表达式作为整体处理。
+	return "(" + pattern + ")"
+}
+
+func hasTopLevelAlternation(pattern string) bool {
+	// 只识别最外层未转义的 |；括号、字符类或转义后的 | 都保持原有正则语义。
+	var (
+		parenDepth   int
+		bracketDepth int
+		escaped      bool
+	)
+	for _, r := range pattern {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+
+		switch r {
+		case '[':
+			if bracketDepth == 0 {
+				bracketDepth = 1
+			}
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '(':
+			if bracketDepth == 0 {
+				parenDepth++
+			}
+		case ')':
+			if bracketDepth == 0 && parenDepth > 0 {
+				parenDepth--
+			}
+		case '|':
+			if bracketDepth == 0 && parenDepth == 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func extractNegativeLookahead(pattern string) (string, bool) {

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -31,8 +31,20 @@ func Rewrite(pattern string) RewriteResult {
 		}
 	}
 
+	if alternatives, ok := splitTopLevelAlternation(pattern); ok {
+		rewritten := make([]string, 0, len(alternatives))
+		for _, alternative := range alternatives {
+			rewritten = append(rewritten, rewriteSinglePattern(alternative))
+		}
+		return RewriteResult{Pattern: "(" + strings.Join(rewritten, "|") + ")"}
+	}
+
+	return RewriteResult{Pattern: rewriteSinglePattern(pattern)}
+}
+
+func rewriteSinglePattern(pattern string) string {
 	if isExplicitContains(pattern) {
-		return RewriteResult{Pattern: pattern}
+		return pattern
 	}
 
 	hasPrefix := hasUnescapedPrefixAnchor(pattern)
@@ -40,32 +52,26 @@ func Rewrite(pattern string) RewriteResult {
 
 	switch {
 	case hasPrefix && hasSuffix:
-		return RewriteResult{Pattern: trimSuffixAnchor(trimPrefixAnchor(pattern))}
+		return trimSuffixAnchor(trimPrefixAnchor(pattern))
 	case hasPrefix:
-		return RewriteResult{Pattern: trimPrefixAnchor(pattern) + ".*"}
+		return addContainsSuffix(trimPrefixAnchor(pattern))
 	case hasSuffix:
-		return RewriteResult{Pattern: ".*" + trimSuffixAnchor(pattern)}
+		return addContainsPrefix(trimSuffixAnchor(pattern))
 	default:
-		return RewriteResult{Pattern: ".*" + wrapTopLevelAlternation(pattern) + ".*"}
+		return addContainsSuffix(addContainsPrefix(pattern))
 	}
 }
 
-func wrapTopLevelAlternation(pattern string) string {
-	if !hasTopLevelAlternation(pattern) {
-		return pattern
-	}
-	// ES regexp 是整值匹配，补齐前后 .* 时需要把顶层或表达式作为整体处理。
-	return "(" + pattern + ")"
-}
-
-func hasTopLevelAlternation(pattern string) bool {
+func splitTopLevelAlternation(pattern string) ([]string, bool) {
 	// 只识别最外层未转义的 |；括号、字符类或转义后的 | 都保持原有正则语义。
 	var (
+		alternatives []string
+		start        int
 		parenDepth   int
 		bracketDepth int
 		escaped      bool
 	)
-	for _, r := range pattern {
+	for i, r := range pattern {
 		if escaped {
 			escaped = false
 			continue
@@ -94,11 +100,16 @@ func hasTopLevelAlternation(pattern string) bool {
 			}
 		case '|':
 			if bracketDepth == 0 && parenDepth == 0 {
-				return true
+				alternatives = append(alternatives, pattern[start:i])
+				start = i + len(string(r))
 			}
 		}
 	}
-	return false
+	if len(alternatives) == 0 {
+		return nil, false
+	}
+	alternatives = append(alternatives, pattern[start:])
+	return alternatives, true
 }
 
 func extractNegativeLookahead(pattern string) (string, bool) {
@@ -142,6 +153,20 @@ func hasUnescapedSuffixAnchor(pattern string) bool {
 
 func isExplicitContains(pattern string) bool {
 	return hasUnescapedPrefixLiteral(pattern, ".*") && hasUnescapedSuffixLiteral(pattern, ".*")
+}
+
+func addContainsPrefix(pattern string) string {
+	if hasUnescapedPrefixLiteral(pattern, ".*") {
+		return pattern
+	}
+	return ".*" + pattern
+}
+
+func addContainsSuffix(pattern string) string {
+	if hasUnescapedSuffixLiteral(pattern, ".*") {
+		return pattern
+	}
+	return pattern + ".*"
 }
 
 func hasUnescapedPrefixLiteral(pattern string, literal string) bool {

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -1,0 +1,126 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package esregexpcompat
+
+import "strings"
+
+const (
+	negativeLookaheadPrefix = `^(?!.*`
+	negativeLookaheadSuffix = `).*`
+)
+
+// RewriteResult 表示 ES regexp 兼容改写后的表达式，以及是否需要改成反向正则条件。
+type RewriteResult struct {
+	Pattern  string
+	Negative bool
+}
+
+// Rewrite 将 Python/Doris 搜索语义下的基础正则，改写成 ES regexp 整值匹配语义。
+func Rewrite(pattern string) RewriteResult {
+	if inner, ok := extractNegativeLookahead(pattern); ok {
+		return RewriteResult{
+			Pattern:  ".*" + inner + ".*",
+			Negative: true,
+		}
+	}
+
+	if isExplicitContains(pattern) {
+		return RewriteResult{Pattern: pattern}
+	}
+
+	hasPrefix := hasUnescapedPrefixAnchor(pattern)
+	hasSuffix := hasUnescapedSuffixAnchor(pattern)
+
+	switch {
+	case hasPrefix && hasSuffix:
+		return RewriteResult{Pattern: trimSuffixAnchor(trimPrefixAnchor(pattern))}
+	case hasPrefix:
+		return RewriteResult{Pattern: trimPrefixAnchor(pattern) + ".*"}
+	case hasSuffix:
+		return RewriteResult{Pattern: ".*" + trimSuffixAnchor(pattern)}
+	default:
+		return RewriteResult{Pattern: ".*" + pattern + ".*"}
+	}
+}
+
+func extractNegativeLookahead(pattern string) (string, bool) {
+	if !strings.HasPrefix(pattern, negativeLookaheadPrefix) {
+		return "", false
+	}
+
+	// 当前只兼容历史策略中出现的基础形式：^(?!.*foo).* 或 ^(?!.*foo).*$。
+	body := strings.TrimPrefix(pattern, negativeLookaheadPrefix)
+	switch {
+	case strings.HasSuffix(body, negativeLookaheadSuffix+"$"):
+		body = strings.TrimSuffix(body, negativeLookaheadSuffix+"$")
+	case strings.HasSuffix(body, negativeLookaheadSuffix):
+		body = strings.TrimSuffix(body, negativeLookaheadSuffix)
+	default:
+		return "", false
+	}
+
+	if body == "" {
+		return "", false
+	}
+	return body, true
+}
+
+func hasUnescapedPrefixAnchor(pattern string) bool {
+	return strings.HasPrefix(pattern, "^")
+}
+
+func hasUnescapedSuffixAnchor(pattern string) bool {
+	if !strings.HasSuffix(pattern, "$") {
+		return false
+	}
+
+	// 末尾 $ 前有奇数个连续反斜杠时，说明 $ 是被转义的普通字符。
+	backslashes := 0
+	for i := len(pattern) - 2; i >= 0 && pattern[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 0
+}
+
+func isExplicitContains(pattern string) bool {
+	return hasUnescapedPrefixLiteral(pattern, ".*") && hasUnescapedSuffixLiteral(pattern, ".*")
+}
+
+func hasUnescapedPrefixLiteral(pattern string, literal string) bool {
+	return strings.HasPrefix(pattern, literal)
+}
+
+func hasUnescapedSuffixLiteral(pattern string, literal string) bool {
+	if !strings.HasSuffix(pattern, literal) {
+		return false
+	}
+	start := len(pattern) - len(literal)
+	if start == 0 {
+		return true
+	}
+
+	// literal 起始位置前有奇数个反斜杠时，说明该 literal 被转义。
+	backslashes := 0
+	for i := start - 1; i >= 0 && pattern[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 0
+}
+
+func trimPrefixAnchor(pattern string) string {
+	return strings.TrimPrefix(pattern, "^")
+}
+
+func trimSuffixAnchor(pattern string) string {
+	if hasUnescapedSuffixAnchor(pattern) {
+		return pattern[:len(pattern)-1]
+	}
+	return pattern
+}

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -77,12 +77,12 @@ func TestRewrite(t *testing.T) {
 			pattern:     "^foo.*",
 			wantPattern: "foo.*",
 		},
-		"负向前瞻改写为反向正则": {
+		"不包含语义固定前缀形式改写为反向正则": {
 			pattern:      "^(?!.*idip).*",
 			wantPattern:  ".*idip.*",
 			wantNegative: true,
 		},
-		"带结尾锚点的负向前瞻改写为反向正则": {
+		"不包含语义固定前缀和结尾锚点形式改写为反向正则": {
 			pattern:      "^(?!.*idip).*$",
 			wantPattern:  ".*idip.*",
 			wantNegative: true,

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -24,6 +24,18 @@ func TestRewrite(t *testing.T) {
 			pattern:  "a.*b",
 			expected: RewriteResult{Pattern: ".*a.*b.*"},
 		},
+		"顶层或表达式按整体补齐包含匹配": {
+			pattern:  "foo|bar",
+			expected: RewriteResult{Pattern: ".*(foo|bar).*"},
+		},
+		"括号内或表达式不重复包裹": {
+			pattern:  "(foo|bar)",
+			expected: RewriteResult{Pattern: ".*(foo|bar).*"},
+		},
+		"字符类内竖线不视为顶层或表达式": {
+			pattern:  "[a|b]",
+			expected: RewriteResult{Pattern: ".*[a|b].*"},
+		},
 		"前缀锚点改写为整值前缀匹配": {
 			pattern:  "^foo",
 			expected: RewriteResult{Pattern: "foo.*"},

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -25,9 +25,21 @@ func TestRewrite(t *testing.T) {
 			pattern:     "a.*b",
 			wantPattern: ".*a.*b.*",
 		},
-		"顶层或表达式按整体补齐包含匹配": {
+		"顶层或表达式按分支补齐包含匹配": {
 			pattern:     "foo|bar",
-			wantPattern: ".*(foo|bar).*",
+			wantPattern: "(.*foo.*|.*bar.*)",
+		},
+		"顶层或表达式按分支保留锚点语义": {
+			pattern:     "^foo|bar",
+			wantPattern: "(foo.*|.*bar.*)",
+		},
+		"顶层或表达式按分支处理后缀锚点": {
+			pattern:     "foo|bar$",
+			wantPattern: "(.*foo.*|.*bar)",
+		},
+		"顶层或表达式按分支处理显式包含": {
+			pattern:     ".*foo|bar.*",
+			wantPattern: "(.*foo.*|.*bar.*)",
 		},
 		"括号内或表达式不重复包裹": {
 			pattern:     "(foo|bar)",
@@ -52,6 +64,18 @@ func TestRewrite(t *testing.T) {
 		"已显式包含匹配时保持不变": {
 			pattern:     ".*foo.*",
 			wantPattern: ".*foo.*",
+		},
+		"已有单侧前缀包含时只补齐后缀": {
+			pattern:     ".*foo",
+			wantPattern: ".*foo.*",
+		},
+		"已有单侧后缀包含时只补齐前缀": {
+			pattern:     "foo.*",
+			wantPattern: ".*foo.*",
+		},
+		"前缀锚点后已有后缀包含时不重复补齐": {
+			pattern:     "^foo.*",
+			wantPattern: "foo.*",
 		},
 		"负向前瞻改写为反向正则": {
 			pattern:      "^(?!.*idip).*",

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -1,0 +1,69 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package esregexpcompat
+
+import "testing"
+
+func TestRewrite(t *testing.T) {
+	tests := map[string]struct {
+		pattern  string
+		expected RewriteResult
+	}{
+		"普通文本按包含匹配补齐": {
+			pattern:  "TypeError",
+			expected: RewriteResult{Pattern: ".*TypeError.*"},
+		},
+		"普通正则按包含匹配补齐": {
+			pattern:  "a.*b",
+			expected: RewriteResult{Pattern: ".*a.*b.*"},
+		},
+		"前缀锚点改写为整值前缀匹配": {
+			pattern:  "^foo",
+			expected: RewriteResult{Pattern: "foo.*"},
+		},
+		"后缀锚点改写为整值后缀匹配": {
+			pattern:  "foo$",
+			expected: RewriteResult{Pattern: ".*foo"},
+		},
+		"首尾锚点改写为整值匹配": {
+			pattern:  "^foo$",
+			expected: RewriteResult{Pattern: "foo"},
+		},
+		"已显式包含匹配时保持不变": {
+			pattern:  ".*foo.*",
+			expected: RewriteResult{Pattern: ".*foo.*"},
+		},
+		"负向前瞻改写为反向正则": {
+			pattern:  "^(?!.*idip).*",
+			expected: RewriteResult{Pattern: ".*idip.*", Negative: true},
+		},
+		"带结尾锚点的负向前瞻改写为反向正则": {
+			pattern:  "^(?!.*idip).*$",
+			expected: RewriteResult{Pattern: ".*idip.*", Negative: true},
+		},
+		"转义前缀锚点按普通包含处理": {
+			pattern:  `\^foo`,
+			expected: RewriteResult{Pattern: `.*\^foo.*`},
+		},
+		"转义后缀锚点按普通包含处理": {
+			pattern:  `foo\$`,
+			expected: RewriteResult{Pattern: `.*foo\$.*`},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Rewrite(tt.pattern)
+			if got != tt.expected {
+				t.Fatalf("Rewrite(%q) = %+v, want %+v", tt.pattern, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -13,68 +13,74 @@ import "testing"
 
 func TestRewrite(t *testing.T) {
 	tests := map[string]struct {
-		pattern  string
-		expected RewriteResult
+		pattern      string
+		wantPattern  string
+		wantNegative bool
 	}{
 		"普通文本按包含匹配补齐": {
-			pattern:  "TypeError",
-			expected: RewriteResult{Pattern: ".*TypeError.*"},
+			pattern:     "TypeError",
+			wantPattern: ".*TypeError.*",
 		},
 		"普通正则按包含匹配补齐": {
-			pattern:  "a.*b",
-			expected: RewriteResult{Pattern: ".*a.*b.*"},
+			pattern:     "a.*b",
+			wantPattern: ".*a.*b.*",
 		},
 		"顶层或表达式按整体补齐包含匹配": {
-			pattern:  "foo|bar",
-			expected: RewriteResult{Pattern: ".*(foo|bar).*"},
+			pattern:     "foo|bar",
+			wantPattern: ".*(foo|bar).*",
 		},
 		"括号内或表达式不重复包裹": {
-			pattern:  "(foo|bar)",
-			expected: RewriteResult{Pattern: ".*(foo|bar).*"},
+			pattern:     "(foo|bar)",
+			wantPattern: ".*(foo|bar).*",
 		},
 		"字符类内竖线不视为顶层或表达式": {
-			pattern:  "[a|b]",
-			expected: RewriteResult{Pattern: ".*[a|b].*"},
+			pattern:     "[a|b]",
+			wantPattern: ".*[a|b].*",
 		},
 		"前缀锚点改写为整值前缀匹配": {
-			pattern:  "^foo",
-			expected: RewriteResult{Pattern: "foo.*"},
+			pattern:     "^foo",
+			wantPattern: "foo.*",
 		},
 		"后缀锚点改写为整值后缀匹配": {
-			pattern:  "foo$",
-			expected: RewriteResult{Pattern: ".*foo"},
+			pattern:     "foo$",
+			wantPattern: ".*foo",
 		},
 		"首尾锚点改写为整值匹配": {
-			pattern:  "^foo$",
-			expected: RewriteResult{Pattern: "foo"},
+			pattern:     "^foo$",
+			wantPattern: "foo",
 		},
 		"已显式包含匹配时保持不变": {
-			pattern:  ".*foo.*",
-			expected: RewriteResult{Pattern: ".*foo.*"},
+			pattern:     ".*foo.*",
+			wantPattern: ".*foo.*",
 		},
 		"负向前瞻改写为反向正则": {
-			pattern:  "^(?!.*idip).*",
-			expected: RewriteResult{Pattern: ".*idip.*", Negative: true},
+			pattern:      "^(?!.*idip).*",
+			wantPattern:  ".*idip.*",
+			wantNegative: true,
 		},
 		"带结尾锚点的负向前瞻改写为反向正则": {
-			pattern:  "^(?!.*idip).*$",
-			expected: RewriteResult{Pattern: ".*idip.*", Negative: true},
+			pattern:      "^(?!.*idip).*$",
+			wantPattern:  ".*idip.*",
+			wantNegative: true,
 		},
 		"转义前缀锚点按普通包含处理": {
-			pattern:  `\^foo`,
-			expected: RewriteResult{Pattern: `.*\^foo.*`},
+			pattern:     `\^foo`,
+			wantPattern: `.*\^foo.*`,
 		},
 		"转义后缀锚点按普通包含处理": {
-			pattern:  `foo\$`,
-			expected: RewriteResult{Pattern: `.*foo\$.*`},
+			pattern:     `foo\$`,
+			wantPattern: `.*foo\$.*`,
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := Rewrite(tt.pattern)
-			if got != tt.expected {
-				t.Fatalf("Rewrite(%q) = %+v, want %+v", tt.pattern, got, tt.expected)
+			if got.Pattern != tt.wantPattern {
+				t.Fatalf("Rewrite(%q).Pattern = %q, want %q", tt.pattern, got.Pattern, tt.wantPattern)
+			}
+			if got.Negative != tt.wantNegative {
+				t.Fatalf("Rewrite(%q).Negative = %v, want %v", tt.pattern, got.Negative, tt.wantNegative)
 			}
 		})
 	}

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -87,6 +87,11 @@ func TestRewrite(t *testing.T) {
 			wantPattern:  ".*idip.*",
 			wantNegative: true,
 		},
+		"不包含语义固定前缀内的顶层或表达式按分支补齐包含匹配": {
+			pattern:      "^(?!.*foo|.*bar).*",
+			wantPattern:  "(.*foo.*|.*bar.*)",
+			wantNegative: true,
+		},
 		"转义前缀锚点按普通包含处理": {
 			pattern:     `\^foo`,
 			wantPattern: `.*\^foo.*`,

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -223,6 +223,18 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 			sql:   "`name` REGEXP '^(?!.*foo).*' OR `status` = 'ok'",
 			dsl:   `{"bool":{"should":[{"bool":{"must":{"exists":{"field":"name"}},"must_not":{"regexp":{"name":{"value":".*foo.*"}}}}},{"term":{"status":"ok"}}]}}`,
 		},
+		{
+			name:  "negated empty string stays required with explicit must",
+			input: `+status:ok NOT log:""`,
+			sql:   "`log` IS NULL AND `status` = 'ok'",
+			dsl:   `{"bool":{"must":[{"term":{"status":"ok"}},{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}]}}`,
+		},
+		{
+			name:  "composite negated group does not collapse sql empty check",
+			input: `NOT ((status:ok) OR (log:""))`,
+			sql:   "NOT ((`status` = 'ok') OR (`log` IS NOT NULL))",
+			dsl:   `{"bool":{"must_not":{"bool":{"should":[{"term":{"status":"ok"}},{"exists":{"field":"log"}}]}}}}`,
+		},
 	}
 
 	mock.Init()
@@ -687,10 +699,15 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"regexp":{"msg":{"value":".*TypeError.*"}}}`,
 			sql: "`msg` REGEXP 'TypeError'",
 		},
-		"字段正则顶层或表达式按整体补齐包含匹配": {
+		"字段正则顶层或表达式按分支补齐包含匹配": {
 			q:   `msg:/foo|bar/`,
-			es:  `{"regexp":{"msg":{"value":".*(foo|bar).*"}}}`,
+			es:  `{"regexp":{"msg":{"value":"(.*foo.*|.*bar.*)"}}}`,
 			sql: "`msg` REGEXP 'foo|bar'",
+		},
+		"字段正则顶层或表达式保留分支锚点语义": {
+			q:   `msg:/^foo|bar/`,
+			es:  `{"regexp":{"msg":{"value":"(foo.*|.*bar.*)"}}}`,
+			sql: "`msg` REGEXP '^foo|bar'",
 		},
 		"字段正则前缀锚点改写为整值前缀匹配": {
 			q:   `msg:/^TypeError/`,
@@ -1309,6 +1326,11 @@ func TestLuceneParser(t *testing.T) {
 			q:   `NOT ((log:""))`,
 			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
 			sql: "`log` IS NULL",
+		},
+		"取反复合分组空字符串不误改写 SQL": {
+			q:   `NOT ((status:ok) OR (log:""))`,
+			es:  `{"bool":{"must_not":{"bool":{"should":[{"term":{"status":"ok"}},{"exists":{"field":"log"}}]}}}}`,
+			sql: "NOT ((`status` = 'ok') OR (`log` IS NOT NULL))",
 		},
 		"edge_field_with_underscore": {
 			q:   `_field:value`,

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -188,6 +188,12 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 			dsl:   `{"nested":{"path":"event","query":{"term":{"event.name":"test"}}}}`,
 		},
 		{
+			name:  "grouped negated nested empty string keeps nested non-empty semantics",
+			input: `NOT ((event.name:""))`,
+			sql:   "CAST(event['name'] AS STRING) IS NOT NULL AND CAST(event['name'] AS STRING) != ''",
+			dsl:   `{"nested":{"path":"event","query":{"bool":{"must":{"exists":{"field":"event.name"}},"must_not":{"term":{"event.name":""}}}}}}`,
+		},
+		{
 			name:  "test-1",
 			input: `__ext.io_kubernetes_pod_namespace: "gfp-online-livepy-b" AND is_data_valid: "1" AND born_dist_to_recipient: <400 AND recipient_exists: "1" AND bot_dead_reason: (*killed_by_unknown* OR *bot_without_injury*) AND approach_succ: "0" AND approach_curr_recipient_frame: >200 AND in_fight_aggressive_ratio: "0"`,
 			sql:   "CAST(__ext['io_kubernetes_pod_namespace'] AS STRING) = 'gfp-online-livepy-b' AND `is_data_valid` = '1' AND `born_dist_to_recipient` < '400' AND `recipient_exists` = '1' AND (`bot_dead_reason` LIKE '%killed_by_unknown%' OR `bot_dead_reason` LIKE '%bot_without_injury%') AND `approach_succ` = '0' AND `approach_curr_recipient_frame` > '200' AND `in_fight_aggressive_ratio` = '0'",

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -217,6 +217,12 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 			sql:   "`status` LIKE '%Active%'",
 			dsl:   `{"wildcard":{"status":{"value":"*Active*"}}}`,
 		},
+		{
+			name:  "negative lookahead regexp keeps implicit should semantics",
+			input: `name:/^(?!.*foo).*/ status:ok`,
+			sql:   "`name` REGEXP '^(?!.*foo).*' OR `status` = 'ok'",
+			dsl:   `{"bool":{"should":[{"bool":{"must":{"exists":{"field":"name"}},"must_not":{"regexp":{"name":{"value":".*foo.*"}}}}},{"term":{"status":"ok"}}]}}`,
+		},
 	}
 
 	mock.Init()
@@ -681,6 +687,11 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"regexp":{"msg":{"value":".*TypeError.*"}}}`,
 			sql: "`msg` REGEXP 'TypeError'",
 		},
+		"字段正则顶层或表达式按整体补齐包含匹配": {
+			q:   `msg:/foo|bar/`,
+			es:  `{"regexp":{"msg":{"value":".*(foo|bar).*"}}}`,
+			sql: "`msg` REGEXP 'foo|bar'",
+		},
 		"字段正则前缀锚点改写为整值前缀匹配": {
 			q:   `msg:/^TypeError/`,
 			es:  `{"regexp":{"msg":{"value":"TypeError.*"}}}`,
@@ -688,7 +699,7 @@ func TestLuceneParser(t *testing.T) {
 		},
 		"字段正则负向前瞻改写为反向正则": {
 			q:   `msg:/^(?!.*idip).*/`,
-			es:  `{"bool":{"must_not":{"regexp":{"msg":{"value":".*idip.*"}}}}}`,
+			es:  `{"bool":{"must":{"exists":{"field":"msg"}},"must_not":{"regexp":{"msg":{"value":".*idip.*"}}}}}`,
 			sql: "`msg` REGEXP '^(?!.*idip).*'",
 		},
 		"fuzzy_and_field": {

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -224,7 +224,7 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 			dsl:   `{"wildcard":{"status":{"value":"*Active*"}}}`,
 		},
 		{
-			name:  "negative lookahead regexp keeps implicit should semantics",
+			name:  "negative prefix regexp keeps implicit should semantics",
 			input: `name:/^(?!.*foo).*/ status:ok`,
 			sql:   "`name` REGEXP '^(?!.*foo).*' OR `status` = 'ok'",
 			dsl:   `{"bool":{"should":[{"bool":{"must":{"exists":{"field":"name"}},"must_not":{"regexp":{"name":{"value":".*foo.*"}}}}},{"term":{"status":"ok"}}]}}`,
@@ -725,7 +725,7 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"regexp":{"msg":{"value":"TypeError.*"}}}`,
 			sql: "`msg` REGEXP '^TypeError'",
 		},
-		"字段正则负向前瞻改写为反向正则": {
+		"字段正则不包含前缀形式改写为反向正则": {
 			q:   `msg:/^(?!.*idip).*/`,
 			es:  `{"bool":{"must":{"exists":{"field":"msg"}},"must_not":{"regexp":{"msg":{"value":".*idip.*"}}}}}`,
 			sql: "`msg` REGEXP '^(?!.*idip).*'",

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -604,6 +604,11 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"bool":{"must_not":{"exists":{"field":"author"}}}}`,
 			sql: "`author` IS NULL",
 		},
+		"field_query_exists_group_not": {
+			q:   `NOT ((_exists_:author))`,
+			es:  `{"bool":{"must_not":{"exists":{"field":"author"}}}}`,
+			sql: "`author` IS NULL",
+		},
 		"field_query_exists_or": {
 			q:   `_exists_: Dsa OR _exists_: Allocate`,
 			es:  `{"bool":{"should":[{"exists":{"field":"Dsa"}},{"exists":{"field":"Allocate"}}]}}`,
@@ -1326,6 +1331,11 @@ func TestLuceneParser(t *testing.T) {
 			q:   `NOT ((log:""))`,
 			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
 			sql: "`log` IS NOT NULL AND `log` != ''",
+		},
+		"取反分组 exists 不改写为空字符串非空语义": {
+			q:   `NOT ((_exists_:log))`,
+			es:  `{"bool":{"must_not":{"exists":{"field":"log"}}}}`,
+			sql: "`log` IS NULL",
 		},
 		"取反复合分组空字符串不误改写 SQL": {
 			q:   `NOT ((status:ok) OR (log:""))`,

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -317,7 +317,7 @@ func TestLuceneParser(t *testing.T) {
 		},
 		"正则匹配": {
 			q:   `name: /joh?n(ath[oa]n)/`,
-			es:  `{"regexp":{"name":{"value":"joh?n(ath[oa]n)"}}}`,
+			es:  `{"regexp":{"name":{"value":".*joh?n(ath[oa]n).*"}}}`,
 			sql: "`name` REGEXP 'joh?n(ath[oa]n)'",
 		},
 		"范围匹配，左闭右开": {
@@ -673,8 +673,23 @@ func TestLuceneParser(t *testing.T) {
 		},
 		"regex_field": {
 			q:   `log:/patt.*n/`,
-			es:  `{"regexp":{"log":{"value":"patt.*n"}}}`,
+			es:  `{"regexp":{"log":{"value":".*patt.*n.*"}}}`,
 			sql: "`log` REGEXP 'patt.*n'",
+		},
+		"字段正则普通文本补齐为包含匹配": {
+			q:   `msg:/TypeError/`,
+			es:  `{"regexp":{"msg":{"value":".*TypeError.*"}}}`,
+			sql: "`msg` REGEXP 'TypeError'",
+		},
+		"字段正则前缀锚点改写为整值前缀匹配": {
+			q:   `msg:/^TypeError/`,
+			es:  `{"regexp":{"msg":{"value":"TypeError.*"}}}`,
+			sql: "`msg` REGEXP '^TypeError'",
+		},
+		"字段正则负向前瞻改写为反向正则": {
+			q:   `msg:/^(?!.*idip).*/`,
+			es:  `{"bool":{"must_not":{"regexp":{"msg":{"value":".*idip.*"}}}}}`,
+			sql: "`msg` REGEXP '^(?!.*idip).*'",
 		},
 		"fuzzy_and_field": {
 			q:   `log: test~`,
@@ -1257,7 +1272,7 @@ func TestLuceneParser(t *testing.T) {
 		},
 		"lucene_field_regex": {
 			q:   `field:/pattern/`,
-			es:  `{"regexp":{"field":{"value":"pattern"}}}`,
+			es:  `{"regexp":{"field":{"value":".*pattern.*"}}}`,
 			sql: "`field` REGEXP 'pattern'",
 		},
 
@@ -1274,9 +1289,14 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"exists":{"field":"log"}}`,
 			sql: "`log` IS NOT NULL",
 		},
-		"edge_empty_field_value_negated_becomes_not_exists": {
+		"取反空字符串在 ES 中改写为字段存在且非空": {
 			q:   `NOT log:""`,
-			es:  `{"bool":{"must_not":{"exists":{"field":"log"}}}}`,
+			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
+			sql: "`log` IS NULL",
+		},
+		"取反分组空字符串在 ES 中改写为字段存在且非空": {
+			q:   `NOT ((log:""))`,
+			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
 			sql: "`log` IS NULL",
 		},
 		"edge_field_with_underscore": {

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -227,7 +227,7 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 			name:  "negated empty string stays required with explicit must",
 			input: `+status:ok NOT log:""`,
 			sql:   "`status` = 'ok' AND `log` IS NOT NULL AND `log` != ''",
-			dsl:   `{"bool":{"must":[{"term":{"status":"ok"}},{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}]}}`,
+			dsl:   `{"bool":{"must":[{"term":{"status":"ok"}},{"bool":{"must":{"exists":{"field":"log"}}}}]}}`,
 		},
 		{
 			name:  "composite negated group does not collapse sql empty check",
@@ -1324,12 +1324,12 @@ func TestLuceneParser(t *testing.T) {
 		},
 		"取反空字符串在 ES 中改写为字段存在且非空": {
 			q:   `NOT log:""`,
-			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
+			es:  `{"bool":{"must":{"exists":{"field":"log"}}}}`,
 			sql: "`log` IS NOT NULL AND `log` != ''",
 		},
 		"取反分组空字符串在 ES 中改写为字段存在且非空": {
 			q:   `NOT ((log:""))`,
-			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
+			es:  `{"bool":{"must":{"exists":{"field":"log"}}}}`,
 			sql: "`log` IS NOT NULL AND `log` != ''",
 		},
 		"取反分组 exists 不改写为空字符串非空语义": {
@@ -1676,6 +1676,45 @@ func queryToJSON(query elastic.Query) (string, error) {
 		return "", err
 	}
 	return string(jsonBytes), nil
+}
+
+func TestNonEmptyFieldQuery(t *testing.T) {
+	tests := map[string]struct {
+		field     string
+		fieldsMap metadata.FieldsMap
+		want      string
+	}{
+		"keyword 字段直接排除空串": {
+			field: "level",
+			fieldsMap: metadata.FieldsMap{
+				"level": {FieldType: "keyword"},
+			},
+			want: `{"bool":{"must":{"exists":{"field":"level"}},"must_not":{"term":{"level":""}}}}`,
+		},
+		"text 字段有 keyword 子字段时用子字段排除空串": {
+			field: "log",
+			fieldsMap: metadata.FieldsMap{
+				"log":         {FieldType: "text", IsAnalyzed: true},
+				"log.keyword": {FieldType: "keyword"},
+			},
+			want: `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log.keyword":""}}}}`,
+		},
+		"text 字段没有精确子字段时只保留 exists": {
+			field: "message",
+			fieldsMap: metadata.FieldsMap{
+				"message": {FieldType: "text", IsAnalyzed: true},
+			},
+			want: `{"bool":{"must":{"exists":{"field":"message"}}}}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := queryToJSON(nonEmptyFieldQuery(tt.field, tt.fieldsMap))
+			assert.Nil(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestConvertSingleQuotes(t *testing.T) {

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -226,7 +226,7 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 		{
 			name:  "negated empty string stays required with explicit must",
 			input: `+status:ok NOT log:""`,
-			sql:   "`log` IS NULL AND `status` = 'ok'",
+			sql:   "`status` = 'ok' AND `log` IS NOT NULL AND `log` != ''",
 			dsl:   `{"bool":{"must":[{"term":{"status":"ok"}},{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}]}}`,
 		},
 		{
@@ -1320,12 +1320,12 @@ func TestLuceneParser(t *testing.T) {
 		"取反空字符串在 ES 中改写为字段存在且非空": {
 			q:   `NOT log:""`,
 			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
-			sql: "`log` IS NULL",
+			sql: "`log` IS NOT NULL AND `log` != ''",
 		},
 		"取反分组空字符串在 ES 中改写为字段存在且非空": {
 			q:   `NOT ((log:""))`,
 			es:  `{"bool":{"must":{"exists":{"field":"log"}},"must_not":{"term":{"log":""}}}}`,
-			sql: "`log` IS NULL",
+			sql: "`log` IS NOT NULL AND `log` != ''",
 		},
 		"取反复合分组空字符串不误改写 SQL": {
 			q:   `NOT ((status:ok) OR (log:""))`,

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -495,7 +495,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 				if n.reverseOp && len(must) == 1 && len(should) == 0 && len(mustNot) == 0 {
 					if field, ok := n.emptyStringExistsGroupQueryField(must[0]); ok {
 						// NOT ((field:"")) 的 NOT 作用在分组上，需要在这里兼容为空串取反语义。
-						result = nonEmptyFieldQuery(field)
+						result = nonEmptyFieldQuery(field, n.Option.FieldsMap)
 						inlineReverseOp = true
 						return allMust, allShould, allMustNot
 					}
@@ -671,7 +671,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 			if value == "" && n.field != nil {
 				// field:"" 语义为字段存在；NOT field:"" 兼容为字段存在且不等于空串。
 				if n.reverseOp {
-					result = nonEmptyFieldQuery(field)
+					result = nonEmptyFieldQuery(field, n.Option.FieldsMap)
 					inlineReverseOp = true
 				} else {
 					result = elastic.NewExistsQuery(field)
@@ -700,10 +700,34 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 	return allMust, allShould, allMustNot
 }
 
-func nonEmptyFieldQuery(field string) elastic.Query {
-	return elastic.NewBoolQuery().
-		Must(elastic.NewExistsQuery(field)).
-		MustNot(elastic.NewTermQuery(field, ""))
+func nonEmptyFieldQuery(field string, fieldsMap metadata.FieldsMap) elastic.Query {
+	q := elastic.NewBoolQuery().Must(elastic.NewExistsQuery(field))
+	if exactField, ok := exactEmptyValueField(field, fieldsMap); ok {
+		q.MustNot(elastic.NewTermQuery(exactField, ""))
+	}
+	return q
+}
+
+func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, bool) {
+	if fieldsMap == nil {
+		return field, true
+	}
+
+	fieldOption := fieldsMap.Field(field)
+	if !fieldOption.IsAnalyzed {
+		return field, true
+	}
+
+	// text/analyzed 字段会经过 analysis，term "" 不会分析查询词，不能稳定表达“值不等于空串”。
+	// 如果 mapping 暴露了 keyword/raw 子字段，则用子字段做精确空串判断；否则 ES 侧只能保留 exists，
+	// 无法完全等价过滤掉原始值为空字符串的文档。
+	for _, candidate := range []string{field + ".keyword", field + ".raw"} {
+		option := fieldsMap.Field(candidate)
+		if option.Existed() && !option.IsAnalyzed {
+			return candidate, true
+		}
+	}
+	return "", false
 }
 
 func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -461,14 +461,15 @@ func (n *ConditionNode) String() string {
 
 func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Query, allMustNot []elastic.Query) {
 	var (
-		result   elastic.Query
-		notEqual bool
+		result          elastic.Query
+		notEqual        bool
+		inlineReverseOp bool
 	)
 	defer func() {
 		if result == nil {
 			return
 		}
-		if n.reverseOp || notEqual {
+		if (n.reverseOp && !inlineReverseOp) || notEqual {
 			allMustNot = append(allMustNot, result)
 		} else {
 			allMust = append(allMust, result)
@@ -487,7 +488,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 					if field, ok := existsQueryField(must[0]); ok {
 						// NOT ((field:"")) 的 NOT 作用在分组上，需要在这里兼容为空串取反语义。
 						result = nonEmptyFieldQuery(field)
-						n.reverseOp = false
+						inlineReverseOp = true
 						return allMust, allShould, allMustNot
 					}
 				}
@@ -663,7 +664,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 				// field:"" 语义为字段存在；NOT field:"" 兼容为字段存在且不等于空串。
 				if n.reverseOp {
 					result = nonEmptyFieldQuery(field)
-					n.reverseOp = false
+					inlineReverseOp = true
 				} else {
 					result = elastic.NewExistsQuery(field)
 				}
@@ -705,11 +706,55 @@ func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {
 }
 
 func existsSQLField(sql string) (string, bool) {
-	for strings.HasPrefix(sql, "(") && strings.HasSuffix(sql, ")") {
-		sql = strings.TrimPrefix(strings.TrimSuffix(sql, ")"), "(")
+	for isWrappedExpression(sql) {
+		sql = strings.TrimSpace(sql[1 : len(sql)-1])
 	}
 	field, ok := strings.CutSuffix(sql, " IS NOT NULL")
-	return field, ok && field != ""
+	if !ok || field == "" {
+		return "", false
+	}
+	upperField := strings.ToUpper(field)
+	if strings.Contains(upperField, " OR ") || strings.Contains(upperField, " AND ") {
+		return "", false
+	}
+	return field, balancedParentheses(field)
+}
+
+func isWrappedExpression(sql string) bool {
+	sql = strings.TrimSpace(sql)
+	if len(sql) < 2 || sql[0] != '(' || sql[len(sql)-1] != ')' {
+		return false
+	}
+
+	depth := 0
+	for i, r := range sql {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i != len(sql)-1 {
+				return false
+			}
+		}
+	}
+	return depth == 0
+}
+
+func balancedParentheses(sql string) bool {
+	depth := 0
+	for _, r := range sql {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return depth == 0
 }
 
 func existsQueryField(query elastic.Query) (string, bool) {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -725,6 +725,8 @@ func wrapNestedFieldQuery(field string, fieldsMap metadata.FieldsMap, query elas
 	fieldOption := fieldsMap.Field(field)
 	nestedPath := fieldOption.OriginField
 	if nestedPath == "" {
+		// 部分 mapping 只有顶层 nested 字段声明，没有在叶子字段上回填 OriginField。
+		// 这类字段仍按 dotted path 的首段作为 nested path，例如 nested.key -> nested。
 		nestedPath = strings.Split(field, ".")[0]
 	}
 	return elastic.NewNestedQuery(nestedPath, query)

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -460,6 +460,7 @@ func (n *ConditionNode) String() string {
 }
 
 func nonEmptyFieldSQL(field string) string {
+	// NOT field:"" 在 ES DSL 中表示字段存在且不等于空串，SQL/Doris 渲染需保持同义。
 	return fmt.Sprintf("%s IS NOT NULL AND %s != ''", field, field)
 }
 

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -747,6 +747,8 @@ func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, b
 	// 如果 mapping 暴露了 keyword/raw 子字段，则用子字段做精确空串判断；否则 ES 侧只能保留 exists，
 	// 无法完全等价过滤掉原始值为空字符串的文档。
 	for _, candidate := range []string{field + ".keyword", field + ".raw"} {
+		// 这里不主动假设子字段存在，只使用 FieldsMap 中已经解析或注入的精确子字段。
+		// 如果没有命中，避免向 ES 下发可能不存在的 field.keyword/field.raw 查询。
 		option := fieldsMap.Field(candidate)
 		if option.Existed() && !option.IsAnalyzed {
 			return candidate, true

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -747,8 +747,8 @@ func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, b
 	// 如果 mapping 暴露了 keyword/raw 子字段，则用子字段做精确空串判断；否则 ES 侧只能保留 exists，
 	// 无法完全等价过滤掉原始值为空字符串的文档。
 	for _, candidate := range []string{field + ".keyword", field + ".raw"} {
-		// 这里不主动假设子字段存在，只使用 FieldsMap 中已经解析或注入的精确子字段。
-		// 如果没有命中，避免向 ES 下发可能不存在的 field.keyword/field.raw 查询。
+		// field.keyword/field.raw 是 ES multi-field 中常见的精确值子字段命名。
+		// 这里按 FieldsMap 中已知字段选择可用于 term 查询的非 analyzed 子字段。
 		option := fieldsMap.Field(candidate)
 		if option.Existed() && !option.IsAnalyzed {
 			return candidate, true

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -640,7 +640,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 			cq.Boost(cast.ToFloat64(cv.Boost))
 		}
 		if rewrite.Negative {
-			// 正向负前瞻必须要求字段存在；单独 must_not regexp 会误匹配缺失字段。
+			// 正向不包含前缀形式必须要求字段存在；单独 must_not regexp 会误匹配缺失字段。
 			result = negativeLookaheadQuery(field, cq)
 		} else {
 			result = cq
@@ -748,7 +748,7 @@ func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, b
 }
 
 func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {
-	// ES regexp 不支持负向前瞻，用字段存在 + 反向 regexp 保留“字段值不包含”的语义。
+	// ES regexp 不支持不包含前缀形式，用字段存在 + 反向 regexp 保留“字段值不包含”的语义。
 	return elastic.NewBoolQuery().
 		Must(elastic.NewExistsQuery(field)).
 		MustNot(regexp)

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -269,6 +269,7 @@ type ConditionNode struct {
 	value Node
 }
 
+// likeValue 将 Lucene 通配符转换为 SQL LIKE 通配符，并保留转义后的字面量。
 func (n *ConditionNode) likeValue(s string) string {
 	if s == "" {
 		return ""
@@ -302,6 +303,7 @@ func (n *ConditionNode) likeValue(s string) string {
 	return string(ns)
 }
 
+// SetField 把分组外层字段下推给内部条件，例如 log:(a OR b)。
 func (n *ConditionNode) SetField(field Node) {
 	if field != nil {
 		n.field = field
@@ -462,6 +464,7 @@ func (n *ConditionNode) String() string {
 	return fmt.Sprintf("%s %s '%s'", field, op, value)
 }
 
+// nonEmptyFieldSQL 渲染“字段存在且不为空字符串”的 SQL 条件，用于 NOT field:"" 兼容语义。
 func nonEmptyFieldSQL(field string) string {
 	// NOT field:"" 在 ES DSL 中表示字段存在且不等于空串，SQL/Doris 渲染需保持同义。
 	return fmt.Sprintf("%s IS NOT NULL AND %s != ''", field, field)
@@ -700,6 +703,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 	return allMust, allShould, allMustNot
 }
 
+// nonEmptyFieldQuery 构造“字段存在且不为空字符串”的 ES 查询；text 字段优先用 keyword/raw 子字段判断空串。
 func nonEmptyFieldQuery(field string, fieldsMap metadata.FieldsMap) elastic.Query {
 	q := elastic.NewBoolQuery().Must(elastic.NewExistsQuery(field))
 	if exactField, ok := exactEmptyValueField(field, fieldsMap); ok {
@@ -708,6 +712,7 @@ func nonEmptyFieldQuery(field string, fieldsMap metadata.FieldsMap) elastic.Quer
 	return q
 }
 
+// wrapNestedFieldQuery 在字段属于 nested mapping 时，用正确 path 包装已有字段查询。
 func wrapNestedFieldQuery(field string, fieldsMap metadata.FieldsMap, query elastic.Query) elastic.Query {
 	if fieldsMap == nil {
 		return query
@@ -725,6 +730,7 @@ func wrapNestedFieldQuery(field string, fieldsMap metadata.FieldsMap, query elas
 	return elastic.NewNestedQuery(nestedPath, query)
 }
 
+// exactEmptyValueField 返回可用于精确判断空字符串的字段；analyzed text 字段需改用 keyword/raw 子字段。
 func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, bool) {
 	if fieldsMap == nil {
 		return field, true
@@ -747,6 +753,7 @@ func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, b
 	return "", false
 }
 
+// negativeLookaheadQuery 用 exists + must_not regexp 表达固定“不包含前缀形式”的兼容语义。
 func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {
 	// ES regexp 不支持不包含前缀形式，用字段存在 + 反向 regexp 保留“字段值不包含”的语义。
 	return elastic.NewBoolQuery().
@@ -754,6 +761,7 @@ func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {
 		MustNot(regexp)
 }
 
+// existsSQLField 从简单的 SQL exists 表达式中取出字段名，并拒绝包含 AND/OR 的复合表达式。
 func existsSQLField(sql string) (string, bool) {
 	for isWrappedExpression(sql) {
 		sql = strings.TrimSpace(sql[1 : len(sql)-1])
@@ -769,6 +777,7 @@ func existsSQLField(sql string) (string, bool) {
 	return field, balancedParentheses(field)
 }
 
+// emptyStringExistsGroupSQLField 判断当前分组是否源自 field:""，并从 SQL 表达式中取真实字段名。
 func (n *ConditionNode) emptyStringExistsGroupSQLField(sql string) (string, bool) {
 	// field:"" 与 _exists_:field 都会先渲染成 field IS NOT NULL。
 	// 分组取反时必须回看 AST 来源，只允许 field:"" 走“字段存在且非空”的兼容语义。
@@ -778,6 +787,7 @@ func (n *ConditionNode) emptyStringExistsGroupSQLField(sql string) (string, bool
 	return existsSQLField(sql)
 }
 
+// emptyStringExistsGroupQueryField 判断当前分组是否源自 field:""，并从已生成 DSL 中取真实字段名。
 func (n *ConditionNode) emptyStringExistsGroupQueryField(query elastic.Query) (string, bool) {
 	// DSL 路径同样会把 field:"" 与 _exists_:field 都生成为 exists query。
 	// 这里先确认分组源自 field:""，再从 query 中取经过别名转换后的真实字段名。
@@ -787,6 +797,7 @@ func (n *ConditionNode) emptyStringExistsGroupQueryField(query elastic.Query) (s
 	return existsQueryField(query)
 }
 
+// explicitExistsGroupSQLField 判断当前分组是否源自 _exists_:field，并从 SQL 表达式中取真实字段名。
 func (n *ConditionNode) explicitExistsGroupSQLField(sql string) (string, bool) {
 	// 显式 _exists_ 分组取反应保持存在性取反，避免被上面的空字符串兼容逻辑误改成非空字符串检查。
 	if !n.isExplicitExistsGroupCondition() {
@@ -795,6 +806,7 @@ func (n *ConditionNode) explicitExistsGroupSQLField(sql string) (string, bool) {
 	return existsSQLField(sql)
 }
 
+// isEmptyStringExistsGroupCondition 判断分组是否只包含一个 field:"" 条件。
 func (n *ConditionNode) isEmptyStringExistsGroupCondition() bool {
 	if !n.isGroup {
 		return false
@@ -806,6 +818,7 @@ func (n *ConditionNode) isEmptyStringExistsGroupCondition() bool {
 	return child.isEmptyStringExistsCondition()
 }
 
+// isEmptyStringExistsCondition 判断节点是否为正向 field:"" 条件；该条件在当前语义中表示字段存在。
 func (n *ConditionNode) isEmptyStringExistsCondition() bool {
 	if n == nil || n.reverseOp {
 		return false
@@ -822,6 +835,7 @@ func (n *ConditionNode) isEmptyStringExistsCondition() bool {
 	return ok && strings.Trim(value.Value, `"`) == ""
 }
 
+// isExplicitExistsGroupCondition 判断分组是否只包含一个显式 _exists_:field 条件。
 func (n *ConditionNode) isExplicitExistsGroupCondition() bool {
 	if !n.isGroup {
 		return false
@@ -833,6 +847,7 @@ func (n *ConditionNode) isExplicitExistsGroupCondition() bool {
 	return child.isExplicitExistsCondition()
 }
 
+// isExplicitExistsCondition 判断节点是否为正向 _exists_:field 条件。
 func (n *ConditionNode) isExplicitExistsCondition() bool {
 	if n == nil || n.reverseOp {
 		return false
@@ -845,6 +860,7 @@ func (n *ConditionNode) isExplicitExistsCondition() bool {
 	return ok && field == "_exists_"
 }
 
+// singleGroupChild 返回单条件分组的唯一子节点；多条件分组不能套用 field:"" 或 _exists_ 的特殊取反语义。
 func (n *ConditionNode) singleGroupChild() (*ConditionNode, bool) {
 	logic, ok := n.value.(*LogicNode)
 	if !ok || len(logic.Nodes) != 1 {
@@ -853,6 +869,7 @@ func (n *ConditionNode) singleGroupChild() (*ConditionNode, bool) {
 	return logic.Nodes[0], logic.Nodes[0] != nil
 }
 
+// conditionFieldName 读取条件节点的原始字段名；这里只接受普通字符串字段。
 func conditionFieldName(n *ConditionNode) (string, bool) {
 	if n == nil || n.field == nil {
 		return "", false
@@ -864,6 +881,7 @@ func conditionFieldName(n *ConditionNode) (string, bool) {
 	return field.Value, true
 }
 
+// isWrappedExpression 判断 SQL 表达式是否被一对覆盖全表达式的括号包裹。
 func isWrappedExpression(sql string) bool {
 	sql = strings.TrimSpace(sql)
 	if len(sql) < 2 || sql[0] != '(' || sql[len(sql)-1] != ')' {
@@ -885,6 +903,7 @@ func isWrappedExpression(sql string) bool {
 	return depth == 0
 }
 
+// balancedParentheses 判断 SQL 片段括号是否平衡，用于避免从异常表达式中误提字段名。
 func balancedParentheses(sql string) bool {
 	depth := 0
 	for _, r := range sql {
@@ -901,6 +920,7 @@ func balancedParentheses(sql string) bool {
 	return depth == 0
 }
 
+// existsQueryField 从 exists 或 nested exists DSL 中反查字段名。
 func existsQueryField(query elastic.Query) (string, bool) {
 	// 分组反向场景只能拿到已生成的 query，这里从 exists/nested exists DSL 中反查字段名。
 	source, err := query.Source()
@@ -918,6 +938,7 @@ func existsQueryField(query elastic.Query) (string, bool) {
 	return existsQueryFieldFromSource(body)
 }
 
+// existsQueryFieldFromSource 从 olivere/elastic 生成的 exists query source 中读取 field。
 func existsQueryFieldFromSource(source any) (string, bool) {
 	body, ok := source.(map[string]any)
 	if !ok {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -319,7 +319,7 @@ func (n *ConditionNode) String() string {
 			if n.reverseOp {
 				// NOT ((field:"")) 的 SQL 字符串语义也要和 DSL 一样兼容为空值判断。
 				if field, ok := existsSQLField(sql); ok {
-					return fmt.Sprintf("%s IS NULL", field)
+					return nonEmptyFieldSQL(field)
 				}
 				sql = fmt.Sprintf("(%s)", sql)
 				sql = fmt.Sprintf("NOT %s", sql)
@@ -430,7 +430,7 @@ func (n *ConditionNode) String() string {
 		if value == "" && n.field != nil {
 			// field:"" 语义为字段存在，与分词无关
 			if n.reverseOp {
-				return fmt.Sprintf("%s IS NULL", field)
+				return nonEmptyFieldSQL(field)
 			}
 			return fmt.Sprintf("%s IS NOT NULL", field)
 		}
@@ -457,6 +457,10 @@ func (n *ConditionNode) String() string {
 	}
 
 	return fmt.Sprintf("%s %s '%s'", field, op, value)
+}
+
+func nonEmptyFieldSQL(field string) string {
+	return fmt.Sprintf("%s IS NOT NULL AND %s != ''", field, field)
 }
 
 func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Query, allMustNot []elastic.Query) {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -316,9 +316,15 @@ func (n *ConditionNode) String() string {
 				n.value.SetField(n.field)
 			}
 			sql := n.value.String()
-			sql = fmt.Sprintf("(%s)", sql)
 			if n.reverseOp {
+				// NOT ((field:"")) 的 SQL 字符串语义也要和 DSL 一样兼容为空值判断。
+				if field, ok := existsSQLField(sql); ok {
+					return fmt.Sprintf("%s IS NULL", field)
+				}
+				sql = fmt.Sprintf("(%s)", sql)
 				sql = fmt.Sprintf("NOT %s", sql)
+			} else {
+				sql = fmt.Sprintf("(%s)", sql)
 			}
 			return sql
 		}
@@ -620,15 +626,16 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 	case *RegexpNode:
 		rewrite := esregexpcompat.Rewrite(value)
 		value = rewrite.Pattern
-		if rewrite.Negative {
-			// ES regexp 不支持负向前瞻，改写为反向正则条件承载语义。
-			n.reverseOp = !n.reverseOp
-		}
 		cq := elastic.NewRegexpQuery(field, value)
 		if cv.Boost != "" {
 			cq.Boost(cast.ToFloat64(cv.Boost))
 		}
-		result = cq
+		if rewrite.Negative {
+			// 正向负前瞻必须要求字段存在；单独 must_not regexp 会误匹配缺失字段。
+			result = negativeLookaheadQuery(field, cq)
+		} else {
+			result = cq
+		}
 	case *StringNode:
 		switch op {
 		case ">":
@@ -688,6 +695,21 @@ func nonEmptyFieldQuery(field string) elastic.Query {
 	return elastic.NewBoolQuery().
 		Must(elastic.NewExistsQuery(field)).
 		MustNot(elastic.NewTermQuery(field, ""))
+}
+
+func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {
+	// ES regexp 不支持负向前瞻，用字段存在 + 反向 regexp 保留“字段值不包含”的语义。
+	return elastic.NewBoolQuery().
+		Must(elastic.NewExistsQuery(field)).
+		MustNot(regexp)
+}
+
+func existsSQLField(sql string) (string, bool) {
+	for strings.HasPrefix(sql, "(") && strings.HasSuffix(sql, ")") {
+		sql = strings.TrimPrefix(strings.TrimSuffix(sql, ")"), "(")
+	}
+	field, ok := strings.CutSuffix(sql, " IS NOT NULL")
+	return field, ok && field != ""
 }
 
 func existsQueryField(query elastic.Query) (string, bool) {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -464,9 +464,9 @@ func (n *ConditionNode) String() string {
 	return fmt.Sprintf("%s %s '%s'", field, op, value)
 }
 
-// nonEmptyFieldSQL 渲染“字段存在且不为空字符串”的 SQL 条件，用于 NOT field:"" 兼容语义。
+// nonEmptyFieldSQL 渲染 SQL/Doris 路径的“字段存在且不为空字符串”条件，用于 NOT field:"" 兼容语义。
 func nonEmptyFieldSQL(field string) string {
-	// NOT field:"" 在 ES DSL 中表示字段存在且不等于空串，SQL/Doris 渲染需保持同义。
+	// Doris SQL 路径直接使用原字段比较空串：field IS NOT NULL AND field != ''。
 	return fmt.Sprintf("%s IS NOT NULL AND %s != ''", field, field)
 }
 
@@ -498,6 +498,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 				if n.reverseOp && len(must) == 1 && len(should) == 0 && len(mustNot) == 0 {
 					if field, ok := n.emptyStringExistsGroupQueryField(must[0]); ok {
 						// NOT ((field:"")) 的 NOT 作用在分组上，需要在这里兼容为空串取反语义。
+						// 重建后的非空 bool query 仍要保持原字段的 nested scope；普通字段会原样返回。
 						result = wrapNestedFieldQuery(field, n.Option.FieldsMap, nonEmptyFieldQuery(field, n.Option.FieldsMap))
 						inlineReverseOp = true
 						return allMust, allShould, allMustNot
@@ -706,7 +707,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 // nonEmptyFieldQuery 构造“字段存在且不为空字符串”的 ES 查询；text 字段优先用 keyword/raw 子字段判断空串。
 func nonEmptyFieldQuery(field string, fieldsMap metadata.FieldsMap) elastic.Query {
 	q := elastic.NewBoolQuery().Must(elastic.NewExistsQuery(field))
-	if exactField, ok := exactEmptyValueField(field, fieldsMap); ok {
+	if exactField, ok := exactSubfieldForEmptyValue(field, fieldsMap); ok {
 		q.MustNot(elastic.NewTermQuery(exactField, ""))
 	}
 	return q
@@ -732,8 +733,8 @@ func wrapNestedFieldQuery(field string, fieldsMap metadata.FieldsMap, query elas
 	return elastic.NewNestedQuery(nestedPath, query)
 }
 
-// exactEmptyValueField 返回可用于精确判断空字符串的字段；analyzed text 字段需改用 keyword/raw 子字段。
-func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, bool) {
+// exactSubfieldForEmptyValue 返回 ES DSL 路径可用于精确判断空字符串的字段或精确值子字段。
+func exactSubfieldForEmptyValue(field string, fieldsMap metadata.FieldsMap) (string, bool) {
 	if fieldsMap == nil {
 		return field, true
 	}
@@ -743,11 +744,11 @@ func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, b
 		return field, true
 	}
 
-	// text/analyzed 字段会经过 analysis，term "" 不会分析查询词，不能稳定表达“值不等于空串”。
-	// 如果 mapping 暴露了 keyword/raw 子字段，则用子字段做精确空串判断；否则 ES 侧只能保留 exists，
-	// 无法完全等价过滤掉原始值为空字符串的文档。
+	// ES text/analyzed 字段会经过 analysis，term "" 不会分析查询词，不能稳定表达“值不等于空串”。
+	// ES DSL 路径优先选择 mapping 中的 keyword/raw multi-fields 子字段做精确空串判断；没有精确子字段时只保留 exists。
 	for _, candidate := range []string{field + ".keyword", field + ".raw"} {
-		// field.keyword/field.raw 是 ES multi-field 中常见的精确值子字段命名。
+		// field.keyword/field.raw 是 ES multi-fields 中常见的精确值子字段命名。
+		// 参考：https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/multi-fields
 		// 这里按 FieldsMap 中已知字段选择可用于 term 查询的非 analyzed 子字段。
 		option := fieldsMap.Field(candidate)
 		if option.Existed() && !option.IsAnalyzed {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/esregexpcompat"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/lucene_parser/gen"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 )
@@ -476,6 +477,14 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 
 			must, should, mustNot := n.value.DSL()
 			if b, ok := n.value.(*LogicNode); ok {
+				if n.reverseOp && len(must) == 1 && len(should) == 0 && len(mustNot) == 0 {
+					if field, ok := existsQueryField(must[0]); ok {
+						// NOT ((field:"")) 的 NOT 作用在分组上，需要在这里兼容为空串取反语义。
+						result = nonEmptyFieldQuery(field)
+						n.reverseOp = false
+						return allMust, allShould, allMustNot
+					}
+				}
 				if b.boost != "" {
 					result = elastic.NewBoolQuery().Must(must...).Should(should...).MustNot(mustNot...).Boost(cast.ToFloat64(b.boost))
 				} else {
@@ -609,6 +618,12 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 			result = cq
 		}
 	case *RegexpNode:
+		rewrite := esregexpcompat.Rewrite(value)
+		value = rewrite.Pattern
+		if rewrite.Negative {
+			// ES regexp 不支持负向前瞻，改写为反向正则条件承载语义。
+			n.reverseOp = !n.reverseOp
+		}
 		cq := elastic.NewRegexpQuery(field, value)
 		if cv.Boost != "" {
 			cq.Boost(cast.ToFloat64(cv.Boost))
@@ -637,22 +652,27 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 				break
 			}
 
-				if value == "" && n.field != nil {
-					// field:"" 语义为字段存在，与分词无关
-					result = elastic.NewExistsQuery(field)
-				} else if fieldOption.IsAnalyzed {
-					cq := elastic.NewMatchPhraseQuery(field, value)
-					if cv.Boost != "" {
-						cq.Boost(cast.ToFloat64(cv.Boost))
-					}
-					result = cq
+			if value == "" && n.field != nil {
+				// field:"" 语义为字段存在；NOT field:"" 兼容为字段存在且不等于空串。
+				if n.reverseOp {
+					result = nonEmptyFieldQuery(field)
+					n.reverseOp = false
 				} else {
-					cq := elastic.NewTermQuery(field, value)
-					if cv.Boost != "" {
-						cq.Boost(cast.ToFloat64(cv.Boost))
-					}
-					result = cq
+					result = elastic.NewExistsQuery(field)
 				}
+			} else if fieldOption.IsAnalyzed {
+				cq := elastic.NewMatchPhraseQuery(field, value)
+				if cv.Boost != "" {
+					cq.Boost(cast.ToFloat64(cv.Boost))
+				}
+				result = cq
+			} else {
+				cq := elastic.NewTermQuery(field, value)
+				if cv.Boost != "" {
+					cq.Boost(cast.ToFloat64(cv.Boost))
+				}
+				result = cq
+			}
 		}
 	}
 
@@ -662,6 +682,31 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 	}
 
 	return allMust, allShould, allMustNot
+}
+
+func nonEmptyFieldQuery(field string) elastic.Query {
+	return elastic.NewBoolQuery().
+		Must(elastic.NewExistsQuery(field)).
+		MustNot(elastic.NewTermQuery(field, ""))
+}
+
+func existsQueryField(query elastic.Query) (string, bool) {
+	// 分组反向场景只能拿到已生成的 query，这里从 exists DSL 中反查字段名。
+	source, err := query.Source()
+	if err != nil {
+		return "", false
+	}
+
+	body, ok := source.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	exists, ok := body["exists"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	field, ok := exists["field"].(string)
+	return field, ok && field != ""
 }
 
 func (n *ConditionNode) VisitTerminal(ctx antlr.TerminalNode) any {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -495,7 +495,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 				if n.reverseOp && len(must) == 1 && len(should) == 0 && len(mustNot) == 0 {
 					if field, ok := n.emptyStringExistsGroupQueryField(must[0]); ok {
 						// NOT ((field:"")) 的 NOT 作用在分组上，需要在这里兼容为空串取反语义。
-						result = nonEmptyFieldQuery(field, n.Option.FieldsMap)
+						result = wrapNestedFieldQuery(field, n.Option.FieldsMap, nonEmptyFieldQuery(field, n.Option.FieldsMap))
 						inlineReverseOp = true
 						return allMust, allShould, allMustNot
 					}
@@ -694,7 +694,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 
 	originField := n.Option.FieldsMap.Field(strings.Split(field, ".")[0])
 	if strings.ToUpper(originField.FieldType) == "NESTED" {
-		result = elastic.NewNestedQuery(fieldOption.OriginField, result)
+		result = wrapNestedFieldQuery(field, n.Option.FieldsMap, result)
 	}
 
 	return allMust, allShould, allMustNot
@@ -706,6 +706,23 @@ func nonEmptyFieldQuery(field string, fieldsMap metadata.FieldsMap) elastic.Quer
 		q.MustNot(elastic.NewTermQuery(exactField, ""))
 	}
 	return q
+}
+
+func wrapNestedFieldQuery(field string, fieldsMap metadata.FieldsMap, query elastic.Query) elastic.Query {
+	if fieldsMap == nil {
+		return query
+	}
+	originField := fieldsMap.Field(strings.Split(field, ".")[0])
+	if strings.ToUpper(originField.FieldType) != "NESTED" {
+		return query
+	}
+
+	fieldOption := fieldsMap.Field(field)
+	nestedPath := fieldOption.OriginField
+	if nestedPath == "" {
+		nestedPath = strings.Split(field, ".")[0]
+	}
+	return elastic.NewNestedQuery(nestedPath, query)
 }
 
 func exactEmptyValueField(field string, fieldsMap metadata.FieldsMap) (string, bool) {
@@ -885,12 +902,23 @@ func balancedParentheses(sql string) bool {
 }
 
 func existsQueryField(query elastic.Query) (string, bool) {
-	// 分组反向场景只能拿到已生成的 query，这里从 exists DSL 中反查字段名。
+	// 分组反向场景只能拿到已生成的 query，这里从 exists/nested exists DSL 中反查字段名。
 	source, err := query.Source()
 	if err != nil {
 		return "", false
 	}
 
+	body, ok := source.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	if nested, ok := body["nested"].(map[string]any); ok {
+		return existsQueryFieldFromSource(nested["query"])
+	}
+	return existsQueryFieldFromSource(body)
+}
+
+func existsQueryFieldFromSource(source any) (string, bool) {
 	body, ok := source.(map[string]any)
 	if !ok {
 		return "", false

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -318,8 +318,11 @@ func (n *ConditionNode) String() string {
 			sql := n.value.String()
 			if n.reverseOp {
 				// NOT ((field:"")) 的 SQL 字符串语义也要和 DSL 一样兼容为空值判断。
-				if field, ok := existsSQLField(sql); ok {
+				if field, ok := n.emptyStringExistsGroupSQLField(sql); ok {
 					return nonEmptyFieldSQL(field)
+				}
+				if field, ok := n.explicitExistsGroupSQLField(sql); ok {
+					return fmt.Sprintf("%s IS NULL", field)
 				}
 				sql = fmt.Sprintf("(%s)", sql)
 				sql = fmt.Sprintf("NOT %s", sql)
@@ -490,7 +493,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 			must, should, mustNot := n.value.DSL()
 			if b, ok := n.value.(*LogicNode); ok {
 				if n.reverseOp && len(must) == 1 && len(should) == 0 && len(mustNot) == 0 {
-					if field, ok := existsQueryField(must[0]); ok {
+					if field, ok := n.emptyStringExistsGroupQueryField(must[0]); ok {
 						// NOT ((field:"")) 的 NOT 作用在分组上，需要在这里兼容为空串取反语义。
 						result = nonEmptyFieldQuery(field)
 						inlineReverseOp = true
@@ -723,6 +726,101 @@ func existsSQLField(sql string) (string, bool) {
 		return "", false
 	}
 	return field, balancedParentheses(field)
+}
+
+func (n *ConditionNode) emptyStringExistsGroupSQLField(sql string) (string, bool) {
+	// field:"" 与 _exists_:field 都会先渲染成 field IS NOT NULL。
+	// 分组取反时必须回看 AST 来源，只允许 field:"" 走“字段存在且非空”的兼容语义。
+	if !n.isEmptyStringExistsGroupCondition() {
+		return "", false
+	}
+	return existsSQLField(sql)
+}
+
+func (n *ConditionNode) emptyStringExistsGroupQueryField(query elastic.Query) (string, bool) {
+	// DSL 路径同样会把 field:"" 与 _exists_:field 都生成为 exists query。
+	// 这里先确认分组源自 field:""，再从 query 中取经过别名转换后的真实字段名。
+	if !n.isEmptyStringExistsGroupCondition() {
+		return "", false
+	}
+	return existsQueryField(query)
+}
+
+func (n *ConditionNode) explicitExistsGroupSQLField(sql string) (string, bool) {
+	// 显式 _exists_ 分组取反应保持存在性取反，避免被上面的空字符串兼容逻辑误改成非空字符串检查。
+	if !n.isExplicitExistsGroupCondition() {
+		return "", false
+	}
+	return existsSQLField(sql)
+}
+
+func (n *ConditionNode) isEmptyStringExistsGroupCondition() bool {
+	if !n.isGroup {
+		return false
+	}
+	child, ok := n.singleGroupChild()
+	if !ok {
+		return false
+	}
+	return child.isEmptyStringExistsCondition()
+}
+
+func (n *ConditionNode) isEmptyStringExistsCondition() bool {
+	if n == nil || n.reverseOp {
+		return false
+	}
+	if n.isGroup {
+		child, ok := n.singleGroupChild()
+		return ok && child.isEmptyStringExistsCondition()
+	}
+	field, ok := conditionFieldName(n)
+	if !ok || field == "_exists_" {
+		return false
+	}
+	value, ok := n.value.(*StringNode)
+	return ok && strings.Trim(value.Value, `"`) == ""
+}
+
+func (n *ConditionNode) isExplicitExistsGroupCondition() bool {
+	if !n.isGroup {
+		return false
+	}
+	child, ok := n.singleGroupChild()
+	if !ok {
+		return false
+	}
+	return child.isExplicitExistsCondition()
+}
+
+func (n *ConditionNode) isExplicitExistsCondition() bool {
+	if n == nil || n.reverseOp {
+		return false
+	}
+	if n.isGroup {
+		child, ok := n.singleGroupChild()
+		return ok && child.isExplicitExistsCondition()
+	}
+	field, ok := conditionFieldName(n)
+	return ok && field == "_exists_"
+}
+
+func (n *ConditionNode) singleGroupChild() (*ConditionNode, bool) {
+	logic, ok := n.value.(*LogicNode)
+	if !ok || len(logic.Nodes) != 1 {
+		return nil, false
+	}
+	return logic.Nodes[0], logic.Nodes[0] != nil
+}
+
+func conditionFieldName(n *ConditionNode) (string, bool) {
+	if n == nil || n.field == nil {
+		return "", false
+	}
+	field, ok := n.field.(*StringNode)
+	if !ok || field.Value == "" {
+		return "", false
+	}
+	return field.Value, true
 }
 
 func isWrappedExpression(sql string) bool {

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -472,15 +472,15 @@ func nonEmptyFieldSQL(field string) string {
 
 func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Query, allMustNot []elastic.Query) {
 	var (
-		result          elastic.Query
-		notEqual        bool
-		inlineReverseOp bool
+		result       elastic.Query
+		notEqual     bool
+		outerMustNot = n.reverseOp
 	)
 	defer func() {
 		if result == nil {
 			return
 		}
-		if (n.reverseOp && !inlineReverseOp) || notEqual {
+		if outerMustNot || notEqual {
 			allMustNot = append(allMustNot, result)
 		} else {
 			allMust = append(allMust, result)
@@ -500,7 +500,8 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 						// NOT ((field:"")) 的 NOT 作用在分组上，需要在这里兼容为空串取反语义。
 						// 重建后的非空 bool query 仍要保持原字段的 nested scope；普通字段会原样返回。
 						result = wrapNestedFieldQuery(field, n.Option.FieldsMap, nonEmptyFieldQuery(field, n.Option.FieldsMap))
-						inlineReverseOp = true
+						// 取反已经表达为“字段存在且非空”，收尾阶段不再追加外层 must_not。
+						outerMustNot = false
 						return allMust, allShould, allMustNot
 					}
 				}
@@ -676,7 +677,8 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 				// field:"" 语义为字段存在；NOT field:"" 兼容为字段存在且不等于空串。
 				if n.reverseOp {
 					result = nonEmptyFieldQuery(field, n.Option.FieldsMap)
-					inlineReverseOp = true
+					// 取反已经表达为“字段存在且非空”，收尾阶段不再追加外层 must_not。
+					outerMustNot = false
 				} else {
 					result = elastic.NewExistsQuery(field)
 				}

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -955,6 +955,13 @@ func (f *FormatFactory) getQuery(key string, qs ...elastic.Query) (q elastic.Que
 	return q
 }
 
+func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {
+	// ES regexp 不支持负向前瞻，用字段存在 + 反向 regexp 保留“字段值不包含”的语义。
+	return elastic.NewBoolQuery().
+		Must(elastic.NewExistsQuery(field)).
+		MustNot(regexp)
+}
+
 // Query 把 ts 的 conditions 转换成 es 查询
 func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Query, error) {
 	bootQueries := make([]elastic.Query, 0)
@@ -1007,7 +1014,6 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 					}
 
 					queries := make([]elastic.Query, 0)
-					effectiveOperator := con.Operator
 					for _, value := range con.Value {
 						var query elastic.Query
 						if con.DimensionName != "" {
@@ -1083,16 +1089,13 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 								case structured.ConditionRegEqual, structured.ConditionNotRegEqual:
 									rewrite := esregexpcompat.Rewrite(value)
 									value = rewrite.Pattern
+									regexpQuery := elastic.NewRegexpQuery(key, value)
 									if rewrite.Negative {
-										// ES regexp 不支持负向前瞻，改写为相反的正则操作符承载语义。
-										switch con.Operator {
-										case structured.ConditionRegEqual:
-											effectiveOperator = structured.ConditionNotRegEqual
-										case structured.ConditionNotRegEqual:
-											effectiveOperator = structured.ConditionRegEqual
-										}
+										// 每个 value 独立承载负前瞻语义，避免污染同一条件下的其他正则值。
+										query = negativeLookaheadQuery(key, regexpQuery)
+									} else {
+										query = regexpQuery
 									}
-									query = elastic.NewRegexpQuery(key, value)
 								case structured.ConditionGt:
 									query = elastic.NewRangeQuery(key).Gt(value).Format(format)
 								case structured.ConditionGte:
@@ -1119,7 +1122,7 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 					}
 
 					// 非空才进行验证
-					switch effectiveOperator {
+					switch con.Operator {
 					case structured.ConditionEqual, structured.ConditionContains, structured.ConditionRegEqual:
 						q = f.getQuery(Should, queries...)
 					case structured.ConditionNotEqual, structured.ConditionNotContains, structured.ConditionNotRegEqual:

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -956,7 +956,7 @@ func (f *FormatFactory) getQuery(key string, qs ...elastic.Query) (q elastic.Que
 }
 
 func negativeLookaheadQuery(field string, regexp elastic.Query) elastic.Query {
-	// ES regexp 不支持负向前瞻，用字段存在 + 反向 regexp 保留“字段值不包含”的语义。
+	// ES regexp 不支持不包含前缀形式，用字段存在 + 反向 regexp 保留“字段值不包含”的语义。
 	return elastic.NewBoolQuery().
 		Must(elastic.NewExistsQuery(field)).
 		MustNot(regexp)
@@ -1091,7 +1091,7 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 									value = rewrite.Pattern
 									regexpQuery := elastic.NewRegexpQuery(key, value)
 									if rewrite.Negative {
-										// 每个 value 独立承载负前瞻语义，避免污染同一条件下的其他正则值。
+										// 每个 value 独立承载不包含前缀语义，避免污染同一条件下的其他正则值。
 										query = negativeLookaheadQuery(key, regexpQuery)
 									} else {
 										query = regexpQuery

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/esregexpcompat"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/function"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/json"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/lucene_parser"
@@ -1006,6 +1007,7 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 					}
 
 					queries := make([]elastic.Query, 0)
+					effectiveOperator := con.Operator
 					for _, value := range con.Value {
 						var query elastic.Query
 						if con.DimensionName != "" {
@@ -1079,6 +1081,17 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 										query = elastic.NewWildcardQuery(key, value)
 									}
 								case structured.ConditionRegEqual, structured.ConditionNotRegEqual:
+									rewrite := esregexpcompat.Rewrite(value)
+									value = rewrite.Pattern
+									if rewrite.Negative {
+										// ES regexp 不支持负向前瞻，改写为相反的正则操作符承载语义。
+										switch con.Operator {
+										case structured.ConditionRegEqual:
+											effectiveOperator = structured.ConditionNotRegEqual
+										case structured.ConditionNotRegEqual:
+											effectiveOperator = structured.ConditionRegEqual
+										}
+									}
 									query = elastic.NewRegexpQuery(key, value)
 								case structured.ConditionGt:
 									query = elastic.NewRangeQuery(key).Gt(value).Format(format)
@@ -1106,7 +1119,7 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 					}
 
 					// 非空才进行验证
-					switch con.Operator {
+					switch effectiveOperator {
 					case structured.ConditionEqual, structured.ConditionContains, structured.ConditionRegEqual:
 						q = f.getQuery(Should, queries...)
 					case structured.ConditionNotEqual, structured.ConditionNotContains, structured.ConditionNotRegEqual:
@@ -1115,7 +1128,7 @@ func (f *FormatFactory) Query(allConditions metadata.AllConditions) (elastic.Que
 							innerQuery := f.getQuery(Should, queries...)
 							nestedQuery := elastic.NewNestedQuery(nestedPath, innerQuery)
 							q = f.getQuery(MustNot, nestedQuery)
-							isNestedBefore = true // Mark as already nested to avoid double wrapping
+							isNestedBefore = true // 已经包装 nested，避免后续重复包装。
 						} else {
 							// 非嵌套字段直接使用MustNot
 							q = f.getQuery(MustNot, queries...)

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -260,7 +260,7 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"regexp":{"keyword":{"value":".*TypeError.*"}}}}`,
 		},
-		"结构化正则顶层或表达式按整体补齐包含匹配": {
+		"结构化正则顶层或表达式按分支补齐包含匹配": {
 			conditions: metadata.AllConditions{
 				{
 					{
@@ -270,7 +270,19 @@ func TestFormatFactory_Query(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"query":{"regexp":{"keyword":{"value":".*(foo|bar).*"}}}}`,
+			expected: `{"query":{"regexp":{"keyword":{"value":"(.*foo.*|.*bar.*)"}}}}`,
+		},
+		"结构化正则顶层或表达式保留分支锚点语义": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"^foo|bar"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"regexp":{"keyword":{"value":"(foo.*|.*bar.*)"}}}}`,
 		},
 		"结构化正则前缀锚点改写为整值前缀匹配": {
 			conditions: metadata.AllConditions{

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -248,6 +248,54 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"bool":{"should":[{"bool":{"must":[{"match_phrase":{"keyword":{"query":"test"}}},{"nested":{"query":{"match_phrase":{"nested1.key":{"query":"val-1"}}},"path":"nested1"}}]}},{"match_phrase":{"text":{"query":"test"}}}]}}}`,
 		},
+		"结构化正则普通文本补齐为包含匹配": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"TypeError"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"regexp":{"keyword":{"value":".*TypeError.*"}}}}`,
+		},
+		"结构化正则前缀锚点改写为整值前缀匹配": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"^TypeError"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"regexp":{"keyword":{"value":"TypeError.*"}}}}`,
+		},
+		"结构化正则负向前瞻改写为反向正则": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"^(?!.*idip).*"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"must_not":{"regexp":{"keyword":{"value":".*idip.*"}}}}}}`,
+		},
+		"结构化反向正则负向前瞻避免双重取反": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"^(?!.*idip).*"},
+						Operator:      structured.ConditionNotRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"regexp":{"keyword":{"value":".*idip.*"}}}}`,
+		},
 		"multiple nested fields in same condition group": {
 			conditions: metadata.AllConditions{
 				{

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -260,6 +260,18 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"regexp":{"keyword":{"value":".*TypeError.*"}}}}`,
 		},
+		"结构化正则顶层或表达式按整体补齐包含匹配": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"foo|bar"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"regexp":{"keyword":{"value":".*(foo|bar).*"}}}}`,
+		},
 		"结构化正则前缀锚点改写为整值前缀匹配": {
 			conditions: metadata.AllConditions{
 				{
@@ -282,7 +294,19 @@ func TestFormatFactory_Query(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"query":{"bool":{"must_not":{"regexp":{"keyword":{"value":".*idip.*"}}}}}}`,
+			expected: `{"query":{"bool":{"must":{"exists":{"field":"keyword"}},"must_not":{"regexp":{"keyword":{"value":".*idip.*"}}}}}}`,
+		},
+		"结构化正则负向前瞻只作用于当前 value": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"^(?!.*foo).*", "bar"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"should":[{"bool":{"must":{"exists":{"field":"keyword"}},"must_not":{"regexp":{"keyword":{"value":".*foo.*"}}}}},{"regexp":{"keyword":{"value":".*bar.*"}}}]}}}`,
 		},
 		"结构化反向正则负向前瞻避免双重取反": {
 			conditions: metadata.AllConditions{
@@ -294,7 +318,7 @@ func TestFormatFactory_Query(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"query":{"regexp":{"keyword":{"value":".*idip.*"}}}}`,
+			expected: `{"query":{"bool":{"must_not":{"bool":{"must":{"exists":{"field":"keyword"}},"must_not":{"regexp":{"keyword":{"value":".*idip.*"}}}}}}}}`,
 		},
 		"multiple nested fields in same condition group": {
 			conditions: metadata.AllConditions{

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -296,7 +296,7 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"regexp":{"keyword":{"value":"TypeError.*"}}}}`,
 		},
-		"结构化正则负向前瞻改写为反向正则": {
+		"结构化正则不包含前缀形式改写为反向正则": {
 			conditions: metadata.AllConditions{
 				{
 					{
@@ -308,7 +308,7 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"bool":{"must":{"exists":{"field":"keyword"}},"must_not":{"regexp":{"keyword":{"value":".*idip.*"}}}}}}`,
 		},
-		"结构化正则负向前瞻只作用于当前 value": {
+		"结构化正则不包含前缀形式只作用于当前 value": {
 			conditions: metadata.AllConditions{
 				{
 					{
@@ -320,7 +320,7 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"bool":{"should":[{"bool":{"must":{"exists":{"field":"keyword"}},"must_not":{"regexp":{"keyword":{"value":".*foo.*"}}}}},{"regexp":{"keyword":{"value":".*bar.*"}}}]}}}`,
 		},
-		"结构化反向正则负向前瞻避免双重取反": {
+		"结构化反向正则不包含前缀形式避免双重取反": {
 			conditions: metadata.AllConditions{
 				{
 					{


### PR DESCRIPTION
## 背景

监控历史策略中正则条件原先依赖后置过滤的搜索语义。切换到 ES `regexp` 后会按整值匹配处理，例如 `msg:/TypeError/` 只会匹配完整字段值等于 `TypeError` 的文档，和历史按包含匹配的语义不一致。

因此需要在 UQ 下发 ES `regexp` 前做基础 rewrite，将历史搜索语义转换为 ES 整值匹配语义。

## 变更

- 新增 ES regexp 兼容 rewrite 逻辑，主要覆盖以下规则：
  - 模糊匹配：`foo` -> `.*foo.*`
  - 前缀锚点：`^foo` -> `foo.*`
  - 后缀锚点：`foo$` -> `.*foo`
  - 首尾锚点：`^foo$` -> `foo`
- 在 Lucene 字段正则和结构化 `req` / `nreq` 条件生成 ES query 前复用同一套 rewrite 逻辑。
- 兼容 ES `regexp` 不支持的负向前瞻场景，将基础形式 `^(?!.*foo).*` 改写为反向正则 `.*foo.*`。
- 修复 `NOT field:""` 和 `NOT ((field:""))` 的 ES 语义，改为字段存在且不等于空字符串。
- 补充 Lucene parser、ES formatter 和 regexp rewrite 规则的回归测试。
