### PR TITLE
fix: (unify-query)修复 PromQL 引擎初始化时空参数导致的空指针风险 --bug=159252228

### DIFF
--- a/pkg/unify-query/query/promql/engine.go
+++ b/pkg/unify-query/query/promql/engine.go
@@ -26,6 +26,7 @@ type Params struct {
 }
 
 var GlobalEngine *prom.Engine
+
 var defaultLookbackDelta = 5 * time.Minute
 
 // NewEngine
@@ -35,7 +36,10 @@ func NewEngine(params *Params) {
 	if GlobalEngine != nil {
 		return
 	}
-	if params != nil && params.LookbackDelta > 0 {
+	if params == nil {
+		params = &Params{}
+	}
+	if params.LookbackDelta > 0 {
 		defaultLookbackDelta = params.LookbackDelta
 	}
 	GlobalEngine = prom.NewEngine(prom.EngineOpts{

--- a/pkg/unify-query/query/promql/engine_test.go
+++ b/pkg/unify-query/query/promql/engine_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	prom "github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,4 +32,25 @@ func TestNewEngineKeepsDefaultLookbackForExistingEngine(t *testing.T) {
 	NewEngine(&Params{LookbackDelta: 2 * time.Hour})
 
 	assert.Equal(t, 10*time.Minute, GetDefaultLookbackDelta())
+}
+
+func TestNewEngineHandlesNilParams(t *testing.T) {
+	oldEngine := GlobalEngine
+	oldLookback := defaultLookbackDelta
+	oldRegisterer := prometheus.DefaultRegisterer
+	t.Cleanup(func() {
+		GlobalEngine = oldEngine
+		defaultLookbackDelta = oldLookback
+		prometheus.DefaultRegisterer = oldRegisterer
+	})
+
+	GlobalEngine = nil
+	defaultLookbackDelta = 5 * time.Minute
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	assert.NotPanics(t, func() {
+		NewEngine(nil)
+	})
+	assert.NotNil(t, GlobalEngine)
+	assert.Equal(t, 5*time.Minute, GetDefaultLookbackDelta())
 }


### PR DESCRIPTION
## 背景

`promql.NewEngine` 在初始化时只对 `params.LookbackDelta` 做了空值保护，但后续构造 `prom.EngineOpts` 时仍直接读取 `params.MaxSamples`、`params.Timeout` 等字段。

如果调用方传入 `nil`，会存在空指针解引用风险，并触发 `ForwardNull` 静态检查告警。

## 修复

在 `NewEngine` 入口处将 `nil params` 统一归一为空的 `Params` 实例，保证后续参数读取安全，同时保持已有非空参数的初始化逻辑不变。

补充 `NewEngine(nil)` 回归测试，验证空参数场景不会 panic，且默认 `lookback delta` 行为保持不变。

## 测试

```bash
go test ./query/promql