### PR TITLE
feat: (unify-query)显式 table_id/data_label 查询跳过 field_names 硬过滤 --story=135306762

### DIFF
--- a/pkg/unify-query/metadata/const.go
+++ b/pkg/unify-query/metadata/const.go
@@ -32,7 +32,9 @@ const (
 
 	SpaceIsNotExists             = "SPACE_IS_NOT_EXISTS"
 	SpaceTableIDFieldIsNotExists = "SPACE_TABLE_ID_FIELD_IS_NOT_EXISTS"
-	TableIDProxyISNotExists      = "TABLE_ID_PROXY_IS_NOT_EXISTS"
+	// SpaceTableIDFieldMissingFallback 显式 table_id/data_label 路由下，字段在 RT Fields 中缺失（元数据可能过期/延迟）
+	SpaceTableIDFieldMissingFallback = "SPACE_TABLE_ID_FIELD_MISSING_FALLBACK"
+	TableIDProxyISNotExists          = "TABLE_ID_PROXY_IS_NOT_EXISTS"
 
 	QueryRawError = "QUERY_RAW_ERROR"
 

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -105,7 +105,8 @@ func (s *SpaceFilter) getTsDBWithResultTableDetail(t query.TsDBV2, d *routerInfl
 }
 
 func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fieldNameExp *regexp.Regexp, allConditions AllConditions,
-	fieldName, tableID string, isK8s, isK8sFeatureFlag, isSkipField, isFieldMissingFallback bool, tableIDConditions AllConditions,
+	fieldName, tableID string, isK8s, isK8sFeatureFlag, isSkipField, isFieldMissingFallback, isFullTableID bool,
+	tableIDConditions AllConditions,
 ) ([]*query.TsDBV2, error) {
 	rtDetail := s.router.GetResultTable(s.ctx, tableID, false)
 	if rtDetail == nil {
@@ -198,10 +199,22 @@ func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fiel
 	}
 	// 如果字段都不匹配到目标字段，则非目标结果表
 	if len(metricNames) == 0 {
-		// 显式 table_id/data_label 场景下，Fields 只作为辅助展开索引；未命中时兜底返回原 RT。
-		if isFieldMissingFallback {
+		// 显式 table_id/data_label 场景下，Fields 只作为辅助展开索引；未命中时按候选 RT 兜底。
+		// 但正则未命中时不能把正则串当字面 metric/measurement 下推。
+		if isFieldMissingFallback && fieldName != "" && fieldNameExp == nil {
 			defaultTsDB.ExpandMetricNames = []string{fieldName}
-			tsDBs = append(tsDBs, &defaultTsDB)
+			// 完整 table_id 场景下仍复用单指标单表的独立 RT 路由；data_label 多候选保持候选 RT 兜底，避免重复拼到同一个独立 RT。
+			if defaultTsDB.IsSplit() && isFullTableID {
+				sepRt := s.GetMetricSepRT(tableID, fieldName)
+				if sepRt != nil {
+					sepTsDB := s.getTsDBWithResultTableDetail(defaultTsDB, sepRt)
+					tsDBs = append(tsDBs, &sepTsDB)
+				} else {
+					tsDBs = append(tsDBs, &defaultTsDB)
+				}
+			} else {
+				tsDBs = append(tsDBs, &defaultTsDB)
+			}
 		}
 		return tsDBs, nil
 	}
@@ -361,7 +374,7 @@ func (s *SpaceFilter) DataList(opt *TsDBOption) ([]*query.TsDBV2, error) {
 			}
 		}
 		// 指标模糊匹配，可能命中多个私有指标 RT
-		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, db != "", tableIDCondsForFilter)
+		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, db != "", measurement != "", tableIDCondsForFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -105,8 +105,7 @@ func (s *SpaceFilter) getTsDBWithResultTableDetail(t query.TsDBV2, d *routerInfl
 }
 
 func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fieldNameExp *regexp.Regexp, allConditions AllConditions,
-	fieldName, tableID string, isK8s, isK8sFeatureFlag, isSkipField, isFieldMissingFallback, isFullTableID bool,
-	tableIDConditions AllConditions,
+	fieldName, tableID string, isK8s, isK8sFeatureFlag, isSkipField, isFieldMissingFallback bool, tableIDConditions AllConditions,
 ) ([]*query.TsDBV2, error) {
 	rtDetail := s.router.GetResultTable(s.ctx, tableID, false)
 	if rtDetail == nil {
@@ -203,18 +202,7 @@ func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fiel
 		// 但正则未命中时不能把正则串当字面 metric/measurement 下推。
 		if isFieldMissingFallback && fieldName != "" && fieldNameExp == nil {
 			defaultTsDB.ExpandMetricNames = []string{fieldName}
-			// 完整 table_id 场景下仍复用单指标单表的独立 RT 路由；data_label 多候选保持候选 RT 兜底，避免重复拼到同一个独立 RT。
-			if defaultTsDB.IsSplit() && isFullTableID {
-				sepRt := s.GetMetricSepRT(tableID, fieldName)
-				if sepRt != nil {
-					sepTsDB := s.getTsDBWithResultTableDetail(defaultTsDB, sepRt)
-					tsDBs = append(tsDBs, &sepTsDB)
-				} else {
-					tsDBs = append(tsDBs, &defaultTsDB)
-				}
-			} else {
-				tsDBs = append(tsDBs, &defaultTsDB)
-			}
+			tsDBs = append(tsDBs, &defaultTsDB)
 		}
 		return tsDBs, nil
 	}
@@ -374,7 +362,7 @@ func (s *SpaceFilter) DataList(opt *TsDBOption) ([]*query.TsDBV2, error) {
 			}
 		}
 		// 指标模糊匹配，可能命中多个私有指标 RT
-		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, db != "", measurement != "", tableIDCondsForFilter)
+		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, db != "", tableIDCondsForFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -105,7 +105,7 @@ func (s *SpaceFilter) getTsDBWithResultTableDetail(t query.TsDBV2, d *routerInfl
 }
 
 func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fieldNameExp *regexp.Regexp, allConditions AllConditions,
-	fieldName, tableID string, isK8s, isK8sFeatureFlag, isSkipField bool, tableIDConditions AllConditions,
+	fieldName, tableID string, isK8s, isK8sFeatureFlag, isSkipField, isFieldMissingFallback bool, tableIDConditions AllConditions,
 ) ([]*query.TsDBV2, error) {
 	rtDetail := s.router.GetResultTable(s.ctx, tableID, false)
 	if rtDetail == nil {
@@ -198,6 +198,11 @@ func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fiel
 	}
 	// 如果字段都不匹配到目标字段，则非目标结果表
 	if len(metricNames) == 0 {
+		// 显式 table_id/data_label 场景下，Fields 只作为辅助展开索引；未命中时兜底返回原 RT。
+		if isFieldMissingFallback {
+			defaultTsDB.ExpandMetricNames = []string{fieldName}
+			tsDBs = append(tsDBs, &defaultTsDB)
+		}
 		return tsDBs, nil
 	}
 
@@ -356,7 +361,7 @@ func (s *SpaceFilter) DataList(opt *TsDBOption) ([]*query.TsDBV2, error) {
 			}
 		}
 		// 指标模糊匹配，可能命中多个私有指标 RT
-		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, tableIDCondsForFilter)
+		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, db != "", tableIDCondsForFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -203,6 +203,16 @@ func (s *SpaceFilter) NewTsDBs(spaceTable *routerInfluxdb.SpaceResultTable, fiel
 		if isFieldMissingFallback && fieldName != "" && fieldNameExp == nil {
 			defaultTsDB.ExpandMetricNames = []string{fieldName}
 			tsDBs = append(tsDBs, &defaultTsDB)
+
+			// 字段在 RT Fields 中缺失但已按显式路由边界兜底返回：单独上报区分性指标与日志，
+			// 避免 fallback 静默掩盖底层字段元数据同步延迟/缺失，便于监控兜底命中频率与排查。
+			// metric label 固定为空，避免把用户输入的 fieldName 作为标签导致 Prometheus 高基数；具体缺失字段见下方日志。
+			metric.SpaceRouterNotExistInc(s.ctx, s.spaceUid, tableID, "", metadata.SpaceTableIDFieldMissingFallback)
+			metadata.NewMessage(
+				metadata.MsgQueryRouter,
+				"field [%s] missing in result_table [%s] fields, fallback to explicit route rt (metadata maybe stale)",
+				fieldName, tableID,
+			).Info(s.ctx)
 		}
 		return tsDBs, nil
 	}

--- a/pkg/unify-query/query/structured/space.go
+++ b/pkg/unify-query/query/structured/space.go
@@ -326,16 +326,29 @@ func (s *SpaceFilter) DataList(opt *TsDBOption) ([]*query.TsDBV2, error) {
 
 	// tableID 去重，防止重复获取
 	tableIDs := set.New[string]()
+	// fallbackEnabled 标记每个候选 RT 是否允许"字段缺失兜底"：
+	// 仅显式 data_label/table_id 边界内的候选可兜底，避免越过 data_label 边界误带同名 RT。
+	fallbackEnabled := make(map[string]bool)
 	isK8s := false
 
 	if db != "" {
 		// 指标二段式，仅传递 data-label， datalabel 支持各种格式
 		tIDs := s.router.GetDataLabelRelatedRts(s.ctx, string(opt.TableID))
 		tableIDs.Add(tIDs...)
+		// data_label 映射内的候选属于显式 data_label 边界，允许字段缺失兜底
+		for _, tID := range tIDs {
+			fallbackEnabled[tID] = true
+		}
 
 		// 只有当 db 和 measurement 都不为空时，才是 tableID，为了兼容，同时也接入到 tableID  list
 		if measurement != "" {
-			tableIDs.Add(fmt.Sprintf("%s.%s", db, measurement))
+			fullTableID := fmt.Sprintf("%s.%s", db, measurement)
+			tableIDs.Add(fullTableID)
+			// 合成的完整 table_id 仅在不存在 data_label 映射（纯 table_id 查询）时才允许兜底；
+			// 若已存在 data_label 映射，则它只是与 data_label 同名的兼容项，不应越过 data_label 边界兜底。
+			if len(tIDs) == 0 {
+				fallbackEnabled[fullTableID] = true
+			}
 		}
 
 		if tableIDs.Size() == 0 {
@@ -372,7 +385,7 @@ func (s *SpaceFilter) DataList(opt *TsDBOption) ([]*query.TsDBV2, error) {
 			}
 		}
 		// 指标模糊匹配，可能命中多个私有指标 RT
-		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, db != "", tableIDCondsForFilter)
+		newTsDBs, err := s.NewTsDBs(spaceRt, fieldNameExp, opt.AllConditions, opt.FieldName, tID, isK8s, isK8sFeatureFlag, opt.IsSkipField, fallbackEnabled[tID], tableIDCondsForFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/unify-query/query/structured/space_test.go
+++ b/pkg/unify-query/query/structured/space_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/mock"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/query"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
+	ir "github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/router/influxdb"
 )
 
 func TestSpaceFilter_NewTsDBs(t *testing.T) {
@@ -149,6 +151,49 @@ func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
 		assert.Equal(t, []string{"not_exists_metric"}, vmTsDB.ExpandMetricNames)
 	})
 
+	t.Run("full_table_id_empty_field_does_not_fallback", func(t *testing.T) {
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "system.cpu_summary",
+			FieldName:   "",
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, tsdb)
+	})
+
+	t.Run("split_measurement_field_missing_fallback_keeps_separate_metric_rt", func(t *testing.T) {
+		router, err := influxdb.GetSpaceTsDbRouter()
+		require.NoError(t, err)
+
+		metricName := "not_in_fields_but_sep_rt"
+		err = router.Add(ctx, ir.ResultTableDetailKey, "result_table."+metricName, &ir.ResultTableDetail{
+			StorageId:       2,
+			TableId:         "result_table." + metricName,
+			Fields:          []string{metricName},
+			DB:              "other",
+			Measurement:     metricName,
+			VmRt:            "2_bcs_prom_computation_result_table",
+			MeasurementType: redis.BkSplitMeasurement,
+			StorageType:     metadata.VictoriaMetricsStorageType,
+			DataLabel:       metricName,
+		})
+		require.NoError(t, err)
+
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     influxdb.ResultTableInfluxDB,
+			FieldName:   metricName,
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		require.Len(t, tsdb, 1)
+		assert.Equal(t, []string{metricName}, tsdb[0].ExpandMetricNames)
+		assert.Equal(t, metricName, tsdb[0].Measurement)
+		assert.Equal(t, metricName, tsdb[0].DataLabel)
+		assert.Equal(t, metadata.VictoriaMetricsStorageType, tsdb[0].StorageType)
+	})
+
 	t.Run("explicit_route_regex_match_keeps_field_expansion", func(t *testing.T) {
 		tsdb, err := sf.DataList(&TsDBOption{
 			SpaceUid:    influxdb.SpaceUid,
@@ -166,6 +211,18 @@ func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
 		vmTsDB := findTsDBByTableID(tsdb, influxdb.ResultTableVM)
 		require.NotNil(t, vmTsDB)
 		assert.Equal(t, []string{"kubelet_info"}, vmTsDB.ExpandMetricNames)
+	})
+
+	t.Run("explicit_route_regex_missing_does_not_fallback_as_literal_metric", func(t *testing.T) {
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "influxdb",
+			FieldName:   "not_exists_.+",
+			IsRegexp:    true,
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, tsdb)
 	})
 
 	t.Run("full_space_field_missing_still_returns_empty", func(t *testing.T) {

--- a/pkg/unify-query/query/structured/space_test.go
+++ b/pkg/unify-query/query/structured/space_test.go
@@ -162,7 +162,7 @@ func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
 		assert.Empty(t, tsdb)
 	})
 
-	t.Run("split_measurement_field_missing_fallback_keeps_separate_metric_rt", func(t *testing.T) {
+	t.Run("split_measurement_field_missing_fallback_keeps_current_rt_even_when_separate_metric_rt_exists", func(t *testing.T) {
 		router, err := influxdb.GetSpaceTsDbRouter()
 		require.NoError(t, err)
 
@@ -189,9 +189,54 @@ func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, tsdb, 1)
 		assert.Equal(t, []string{metricName}, tsdb[0].ExpandMetricNames)
-		assert.Equal(t, metricName, tsdb[0].Measurement)
-		assert.Equal(t, metricName, tsdb[0].DataLabel)
-		assert.Equal(t, metadata.VictoriaMetricsStorageType, tsdb[0].StorageType)
+		assert.Equal(t, influxdb.ResultTableInfluxDB, tsdb[0].TableID)
+		assert.Equal(t, "influxdb", tsdb[0].Measurement)
+		assert.Equal(t, "influxdb", tsdb[0].DataLabel)
+		assert.Equal(t, metadata.InfluxDBStorageType, tsdb[0].StorageType)
+	})
+
+	t.Run("dotted_data_label_field_missing_fallback_keeps_data_label_rt_boundary", func(t *testing.T) {
+		router, err := influxdb.GetSpaceTsDbRouter()
+		require.NoError(t, err)
+
+		dataLabel := "influx.db"
+		metricName := "dotted_label_missing_metric"
+		err = router.Add(ctx, ir.DataLabelToResultTableKey, dataLabel, &ir.ResultTableList{
+			influxdb.ResultTableInfluxDB,
+			influxdb.ResultTableVM,
+		})
+		require.NoError(t, err)
+		err = router.Add(ctx, ir.ResultTableDetailKey, "result_table."+metricName, &ir.ResultTableDetail{
+			StorageId:       2,
+			TableId:         "result_table." + metricName,
+			Fields:          []string{metricName},
+			DB:              "other",
+			Measurement:     metricName,
+			VmRt:            "2_bcs_prom_computation_result_table",
+			MeasurementType: redis.BkSplitMeasurement,
+			StorageType:     metadata.VictoriaMetricsStorageType,
+			DataLabel:       metricName,
+		})
+		require.NoError(t, err)
+
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     TableID(dataLabel),
+			FieldName:   metricName,
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		require.Len(t, tsdb, 2)
+
+		influxdbTsDB := findTsDBByTableID(tsdb, influxdb.ResultTableInfluxDB)
+		require.NotNil(t, influxdbTsDB)
+		assert.Equal(t, []string{metricName}, influxdbTsDB.ExpandMetricNames)
+		assert.Equal(t, "influxdb", influxdbTsDB.DataLabel)
+
+		vmTsDB := findTsDBByTableID(tsdb, influxdb.ResultTableVM)
+		require.NotNil(t, vmTsDB)
+		assert.Equal(t, []string{metricName}, vmTsDB.ExpandMetricNames)
+		assert.Equal(t, "vm", vmTsDB.DataLabel)
 	})
 
 	t.Run("explicit_route_regex_match_keeps_field_expansion", func(t *testing.T) {

--- a/pkg/unify-query/query/structured/space_test.go
+++ b/pkg/unify-query/query/structured/space_test.go
@@ -98,6 +98,89 @@ func toJson(q []*query.TsDBV2) string {
 	return string(s)
 }
 
+func findTsDBByTableID(tsdb []*query.TsDBV2, tableID string) *query.TsDBV2 {
+	for _, d := range tsdb {
+		if d.TableID == tableID {
+			return d
+		}
+	}
+	return nil
+}
+
+func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+	mock.Init()
+	ctx = metadata.InitHashID(ctx)
+	influxdb.MockSpaceRouter(ctx)
+
+	sf, err := NewSpaceFilter(ctx, &TsDBOption{SpaceUid: influxdb.SpaceUid})
+	require.NoError(t, err)
+
+	t.Run("full_table_id_field_missing_fallbacks_to_original_rt", func(t *testing.T) {
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "system.cpu_summary",
+			FieldName:   "not_exists_metric",
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		require.Len(t, tsdb, 1)
+		assert.Equal(t, "system.cpu_summary", tsdb[0].TableID)
+		assert.Equal(t, []string{"not_exists_metric"}, tsdb[0].ExpandMetricNames)
+	})
+
+	t.Run("data_label_field_missing_fallbacks_to_all_related_rts", func(t *testing.T) {
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "influxdb",
+			FieldName:   "not_exists_metric",
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		require.Len(t, tsdb, 2)
+
+		influxdbTsDB := findTsDBByTableID(tsdb, influxdb.ResultTableInfluxDB)
+		require.NotNil(t, influxdbTsDB)
+		assert.Equal(t, []string{"not_exists_metric"}, influxdbTsDB.ExpandMetricNames)
+
+		vmTsDB := findTsDBByTableID(tsdb, influxdb.ResultTableVM)
+		require.NotNil(t, vmTsDB)
+		assert.Equal(t, []string{"not_exists_metric"}, vmTsDB.ExpandMetricNames)
+	})
+
+	t.Run("explicit_route_regex_match_keeps_field_expansion", func(t *testing.T) {
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "influxdb",
+			FieldName:   "kubelet_.+",
+			IsRegexp:    true,
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+
+		influxdbTsDB := findTsDBByTableID(tsdb, influxdb.ResultTableInfluxDB)
+		require.NotNil(t, influxdbTsDB)
+		assert.Equal(t, []string{"kubelet_cluster_request_total"}, influxdbTsDB.ExpandMetricNames)
+
+		vmTsDB := findTsDBByTableID(tsdb, influxdb.ResultTableVM)
+		require.NotNil(t, vmTsDB)
+		assert.Equal(t, []string{"kubelet_info"}, vmTsDB.ExpandMetricNames)
+	})
+
+	t.Run("full_space_field_missing_still_returns_empty", func(t *testing.T) {
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "",
+			FieldName:   "not_exists_metric",
+			IsSkipK8s:   true,
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, tsdb)
+	})
+}
+
 // TestSpaceFilter_DataList_WithTableIDConditions 表标签条件过滤：nil 时行为不变；有 expr 且 RT 无匹配 Labels 时被过滤
 func TestSpaceFilter_DataList_WithTableIDConditions(t *testing.T) {
 	metadata.InitMetadata()

--- a/pkg/unify-query/query/structured/space_test.go
+++ b/pkg/unify-query/query/structured/space_test.go
@@ -303,6 +303,32 @@ func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
 		assert.Equal(t, "vm", vmTsDB.DataLabel)
 	})
 
+	t.Run("dotted_data_label_with_mapping_does_not_fallback_unrelated_same_named_table_id", func(t *testing.T) {
+		// 回归 Codex 评论 3：dotted data_label 命中映射时，兼容分支合成的同名 table_id
+		// （system.disk 是 space 中真实存在、但不属于该 data_label 映射的 RT，dataLabel=disk）
+		// 不应越过 data_label 边界被字段缺失兜底返回。
+		router, err := influxdb.GetSpaceTsDbRouter()
+		require.NoError(t, err)
+
+		// data_label "system.disk" 仅映射到 influxdb，与 space 中真实的 system.disk RT 无关。
+		err = router.Add(ctx, ir.DataLabelToResultTableKey, "system.disk", &ir.ResultTableList{
+			influxdb.ResultTableInfluxDB,
+		})
+		require.NoError(t, err)
+
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "system.disk",
+			FieldName:   "missing_field_not_in_any_rt",
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		// 只返回 data_label 映射内的 influxdb；同名真实 RT system.disk 不应被越界兜底。
+		require.Len(t, tsdb, 1)
+		assert.Equal(t, influxdb.ResultTableInfluxDB, tsdb[0].TableID)
+		assert.Nil(t, findTsDBByTableID(tsdb, "system.disk"))
+	})
+
 	t.Run("explicit_route_regex_match_keeps_field_expansion", func(t *testing.T) {
 		tsdb, err := sf.DataList(&TsDBOption{
 			SpaceUid:    influxdb.SpaceUid,

--- a/pkg/unify-query/query/structured/space_test.go
+++ b/pkg/unify-query/query/structured/space_test.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -109,6 +110,44 @@ func findTsDBByTableID(tsdb []*query.TsDBV2, tableID string) *query.TsDBV2 {
 	return nil
 }
 
+// spaceRouterSeriesByReason 读取 unify_query_space_router_total 指定 reason 维度下，按 metric label 聚合的累计值，
+// 用于断言兜底埋点是否上报，以及验证 metric label 未携带高基数的用户输入字段名。
+func spaceRouterSeriesByReason(reason string) map[string]float64 {
+	out := make(map[string]float64)
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return out
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "unify_query_space_router_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var gotReason, metricLabel string
+			for _, l := range m.GetLabel() {
+				switch l.GetName() {
+				case "reason":
+					gotReason = l.GetValue()
+				case "metric":
+					metricLabel = l.GetValue()
+				}
+			}
+			if gotReason == reason {
+				out[metricLabel] += m.GetCounter().GetValue()
+			}
+		}
+	}
+	return out
+}
+
+func sumFloat(m map[string]float64) float64 {
+	var s float64
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
 func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
 	metadata.InitMetadata()
 	ctx := metadata.InitHashID(context.Background())
@@ -130,6 +169,31 @@ func TestSpaceFilter_DataList_ExplicitRouteFieldFallback(t *testing.T) {
 		require.Len(t, tsdb, 1)
 		assert.Equal(t, "system.cpu_summary", tsdb[0].TableID)
 		assert.Equal(t, []string{"not_exists_metric"}, tsdb[0].ExpandMetricNames)
+	})
+
+	t.Run("field_missing_fallback_reports_distinct_low_cardinality_metric", func(t *testing.T) {
+		// 兜底命中应上报区分性 reason 指标，避免 fallback 静默掩盖元数据缺失问题；
+		// 同时 metric label 必须固定为空，避免用户输入的 fieldName 造成 Prometheus 高基数。
+		const probeField = "fallback_metric_for_observability"
+		beforeFallback := sumFloat(spaceRouterSeriesByReason(metadata.SpaceTableIDFieldMissingFallback))
+		beforeNotExist := sumFloat(spaceRouterSeriesByReason(metadata.SpaceTableIDFieldIsNotExists))
+
+		tsdb, err := sf.DataList(&TsDBOption{
+			SpaceUid:    influxdb.SpaceUid,
+			TableID:     "system.cpu_summary",
+			FieldName:   probeField,
+			IsSkipField: false,
+		})
+		require.NoError(t, err)
+		require.Len(t, tsdb, 1)
+
+		afterSeries := spaceRouterSeriesByReason(metadata.SpaceTableIDFieldMissingFallback)
+		// 兜底命中：区分性指标总量 +1，而"完全找不到"指标不应增加。
+		assert.Equal(t, beforeFallback+1, sumFloat(afterSeries))
+		assert.Equal(t, beforeNotExist, sumFloat(spaceRouterSeriesByReason(metadata.SpaceTableIDFieldIsNotExists)))
+		// 高基数防护：兜底指标的 metric label 固定为空，绝不能以用户输入的 fieldName 建时序。
+		assert.Contains(t, afterSeries, "")
+		assert.NotContains(t, afterSeries, probeField)
 	})
 
 	t.Run("data_label_field_missing_fallbacks_to_all_related_rts", func(t *testing.T) {


### PR DESCRIPTION
### 背景

显式指定 `table_id` / `data_label` 查询时，候选 RT 已由入参确定，`field_names` 只应作为 metric 展开的辅助索引，不应因为元数据字段缺失或同步延迟导致路由层直接判定 RT 不存在。同时，显式路由场景不应再受 `table_id_conditions` 过滤影响。

### 修复

- 显式 `table_id` / `data_label` 场景下，普通非空 metric 未命中 `field_names` 时，按当前候选 RT 兜底返回，避免路由层误拦截。
- `data_label` 场景的兜底范围严格限制在 `data_label` 映射出的 RT 集合内；字段未命中 fallback 不额外推导独立 RT，避免越过候选 RT / data label 边界。
- 正则 metric 仍优先通过 `field_names` 展开；若正则完全未命中，不再把正则字符串当作字面 metric / measurement 下推。
- `field_name` 为空时不触发 fallback，避免生成 `ExpandMetricNames=[""]`。
- 未指定 `table_id` / `data_label` 的全空间自动找表场景保持原逻辑，仍依赖 `field_names` 收窄候选 RT。
- 显式路由 fallback 命中时新增独立 reason 埋点和日志，用于观测字段元数据缺失/延迟；埋点不携带用户输入的 `field_name`，避免 Prometheus 高基数。
- 补充显式路由 field miss、data_label 多 RT、带点 data_label、正则 miss、空 field_name、独立 RT 不越界、fallback 低基数埋点等回归测试。