### PR TITLE
feat: 新增时间戳单位配置及其实现

### DIFF
--- a/pkg/transfer/config/metadata_options.go
+++ b/pkg/transfer/config/metadata_options.go
@@ -191,6 +191,8 @@ const (
 	MetaFieldOptTimeZone = "time_zone"
 	// MetaFieldOptTimeFormat : 时间格式（string)
 	MetaFieldOptTimeFormat = "time_format"
+	// MetaFieldOptTimestampUnit : 时间戳单位(string)
+	MetaFieldOptTimestampUnit = "timestamp_unit"
 	// MetaFieldOptRealPath : "提取的真实路径"
 	MetaFieldOptRealPath = "real_path"
 

--- a/pkg/transfer/etl/transformer.go
+++ b/pkg/transfer/etl/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/transfer/define"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/transfer/json"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/transfer/logging"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/transfer/types"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/transfer/utils"
 )
 
@@ -258,10 +259,34 @@ func NewTransformByField(field *config.MetaFieldConfig) TransformFn {
 	case define.MetaFieldTypeTimestamp:
 		options := utils.NewMapHelper(field.Option)
 		if options.Exists(config.MetaFieldOptTimeFormat) {
-			return TransformTimeStampByName(
-				options.MustGetString(config.MetaFieldOptTimeFormat),
-				conv.Int(options.GetOrDefault(config.MetaFieldOptTimeZone, 0)),
-			)
+			return func(from interface{}) (to interface{}, err error) {
+				format := options.MustGetString(config.MetaFieldOptTimeFormat)
+
+				fn := TransformTimeStampByName(format, conv.Int(options.GetOrDefault(config.MetaFieldOptTimeZone, 0)))
+				result, err := fn(from)
+				if err != nil {
+					return result, err
+				}
+				if result == nil {
+					return nil, nil
+				}
+
+				v, ok := field.Option[config.MetaFieldOptTimestampUnit]
+				if !ok {
+					return result, nil
+				}
+				u, ok := v.(string)
+				if !ok {
+					return result, nil
+				}
+
+				ts, ok := result.(types.TimeStamp)
+				if !ok {
+					return result, nil
+				}
+				(&ts).SetUnit(u)
+				return ts, err
+			}
 		}
 		fallthrough
 	default:

--- a/pkg/transfer/etl/transformer_test.go
+++ b/pkg/transfer/etl/transformer_test.go
@@ -144,6 +144,13 @@ func (s *TransformByFieldSuite) TestTimeStamp() {
 				"time_zone":   zone,
 			},
 		}, now.Format("2006-01-02 15:04:05"), now.Unix()},
+		{config.MetaFieldConfig{
+			Type: define.MetaFieldTypeTimestamp,
+			Option: map[string]interface{}{
+				"time_format":    "epoch_millisecond",
+				"timestamp_unit": "s",
+			},
+		}, now.UnixMilli(), now.Unix()},
 	}
 	for i, c := range cases {
 		fn := etl.NewTransformByField(&c.field)

--- a/pkg/transfer/types/timestamp.go
+++ b/pkg/transfer/types/timestamp.go
@@ -17,6 +17,7 @@ import (
 // TimeStamp :
 type TimeStamp struct {
 	time.Time
+	unit string // 支持 s/ms/µs/ns（默认为 s）
 }
 
 // NewTimeStamp :
@@ -28,15 +29,31 @@ func NewTimeStamp(t time.Time) TimeStamp {
 
 // String :
 func (t TimeStamp) String() string {
-	return strconv.FormatInt(t.Unix(), 10)
+	return strconv.FormatInt(t.Int64(), 10)
 }
 
 // Int64 :
 func (t TimeStamp) Int64() int64 {
-	return t.Unix()
+	var n int64
+	switch t.unit {
+	case "ms":
+		n = t.UnixMilli()
+	case "µs":
+		n = t.UnixMicro()
+	case "ns":
+		n = t.UnixNano()
+	default:
+		n = t.Unix()
+	}
+	return n
 }
 
 // MarshalJSON :
 func (t TimeStamp) MarshalJSON() ([]byte, error) {
 	return []byte(t.String()), nil
+}
+
+// SetUnit :
+func (t *TimeStamp) SetUnit(u string) {
+	t.unit = u
 }


### PR DESCRIPTION
修复样例数据使用字段配置落库后，时间戳字符串为"1781505302000"，丢失毫秒精度的问题

样例数据为：
```json
{
    "data": "[2026-06-15 14:35:02.185] content",
    "iterationindex": 0
}
```

字段配置为：
```json
{
 "option": {
      "es_type": "date",
      "es_format": "epoch_millis",
      "time_format": "yyyy-MM-dd HH:mm:ss.SSS",
      "time_zone": 8,
      "real_path": "bk_separator_object.request_time",
      "field_index": 1,
      "timestamp_unit": "ms",
      "default_function": "fn:timestamp_from_utctime"
  }
}
```