### PR TITLE
feat: (unify-query)修复 Lucene 非全局正向条件误进入聚合 include --story=135102352

### DIFF
--- a/pkg/unify-query/internal/function/highlight_test.go
+++ b/pkg/unify-query/internal/function/highlight_test.go
@@ -211,6 +211,42 @@ func TestQuery_LabelMap(t *testing.T) {
 			highLightData: map[string]any{},
 		},
 		{
+			name: "query string must modifier extracts positive leaf from mixed expression",
+			query: &metadata.Query{
+				QueryString: `+level:"warn" status:"error"`,
+			},
+			expected: map[string][]LabelMapValue{
+				"level": {
+					{Value: "warn", Operator: metadata.ConditionEqual},
+				},
+			},
+			data: map[string]any{
+				"level":  "warn",
+				"status": "error",
+			},
+			highLightData: map[string]any{
+				"level": []string{`<mark>warn</mark>`},
+			},
+		},
+		{
+			name: "query string must modifier extracts positive leaf with implicit not clause",
+			query: &metadata.Query{
+				QueryString: `+level:"warn" NOT status:"error"`,
+			},
+			expected: map[string][]LabelMapValue{
+				"level": {
+					{Value: "warn", Operator: metadata.ConditionEqual},
+				},
+			},
+			data: map[string]any{
+				"level":  "warn",
+				"status": "error",
+			},
+			highLightData: map[string]any{
+				"level": []string{`<mark>warn</mark>`},
+			},
+		},
+		{
 			name: "query string nested not group is not highlighted",
 			query: &metadata.Query{
 				QueryString: `NOT(game_ret:"-55" AND cmd:20118172) AND ((result:"-3888") OR (result:"-3999") OR (result:"-4000")) AND NOT (game_ret:"-16")`,

--- a/pkg/unify-query/internal/function/highlight_test.go
+++ b/pkg/unify-query/internal/function/highlight_test.go
@@ -182,6 +182,64 @@ func TestQuery_LabelMap(t *testing.T) {
 			},
 		},
 		{
+			name: "query string nested not group is not highlighted",
+			query: &metadata.Query{
+				QueryString: `NOT(game_ret:"-55" AND cmd:20118172) AND ((result:"-3888") OR (result:"-3999") OR (result:"-4000")) AND NOT (game_ret:"-16")`,
+			},
+			expected: map[string][]LabelMapValue{
+				"result": {
+					{Value: "-3888", Operator: metadata.ConditionEqual},
+					{Value: "-3999", Operator: metadata.ConditionEqual},
+					{Value: "-4000", Operator: metadata.ConditionEqual},
+				},
+			},
+		},
+		{
+			name: "query string nested not or group is not highlighted",
+			query: &metadata.Query{
+				QueryString: `log:"good" AND NOT(log:"bad" OR log:"worse")`,
+			},
+			expected: map[string][]LabelMapValue{
+				"log": {
+					{Value: "good", Operator: metadata.ConditionEqual},
+				},
+			},
+			data: map[string]any{
+				"log": "good bad worse",
+			},
+			highLightData: map[string]any{
+				"log": []string{`<mark>good</mark> bad worse`},
+			},
+		},
+		{
+			name: "query string double not group is highlighted",
+			query: &metadata.Query{
+				QueryString: `NOT(NOT(status:"error"))`,
+			},
+			expected: map[string][]LabelMapValue{
+				"status": {
+					{Value: "error", Operator: metadata.ConditionEqual},
+				},
+			},
+			data: map[string]any{
+				"status": "error",
+			},
+			highLightData: map[string]any{
+				"status": []string{`<mark>error</mark>`},
+			},
+		},
+		{
+			name: "query string positive leaf under negated mixed group is not highlighted",
+			query: &metadata.Query{
+				QueryString: `NOT(foo:"x" AND NOT status:"error")`,
+			},
+			expected: map[string][]LabelMapValue{},
+			data: map[string]any{
+				"status": "error",
+			},
+			highLightData: map[string]any{},
+		},
+		{
 			name: "query string wildcard preserves pattern",
 			query: &metadata.Query{
 				QueryString: "message:foo*bar",

--- a/pkg/unify-query/internal/function/highlight_test.go
+++ b/pkg/unify-query/internal/function/highlight_test.go
@@ -247,6 +247,18 @@ func TestQuery_LabelMap(t *testing.T) {
 			},
 		},
 		{
+			name: "query string must modifier under explicit or is not highlighted",
+			query: &metadata.Query{
+				QueryString: `+level:"warn" OR status:"error"`,
+			},
+			expected: map[string][]LabelMapValue{},
+			data: map[string]any{
+				"level":  "warn",
+				"status": "error",
+			},
+			highLightData: map[string]any{},
+		},
+		{
 			name: "query string nested not group is not highlighted",
 			query: &metadata.Query{
 				QueryString: `NOT(game_ret:"-55" AND cmd:20118172) AND ((result:"-3888") OR (result:"-3999") OR (result:"-4000")) AND NOT (game_ret:"-16")`,

--- a/pkg/unify-query/internal/function/highlight_test.go
+++ b/pkg/unify-query/internal/function/highlight_test.go
@@ -182,6 +182,35 @@ func TestQuery_LabelMap(t *testing.T) {
 			},
 		},
 		{
+			name: "query string implicit or same field group is highlighted",
+			query: &metadata.Query{
+				QueryString: `level:("warn" "error")`,
+			},
+			expected: map[string][]LabelMapValue{
+				"level": {
+					{Value: "warn", Operator: metadata.ConditionEqual},
+					{Value: "error", Operator: metadata.ConditionEqual},
+				},
+			},
+			data: map[string]any{
+				"level": "warn",
+			},
+			highLightData: map[string]any{
+				"level": []string{`<mark>warn</mark>`},
+			},
+		},
+		{
+			name: "query string implicit modifier keeps optional positive leaf unhighlighted",
+			query: &metadata.Query{
+				QueryString: `log:"good" NOT log:"bad"`,
+			},
+			expected: map[string][]LabelMapValue{},
+			data: map[string]any{
+				"log": "good bad",
+			},
+			highLightData: map[string]any{},
+		},
+		{
 			name: "query string nested not group is not highlighted",
 			query: &metadata.Query{
 				QueryString: `NOT(game_ret:"-55" AND cmd:20118172) AND ((result:"-3888") OR (result:"-3999") OR (result:"-4000")) AND NOT (game_ret:"-16")`,

--- a/pkg/unify-query/internal/lucene_parser/function.go
+++ b/pkg/unify-query/internal/lucene_parser/function.go
@@ -273,6 +273,17 @@ func conditionNodeWalkLogic(n *LogicNode, reversed bool, fn func(key string, ope
 		for _, label := range labels {
 			fn(label.field, label.operator, label.isWildcard, label.values...)
 		}
+		return
+	}
+
+	conditionNodeWalkMustClauses(n, reversed, fn)
+}
+
+func conditionNodeWalkMustClauses(n *LogicNode, reversed bool, fn func(key string, operator string, isWildcard bool, values ...string)) {
+	for _, node := range n.Nodes {
+		if node.mustOp {
+			conditionNodeWalk(node, reversed, fn)
+		}
 	}
 }
 

--- a/pkg/unify-query/internal/lucene_parser/function.go
+++ b/pkg/unify-query/internal/lucene_parser/function.go
@@ -214,6 +214,8 @@ func realValue(node Node) any {
 	return res
 }
 
+// ConditionNodeWalk 用于提取 LabelMap 候选条件。
+// 这里必须只输出“全局必然正向约束”，否则后续 ES 聚合 terms.include 会被错误收窄。
 func ConditionNodeWalk(node Node, fn func(key string, operator string, isWildcard bool, values ...string)) {
 	conditionNodeWalk(node, false, fn)
 }
@@ -253,9 +255,9 @@ func conditionNodeWalkCondition(n *ConditionNode, reversed bool, fn func(key str
 func conditionNodeWalkLogic(n *LogicNode, reversed bool, fn func(key string, operator string, isWildcard bool, values ...string)) {
 	reversed = toggleReverse(reversed, n.reverseOp)
 	if reversed {
-		// NOT over a composite expression may turn inner positive leaves into optional
-		// matches, for example NOT(a AND NOT b) => NOT a OR b.
-		// Only a single child can be safely reduced by propagating the NOT.
+		// NOT 作用到复合表达式时，内部反转后的正向叶子可能只是可选分支。
+		// 例如 NOT(a AND NOT b) 等价于 NOT a OR b，b 不能作为全局 include。
+		// 只有单子节点可以安全继续向下传递 NOT 语义。
 		if len(n.Nodes) == 1 {
 			conditionNodeWalk(n.Nodes[0], reversed, fn)
 		}
@@ -269,6 +271,8 @@ func conditionNodeWalkLogic(n *LogicNode, reversed bool, fn func(key string, ope
 		return
 	}
 
+	// 同字段 OR/隐式 OR 枚举可以安全作为该字段的 include 白名单。
+	// 例如 level:("warn" "error") 说明所有命中文档的 level 都在这组值内。
 	if labels, ok := sameFieldDisjunctionLabels(n); ok {
 		for _, label := range labels {
 			fn(label.field, label.operator, label.isWildcard, label.values...)
@@ -276,6 +280,8 @@ func conditionNodeWalkLogic(n *LogicNode, reversed bool, fn func(key string, ope
 		return
 	}
 
+	// 混合表达式中只提取实际会进入 must 的子句，保持与 LogicNode.DSL() 的执行语义一致。
+	// 例如 +level:warn status:error 可以提取 level，但 +level:warn OR status:error 不能提取。
 	conditionNodeWalkRequiredClauses(n, reversed, fn)
 }
 
@@ -292,6 +298,7 @@ func logicNodeConditionIsMust(n *LogicNode, index int, node *ConditionNode) bool
 	return logic == logicAnd || (logic == "" && (node.reverseOp || node.mustOp))
 }
 
+// logicNodeConditionOperator 对齐 LogicNode.DSL() 对第一个子句 operator 的特殊处理。
 func logicNodeConditionOperator(n *LogicNode, index int) string {
 	if index == 0 {
 		if len(n.logics) > 0 {

--- a/pkg/unify-query/internal/lucene_parser/function.go
+++ b/pkg/unify-query/internal/lucene_parser/function.go
@@ -276,15 +276,30 @@ func conditionNodeWalkLogic(n *LogicNode, reversed bool, fn func(key string, ope
 		return
 	}
 
-	conditionNodeWalkMustClauses(n, reversed, fn)
+	conditionNodeWalkRequiredClauses(n, reversed, fn)
 }
 
-func conditionNodeWalkMustClauses(n *LogicNode, reversed bool, fn func(key string, operator string, isWildcard bool, values ...string)) {
-	for _, node := range n.Nodes {
-		if node.mustOp {
+func conditionNodeWalkRequiredClauses(n *LogicNode, reversed bool, fn func(key string, operator string, isWildcard bool, values ...string)) {
+	for i, node := range n.Nodes {
+		if logicNodeConditionIsMust(n, i, node) {
 			conditionNodeWalk(node, reversed, fn)
 		}
 	}
+}
+
+func logicNodeConditionIsMust(n *LogicNode, index int, node *ConditionNode) bool {
+	logic := logicNodeConditionOperator(n, index)
+	return logic == logicAnd || (logic == "" && (node.reverseOp || node.mustOp))
+}
+
+func logicNodeConditionOperator(n *LogicNode, index int) string {
+	if index == 0 {
+		if len(n.logics) > 0 {
+			return n.logics[index]
+		}
+		return ""
+	}
+	return logicNodeOperator(n, index)
 }
 
 type conditionWalkLabel struct {

--- a/pkg/unify-query/internal/lucene_parser/function.go
+++ b/pkg/unify-query/internal/lucene_parser/function.go
@@ -297,12 +297,27 @@ func logicNodeIsDisjunction(n *LogicNode) bool {
 		return false
 	}
 
-	for i := 1; i < len(n.Nodes); i++ {
-		if logicNodeOperator(n, i) != logicOR {
+	for i, node := range n.Nodes {
+		if node.mustOp || node.reverseOp {
+			return false
+		}
+		if i == 0 {
+			continue
+		}
+		if !logicNodeOperatorIsDisjunction(n, i) {
 			return false
 		}
 	}
 	return true
+}
+
+func logicNodeOperatorIsDisjunction(n *LogicNode, index int) bool {
+	switch logicNodeOperator(n, index) {
+	case logicOR, "":
+		return true
+	default:
+		return false
+	}
 }
 
 func logicNodeOperator(n *LogicNode, index int) string {

--- a/pkg/unify-query/internal/lucene_parser/function.go
+++ b/pkg/unify-query/internal/lucene_parser/function.go
@@ -215,74 +215,211 @@ func realValue(node Node) any {
 }
 
 func ConditionNodeWalk(node Node, fn func(key string, operator string, isWildcard bool, values ...string)) {
+	conditionNodeWalk(node, false, fn)
+}
+
+func conditionNodeWalk(node Node, reversed bool, fn func(key string, operator string, isWildcard bool, values ...string)) {
 	if node == nil {
 		return
 	}
 
 	switch n := node.(type) {
 	case *ConditionNode:
-		if n.value == nil {
-			return
-		}
-
-		var (
-			field      string
-			op         string
-			isWildcard bool
-		)
-		if n.field != nil {
-			field = n.field.String()
-		}
-		if n.op != nil {
-			op = n.op.String()
-		}
-
-		value := n.value.String()
-
-		switch v := n.value.(type) {
-		case *WildCardNode:
-			op = metadata.ConditionContains
-			isWildcard = true
-			value = normalizeWildcardConditionValue(value)
-		case *RegexpNode:
-			op = metadata.ConditionRegEqual
-		case *StringNode:
-			op = metadata.ConditionEqual
-			// 转义
-			value = strings.ReplaceAll(value, `\`, ``)
-			if n.isQuoted {
-				value = strings.Trim(value, `"`)
-			}
-		case *LogicNode:
-			v.SetField(n.field)
-			ConditionNodeWalk(n.value, fn)
-			return
-		default:
-			return
-		}
-
-		if n.reverseOp {
-			switch op {
-			case metadata.ConditionEqual:
-				op = metadata.ConditionNotEqual
-			case metadata.ConditionNotEqual:
-				op = metadata.ConditionEqual
-			case metadata.ConditionContains:
-				op = metadata.ConditionNotContains
-			case metadata.ConditionNotContains:
-				op = metadata.ConditionContains
-			case metadata.ConditionRegEqual:
-				op = metadata.ConditionNotRegEqual
-			case metadata.ConditionNotRegEqual:
-				op = metadata.ConditionRegEqual
-			}
-		}
-
-		fn(field, op, isWildcard, value)
+		conditionNodeWalkCondition(n, reversed, fn)
 	case *LogicNode:
-		for _, ln := range n.Nodes {
-			ConditionNodeWalk(ln, fn)
+		conditionNodeWalkLogic(n, reversed, fn)
+	}
+}
+
+func conditionNodeWalkCondition(n *ConditionNode, reversed bool, fn func(key string, operator string, isWildcard bool, values ...string)) {
+	if n.value == nil {
+		return
+	}
+
+	reversed = toggleReverse(reversed, n.reverseOp)
+	if v, ok := n.value.(*LogicNode); ok {
+		v.SetField(n.field)
+		conditionNodeWalkLogic(v, reversed, fn)
+		return
+	}
+
+	label, ok := conditionNodeLabel(n, reversed)
+	if !ok {
+		return
+	}
+	fn(label.field, label.operator, label.isWildcard, label.values...)
+}
+
+func conditionNodeWalkLogic(n *LogicNode, reversed bool, fn func(key string, operator string, isWildcard bool, values ...string)) {
+	reversed = toggleReverse(reversed, n.reverseOp)
+	if reversed {
+		// NOT over a composite expression may turn inner positive leaves into optional
+		// matches, for example NOT(a AND NOT b) => NOT a OR b.
+		// Only a single child can be safely reduced by propagating the NOT.
+		if len(n.Nodes) == 1 {
+			conditionNodeWalk(n.Nodes[0], reversed, fn)
 		}
+		return
+	}
+
+	if logicNodeIsConjunction(n) {
+		for _, ln := range n.Nodes {
+			conditionNodeWalk(ln, reversed, fn)
+		}
+		return
+	}
+
+	if labels, ok := sameFieldDisjunctionLabels(n); ok {
+		for _, label := range labels {
+			fn(label.field, label.operator, label.isWildcard, label.values...)
+		}
+	}
+}
+
+type conditionWalkLabel struct {
+	field      string
+	operator   string
+	isWildcard bool
+	values     []string
+}
+
+func logicNodeIsConjunction(n *LogicNode) bool {
+	for i := 1; i < len(n.Nodes); i++ {
+		if logicNodeOperator(n, i) != logicAnd {
+			return false
+		}
+	}
+	return true
+}
+
+func logicNodeIsDisjunction(n *LogicNode) bool {
+	if len(n.Nodes) <= 1 {
+		return false
+	}
+
+	for i := 1; i < len(n.Nodes); i++ {
+		if logicNodeOperator(n, i) != logicOR {
+			return false
+		}
+	}
+	return true
+}
+
+func logicNodeOperator(n *LogicNode, index int) string {
+	if index <= 0 || index-1 >= len(n.logics) {
+		return ""
+	}
+	return n.logics[index-1]
+}
+
+func sameFieldDisjunctionLabels(n *LogicNode) ([]conditionWalkLabel, bool) {
+	if !logicNodeIsDisjunction(n) {
+		return nil, false
+	}
+
+	labels := make([]conditionWalkLabel, 0, len(n.Nodes))
+	var (
+		field    string
+		hasField bool
+	)
+	for _, node := range n.Nodes {
+		label, ok := positiveLeafLabel(node)
+		if !ok {
+			return nil, false
+		}
+		if !hasField {
+			field = label.field
+			hasField = true
+		} else if field != label.field {
+			return nil, false
+		}
+		labels = append(labels, label)
+	}
+
+	return labels, true
+}
+
+func positiveLeafLabel(n *ConditionNode) (conditionWalkLabel, bool) {
+	if n.value == nil || n.reverseOp {
+		return conditionWalkLabel{}, false
+	}
+
+	if v, ok := n.value.(*LogicNode); ok {
+		v.SetField(n.field)
+		if len(v.Nodes) != 1 || v.reverseOp {
+			return conditionWalkLabel{}, false
+		}
+		return positiveLeafLabel(v.Nodes[0])
+	}
+
+	return conditionNodeLabel(n, false)
+}
+
+func conditionNodeLabel(n *ConditionNode, reversed bool) (conditionWalkLabel, bool) {
+	var (
+		field      string
+		op         string
+		isWildcard bool
+	)
+	if n.field != nil {
+		field = n.field.String()
+	}
+	if n.op != nil {
+		op = n.op.String()
+	}
+
+	value := n.value.String()
+
+	switch n.value.(type) {
+	case *WildCardNode:
+		op = metadata.ConditionContains
+		isWildcard = true
+		value = normalizeWildcardConditionValue(value)
+	case *RegexpNode:
+		op = metadata.ConditionRegEqual
+	case *StringNode:
+		op = metadata.ConditionEqual
+		// 转义
+		value = strings.ReplaceAll(value, `\`, ``)
+		if n.isQuoted {
+			value = strings.Trim(value, `"`)
+		}
+	default:
+		return conditionWalkLabel{}, false
+	}
+
+	if reversed {
+		op = reverseConditionOperator(op)
+	}
+
+	return conditionWalkLabel{
+		field:      field,
+		operator:   op,
+		isWildcard: isWildcard,
+		values:     []string{value},
+	}, true
+}
+
+func toggleReverse(reversed, current bool) bool {
+	return reversed != current
+}
+
+func reverseConditionOperator(op string) string {
+	switch op {
+	case metadata.ConditionEqual:
+		return metadata.ConditionNotEqual
+	case metadata.ConditionNotEqual:
+		return metadata.ConditionEqual
+	case metadata.ConditionContains:
+		return metadata.ConditionNotContains
+	case metadata.ConditionNotContains:
+		return metadata.ConditionContains
+	case metadata.ConditionRegEqual:
+		return metadata.ConditionNotRegEqual
+	case metadata.ConditionNotRegEqual:
+		return metadata.ConditionRegEqual
+	default:
+		return op
 	}
 }
 

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -1481,6 +1481,54 @@ func TestFormatFactory_AggIncludeValuesKeepsMustModifierInMixedExpression(t *tes
 	}`, string(bodyJSON))
 }
 
+func TestFormatFactory_AggIncludeValuesSkipsMustModifierUnderExplicitOr(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+	query := &metadata.Query{
+		QueryString: `+level:"warn" OR status:"error"`,
+		Aggregates: metadata.Aggregates{
+			{
+				Name:       Count,
+				Field:      "_index",
+				Dimensions: []string{"level"},
+			},
+		},
+	}
+
+	fact := NewFormatFactory(ctx).
+		WithIncludeValues(function.LabelMap(ctx, query)).
+		WithQuery("_index", metadata.TimeField{}, time.Time{}, time.Time{}, function.Millisecond, 10000)
+
+	name, agg, err := fact.EsAgg(query.Aggregates)
+	assert.NoError(t, err)
+
+	ss := elastic.NewSearchSource().Aggregation(name, agg).Size(0)
+	body, err := ss.Source()
+	assert.NoError(t, err)
+
+	bodyJSON, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"aggregations": {
+			"level": {
+				"aggregations": {
+					"_value": {
+						"value_count": {
+							"field": "_index"
+						}
+					}
+				},
+				"terms": {
+					"field": "level",
+					"missing": " ",
+					"size": 10000
+				}
+			}
+		},
+		"size": 0
+	}`, string(bodyJSON))
+}
+
 func TestFormatFactory_AggIncludeValuesSkipsOptionalPositiveLeafFromNegatedMixedGroup(t *testing.T) {
 	ctx := metadata.InitHashID(context.Background())
 	query := &metadata.Query{

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -1423,6 +1423,64 @@ func TestFormatFactory_AggIncludeValuesKeepsImplicitOrSameFieldGroup(t *testing.
 	}`, string(bodyJSON))
 }
 
+func TestFormatFactory_AggIncludeValuesKeepsMustModifierInMixedExpression(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+	query := &metadata.Query{
+		QueryString: `+level:"warn" status:"error"`,
+		Aggregates: metadata.Aggregates{
+			{
+				Name:       Count,
+				Field:      "_index",
+				Dimensions: []string{"level", "status"},
+			},
+		},
+	}
+
+	fact := NewFormatFactory(ctx).
+		WithIncludeValues(function.LabelMap(ctx, query)).
+		WithQuery("_index", metadata.TimeField{}, time.Time{}, time.Time{}, function.Millisecond, 10000)
+
+	name, agg, err := fact.EsAgg(query.Aggregates)
+	assert.NoError(t, err)
+
+	ss := elastic.NewSearchSource().Aggregation(name, agg).Size(0)
+	body, err := ss.Source()
+	assert.NoError(t, err)
+
+	bodyJSON, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"aggregations": {
+			"status": {
+				"aggregations": {
+					"level": {
+						"aggregations": {
+							"_value": {
+								"value_count": {
+									"field": "_index"
+								}
+							}
+						},
+						"terms": {
+							"field": "level",
+							"include": ["warn"],
+							"missing": " ",
+							"size": 10000
+						}
+					}
+				},
+				"terms": {
+					"field": "status",
+					"missing": " ",
+					"size": 10000
+				}
+			}
+		},
+		"size": 0
+	}`, string(bodyJSON))
+}
+
 func TestFormatFactory_AggIncludeValuesSkipsOptionalPositiveLeafFromNegatedMixedGroup(t *testing.T) {
 	ctx := metadata.InitHashID(context.Background())
 	query := &metadata.Query{

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -1316,6 +1316,112 @@ func TestBuildQuery(t *testing.T) {
 	}
 }
 
+func TestFormatFactory_AggIncludeValuesSkipsNegatedQueryStringValues(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+	query := &metadata.Query{
+		QueryString: `NOT(game_ret:"-55" AND cmd:20118172) AND ((result:"-3888") OR (result:"-3999") OR (result:"-4000")) AND NOT (game_ret:"-16")`,
+		Aggregates: metadata.Aggregates{
+			{
+				Name:       Count,
+				Field:      "_index",
+				Dimensions: []string{"result", "game_ret"},
+			},
+		},
+	}
+
+	fact := NewFormatFactory(ctx).
+		WithIncludeValues(function.LabelMap(ctx, query)).
+		WithQuery("_index", metadata.TimeField{}, time.Time{}, time.Time{}, function.Millisecond, 10000)
+
+	name, agg, err := fact.EsAgg(query.Aggregates)
+	assert.NoError(t, err)
+
+	ss := elastic.NewSearchSource().Aggregation(name, agg).Size(0)
+	body, err := ss.Source()
+	assert.NoError(t, err)
+
+	bodyJSON, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"aggregations": {
+			"game_ret": {
+				"aggregations": {
+					"result": {
+						"aggregations": {
+							"_value": {
+								"value_count": {
+									"field": "_index"
+								}
+							}
+						},
+						"terms": {
+							"field": "result",
+							"include": ["-3888", "-3999", "-4000"],
+							"missing": " ",
+							"size": 10000
+						}
+					}
+				},
+				"terms": {
+					"field": "game_ret",
+					"missing": " ",
+					"size": 10000
+				}
+			}
+		},
+		"size": 0
+		}`, string(bodyJSON))
+}
+
+func TestFormatFactory_AggIncludeValuesSkipsOptionalPositiveLeafFromNegatedMixedGroup(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+	query := &metadata.Query{
+		QueryString: `NOT(foo:"x" AND NOT status:"error")`,
+		Aggregates: metadata.Aggregates{
+			{
+				Name:       Count,
+				Field:      "_index",
+				Dimensions: []string{"status"},
+			},
+		},
+	}
+
+	fact := NewFormatFactory(ctx).
+		WithIncludeValues(function.LabelMap(ctx, query)).
+		WithQuery("_index", metadata.TimeField{}, time.Time{}, time.Time{}, function.Millisecond, 10000)
+
+	name, agg, err := fact.EsAgg(query.Aggregates)
+	assert.NoError(t, err)
+
+	ss := elastic.NewSearchSource().Aggregation(name, agg).Size(0)
+	body, err := ss.Source()
+	assert.NoError(t, err)
+
+	bodyJSON, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"aggregations": {
+			"status": {
+				"aggregations": {
+					"_value": {
+						"value_count": {
+							"field": "_index"
+						}
+					}
+				},
+				"terms": {
+					"field": "status",
+					"missing": " ",
+					"size": 10000
+				}
+			}
+		},
+		"size": 0
+	}`, string(bodyJSON))
+}
+
 func TestFactory_Agg(t *testing.T) {
 	testCases := map[string]struct {
 		aggInfoList []any

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -1374,6 +1374,55 @@ func TestFormatFactory_AggIncludeValuesSkipsNegatedQueryStringValues(t *testing.
 		}`, string(bodyJSON))
 }
 
+func TestFormatFactory_AggIncludeValuesKeepsImplicitOrSameFieldGroup(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+	query := &metadata.Query{
+		QueryString: `level:("warn" "error")`,
+		Aggregates: metadata.Aggregates{
+			{
+				Name:       Count,
+				Field:      "_index",
+				Dimensions: []string{"level"},
+			},
+		},
+	}
+
+	fact := NewFormatFactory(ctx).
+		WithIncludeValues(function.LabelMap(ctx, query)).
+		WithQuery("_index", metadata.TimeField{}, time.Time{}, time.Time{}, function.Millisecond, 10000)
+
+	name, agg, err := fact.EsAgg(query.Aggregates)
+	assert.NoError(t, err)
+
+	ss := elastic.NewSearchSource().Aggregation(name, agg).Size(0)
+	body, err := ss.Source()
+	assert.NoError(t, err)
+
+	bodyJSON, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"aggregations": {
+			"level": {
+				"aggregations": {
+					"_value": {
+						"value_count": {
+							"field": "_index"
+						}
+					}
+				},
+				"terms": {
+					"field": "level",
+					"include": ["warn", "error"],
+					"missing": " ",
+					"size": 10000
+				}
+			}
+		},
+		"size": 0
+	}`, string(bodyJSON))
+}
+
 func TestFormatFactory_AggIncludeValuesSkipsOptionalPositiveLeafFromNegatedMixedGroup(t *testing.T) {
 	ctx := metadata.InitHashID(context.Background())
 	query := &metadata.Query{


### PR DESCRIPTION
## 背景

在 BKLog 通过 UQ 查询 ES 聚合数据时，发现与直查 ES 的聚合结果不一致。排查 trace 后确认，查询过滤条件本身能够命中文档，但 UQ 生成的 ES 聚合 DSL 中，`game_ret.terms.include` 被错误加入了 `query_string` 中 `NOT(...)` 条件里的 `game_ret` 值。

ES 的 `terms.include` 是聚合 bucket 白名单，因此真实聚合结果中的 `game_ret=-28/-136` 被过滤掉，只剩下 include 列表中的 `game_ret=-57`，导致 UQ 聚合结果少于直查 ES。

## 修复

修复 Lucene 条件提取逻辑，`ConditionNodeWalk` 不再简单按叶子节点的正负状态提取字段值，而是结合父级布尔结构，只提取“可证明会约束所有命中文档”的正向条件，用于 `LabelMap` 和 ES 聚合 `terms.include` 优化。

修复后：

- `NOT(game_ret:"-55" AND cmd:20118172)` 中的 `game_ret/cmd` 会被识别为非正向条件，不再进入聚合 include
- `NOT(foo:"x" AND NOT status:"error")` 这类反转后的混合表达式不会把 `status:error` 误当成全局必选条件
- `level:("warn" "error")` 这类同字段隐式 OR 枚举仍会保留 include 优化
- `+level:"warn" status:"error"` 中的 `+level` 会被识别为全局必选条件并保留 include
- `+level:"warn" OR status:"error"` 中的 `+level` 属于 OR 分支，不会被误提取为全局必选条件

因此，只有真实的正向必然条件才会进入 ES `terms.include`，避免聚合 bucket 被错误白名单过滤，同时保留安全场景下的 include 优化。