### PR TITLE
fix: [collector] 修复 license_checker reload 时会导致 panic 问题

### DIFF
--- a/pkg/collector/confengine/config.go
+++ b/pkg/collector/confengine/config.go
@@ -182,3 +182,7 @@ func (tc *TierConfig) Get(token, serviceID, instanceID string) any {
 
 	return nil
 }
+
+func (tc *TierConfig) GetExact(token, typ, id string) (any, bool) {
+	return tc.m.Load(tierKey{Token: token, Type: typ, ID: id})
+}

--- a/pkg/collector/confengine/config_test.go
+++ b/pkg/collector/confengine/config_test.go
@@ -40,9 +40,19 @@ func TestTierConfig(t *testing.T) {
 
 	tc.Del("token1", "service", "service1")
 	assert.Equal(t, "token1", tc.Get("token1", "service1", "").(testConfig).id)
+	_, ok := tc.GetExact("token1", "service", "service1")
+	assert.False(t, ok)
 
 	tc.DelGlobal()
 	assert.Nil(t, tc.GetGlobal())
+	assert.Nil(t, tc.GetByToken("not_exists"))
+
+	val, ok := tc.GetExact("token1", "service", "service2")
+	assert.True(t, ok)
+	assert.Equal(t, "token1/service2", val.(testConfig).id)
+
+	_, ok = tc.GetExact("not_exists", "default", "")
+	assert.False(t, ok)
 }
 
 func TestConfig(t *testing.T) {

--- a/pkg/collector/processor/licensechecker/factory.go
+++ b/pkg/collector/processor/licensechecker/factory.go
@@ -115,17 +115,18 @@ func (p *licenseChecker) Reload(config map[string]any, customized []processor.Su
 
 	diffRet := processor.DiffCustomizedConfig(p.SubConfigs(), customized)
 	for _, obj := range diffRet.Keep {
-		f.cacheMgrs.Get(obj.Token, obj.Type, obj.ID).(*licensecache.Manager).Clean()
+		cleanExactCacheMgr(f.cacheMgrs, obj)
 	}
 
 	for _, obj := range diffRet.Updated {
-		p.cacheMgrs.Get(obj.Token, obj.Type, obj.ID).(*licensecache.Manager).Clean()
-		newCacheMgr := f.cacheMgrs.Get(obj.Token, obj.Type, obj.ID)
-		p.cacheMgrs.Set(obj.Token, obj.Type, obj.ID, newCacheMgr)
+		cleanExactCacheMgr(p.cacheMgrs, obj)
+		if newCacheMgr, ok := f.cacheMgrs.GetExact(obj.Token, obj.Type, obj.ID); ok {
+			p.cacheMgrs.Set(obj.Token, obj.Type, obj.ID, newCacheMgr)
+		}
 	}
 
 	for _, obj := range diffRet.Deleted {
-		p.cacheMgrs.Get(obj.Token, obj.Type, obj.ID).(*licensecache.Manager).Clean()
+		cleanExactCacheMgr(p.cacheMgrs, obj)
 		p.cacheMgrs.Del(obj.Token, obj.Type, obj.ID)
 	}
 
@@ -136,6 +137,12 @@ func (p *licenseChecker) Reload(config map[string]any, customized []processor.Su
 func (p *licenseChecker) Clean() {
 	for _, obj := range p.cacheMgrs.All() {
 		obj.(*licensecache.Manager).Clean()
+	}
+}
+
+func cleanExactCacheMgr(cacheMgrs *confengine.TierConfig, obj processor.SubConfigProcessor) {
+	if mgr, ok := cacheMgrs.GetExact(obj.Token, obj.Type, obj.ID); ok {
+		mgr.(*licensecache.Manager).Clean()
 	}
 }
 

--- a/pkg/collector/processor/licensechecker/factory_test.go
+++ b/pkg/collector/processor/licensechecker/factory_test.go
@@ -77,6 +77,49 @@ processor:
 	assert.Equal(t, mainConf, factory.MainConfig())
 }
 
+func TestLicenseCheckerReloadNewDefaultSubConfigs(t *testing.T) {
+	content := `
+processor:
+    - name: "license_checker/common"
+      config:
+        enabled: true
+        expire_time: 4084531651
+        tolerable_expire: 24h
+        number_nodes: 200
+        tolerable_num_ratio: 1.5
+`
+	mainConf := processor.MustLoadConfigs(content)[0].Config
+
+	obj, err := NewFactory(mainConf, nil)
+	assert.NoError(t, err)
+	factory := obj.(*licenseChecker)
+	defer factory.Clean()
+
+	customized := []processor.SubConfigProcessor{
+		{
+			Token: "token1",
+			Type:  define.SubConfigFieldDefault,
+			Config: processor.Config{
+				Name:   define.ProcessorLicenseChecker,
+				Config: mainConf,
+			},
+		},
+		{
+			Token: "token2",
+			Type:  define.SubConfigFieldDefault,
+			Config: processor.Config{
+				Name:   define.ProcessorLicenseChecker,
+				Config: mainConf,
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		factory.Reload(mainConf, customized)
+	})
+	assert.Equal(t, customized, factory.SubConfigs())
+}
+
 func TestLicenseCheckerProcess(t *testing.T) {
 	content := `
 processor:

--- a/pkg/collector/processor/licensechecker/licensecache/manager.go
+++ b/pkg/collector/processor/licensechecker/licensecache/manager.go
@@ -18,6 +18,7 @@ type Manager struct {
 	mut        sync.RWMutex
 	caches     map[string]*Cache
 	stop       chan struct{}
+	cleanOnce  sync.Once
 	gcInterval time.Duration
 }
 
@@ -31,7 +32,9 @@ func NewManager() *Manager {
 }
 
 func (mgr *Manager) Clean() {
-	close(mgr.stop)
+	mgr.cleanOnce.Do(func() {
+		close(mgr.stop)
+	})
 }
 
 func (mgr *Manager) Get(k string) *Cache {

--- a/pkg/collector/processor/licensechecker/licensecache/manager_test.go
+++ b/pkg/collector/processor/licensechecker/licensecache/manager_test.go
@@ -47,4 +47,12 @@ func TestCacheManager(t *testing.T) {
 		assert.NotNil(t, mgr.GetOrCreate("key1"))
 		assert.Nil(t, mgr.Get("key2")) // gc
 	})
+
+	t.Run("CleanIdempotent", func(t *testing.T) {
+		mgr := NewManager()
+		assert.NotPanics(t, func() {
+			mgr.Clean()
+			mgr.Clean()
+		})
+	})
 }


### PR DESCRIPTION
1. licenseChecker.Reload() 在处理多个新增 license_checker/common default 子配置时，错误地使用了带 fallback 语义的 TierConfig.Get() 去清理旧 cache manager，导致多个新增 token 都 fallback 到同一个 global licensecache.Manager，该 manager 的 Clean() 又不是幂等的，第二次 close(mgr.stop) 触发 panic: close of closed channel

报错的日志内容如下：
```
2026-05-05 11:50:42.507 INFO pipeline/manager.go:248 merge platform processor: license_checker/common
2026-05-05 11:50:42.507 INFO pipeline/manager.go:248 merge platform processor: traces_deriver/delta_duration
2026-05-05 11:50:42.509 INFO pipeline/manager.go:248 merge platform processor: field_normalizer/otel_mapping
2026-05-05 11:50:42.530 WARN tokenreplacer/config.go:56 unknown tokenreplacer type: , skipping initialization
2026-05-05 11:50:42.535 INFO processor/processor.go:115 diff: new processor 'license_checker/common', token=Ymtia2JrYmtia2JrYmtia5mGQPsVC4obBHRlgFDFpvn4MMtKbUZcKyCnhsqP4a9r8JH1u1F122OeTMT13dGlz5nP/DICLyl0kbd0NESS3OE=, type=default, id=
2026-05-05 11:50:42.535 INFO processor/processor.go:115 diff: new processor 'license_checker/common', token=Ymtia2JrYmtia2JrYmtia93rRcMc8CttFPYi0OKPheoRe0Hd6P4h/6Om64aTh8p7xDY1TNVc5iXNejfoSpOgXA==, type=default, id=
2026-05-05 11:50:42.535 INFO processor/processor.go:115 diff: new processor 'license_checker/common', token=Ymtia2JrYmtia2JrYmtiazmjBSuGQDQGguhbavERVZRVWPODPtiMbTyR7KPBF0c6+/+fKmOAlG+8/uST9JRjtA==, type=default, id=
2026-05-05 11:50:42.536 ERROR utils/recover.go:46 Observed a panic: "close of closed channel" (close of closed channel)
goroutine 1 [running]:
github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/internal/utils.logPanic({0xed6ae0, 0x1302ac0})
/home/golang/bk-monitor-datalink/pkg/collector/internal/utils/recover.go:42 +0x4c
github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/internal/utils.HandleCrash()
/home/golang/bk-monitor-datalink/pkg/collector/internal/utils/recover.go:53 +0x6c
panic({0xed6ae0?, 0x1302ac0?})
/usr/local/go/src/runtime/panic.go:792 +0x124
github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/processor/licensechecker/licensecache.(*Manager).Clean(...)
/home/golang/bk-monitor-datalink/pkg/collector/processor/licensechecker/licensecache/manager.go:34
github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/processor/licensechecker.(*licenseChecker).Reload(0x4000c688a0, 0x40016f0330, {0x4001b7f008, 0x114, 0x11c})
/home/golang/bk-monitor-datalink/pkg/collector/processor/licensechecker/factory.go:122 +0x264
github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/pipeline.(*Manager).Reload(0x4000cd8790, 0x0?)
/home/golang/bk-monitor-datalink/pkg/collector/pipeline/manager.go:391 +0x184
github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/controller.(*Controller).Reload(0x400158ce40, 0x4001fbdee8)
/home/golang/bk-monitor-datalink/pkg/collector/controller/controller.go:339 +0x8c
main.main()
/home/golang/bk-monitor-datalink/pkg/collector/cmd/collector/main.go:73 +0x320
```