### PR TITLE
fix:(unify-query)修复 UQ 路由校验空响应误标 mismatch --bug=159709304

### DIFF
--- a/pkg/unify-query/tsdb/victoriaMetrics/instance.go
+++ b/pkg/unify-query/tsdb/victoriaMetrics/instance.go
@@ -194,7 +194,7 @@ func spanSetStorageListDiff(span *trace.Span, requestRtDetail map[string]metadat
 		return
 	}
 
-	if len(responseVMClusterList) == 0 {
+	if responseVMClusterList == nil {
 		span.Set("query-storage-status", "unknown")
 		span.Set("query-storage-reason", "empty_storage_cluster_list")
 		return
@@ -221,6 +221,9 @@ func spanSetStorageListDiff(span *trace.Span, requestRtDetail map[string]metadat
 			})
 		}
 	}
+	sort.Slice(missing, func(i, j int) bool {
+		return missing[i].Cluster < missing[j].Cluster
+	})
 
 	if len(missing) > 0 {
 		span.Set("query-storage-status", "mismatch")

--- a/pkg/unify-query/tsdb/victoriaMetrics/instance.go
+++ b/pkg/unify-query/tsdb/victoriaMetrics/instance.go
@@ -189,6 +189,17 @@ func spanSetStorageListDiff(span *trace.Span, requestRtDetail map[string]metadat
 		}
 	}
 
+	if len(reqClusterToInfo) == 0 {
+		span.Set("query-storage-status", "match")
+		return
+	}
+
+	if len(responseVMClusterList) == 0 {
+		span.Set("query-storage-status", "unknown")
+		span.Set("query-storage-reason", "empty_storage_cluster_list")
+		return
+	}
+
 	respSet := make(map[string]struct{}, len(responseVMClusterList))
 	for _, s := range responseVMClusterList {
 		respSet[s] = struct{}{}

--- a/pkg/unify-query/tsdb/victoriaMetrics/instance_test.go
+++ b/pkg/unify-query/tsdb/victoriaMetrics/instance_test.go
@@ -656,7 +656,7 @@ func TestSpanSetStorageListDiff(t *testing.T) {
 			wantStatus:            "mismatch",
 			wantMissing:           `[{"cluster":"vm_op_2","vm_rt_list":["rt_vm_2"],"table_id_list":["rt_2"]}]`,
 		},
-		"unknown: response storage cluster list is empty": {
+		"unknown: response storage cluster list is missing": {
 			rtDetail: map[string]metadata.RtDetail{
 				"rt_vm_1": {TableID: "rt_1", StorageName: "vm_op_1"},
 				"rt_vm_2": {TableID: "rt_2", StorageName: "vm_op_2"},
@@ -665,6 +665,15 @@ func TestSpanSetStorageListDiff(t *testing.T) {
 			wantStatus:            "unknown",
 			wantReason:            "empty_storage_cluster_list",
 			wantMissing:           "",
+		},
+		"mismatch: response storage cluster list is explicitly empty": {
+			rtDetail: map[string]metadata.RtDetail{
+				"rt_vm_1": {TableID: "rt_1", StorageName: "vm_op_1"},
+				"rt_vm_2": {TableID: "rt_2", StorageName: "vm_op_2"},
+			},
+			responseVMClusterList: []string{},
+			wantStatus:            "mismatch",
+			wantMissing:           `[{"cluster":"vm_op_1","vm_rt_list":["rt_vm_1"],"table_id_list":["rt_1"]},{"cluster":"vm_op_2","vm_rt_list":["rt_vm_2"],"table_id_list":["rt_2"]}]`,
 		},
 		"response has extra cluster not in request: match (extra ignored)": {
 			rtDetail: map[string]metadata.RtDetail{

--- a/pkg/unify-query/tsdb/victoriaMetrics/instance_test.go
+++ b/pkg/unify-query/tsdb/victoriaMetrics/instance_test.go
@@ -635,6 +635,7 @@ func TestSpanSetStorageListDiff(t *testing.T) {
 		rtDetail              map[string]metadata.RtDetail
 		responseVMClusterList []string
 		wantStatus            string
+		wantReason            string
 		wantMissing           string // JSON string or empty
 	}{
 		"match: request cluster names equal response cluster names": {
@@ -654,6 +655,16 @@ func TestSpanSetStorageListDiff(t *testing.T) {
 			responseVMClusterList: []string{"vm_op_1"},
 			wantStatus:            "mismatch",
 			wantMissing:           `[{"cluster":"vm_op_2","vm_rt_list":["rt_vm_2"],"table_id_list":["rt_2"]}]`,
+		},
+		"unknown: response storage cluster list is empty": {
+			rtDetail: map[string]metadata.RtDetail{
+				"rt_vm_1": {TableID: "rt_1", StorageName: "vm_op_1"},
+				"rt_vm_2": {TableID: "rt_2", StorageName: "vm_op_2"},
+			},
+			responseVMClusterList: nil,
+			wantStatus:            "unknown",
+			wantReason:            "empty_storage_cluster_list",
+			wantMissing:           "",
 		},
 		"response has extra cluster not in request: match (extra ignored)": {
 			rtDetail: map[string]metadata.RtDetail{
@@ -683,6 +694,15 @@ func TestSpanSetStorageListDiff(t *testing.T) {
 
 			status, _ := spanAttrString(attrs, "query-storage-status")
 			assert.Equal(t, tc.wantStatus, status)
+
+			if tc.wantReason != "" {
+				reason, ok := spanAttrString(attrs, "query-storage-reason")
+				assert.True(t, ok)
+				assert.Equal(t, tc.wantReason, reason)
+			} else {
+				_, ok := spanAttrString(attrs, "query-storage-reason")
+				assert.False(t, ok)
+			}
 
 			// Check missing field
 			if tc.wantMissing != "" {


### PR DESCRIPTION
## 变更说明

- 当请求侧存在期望 storage，但 BKBase/VM 响应未返回 `storage_cluster_list` 时，将 `query-storage-status` 标记为 `unknown`
- 增加 `query-storage-reason=empty_storage_cluster_list`，避免把缺少校验信息误报为路由 `mismatch`
- 保留真实响应缺少请求侧 storage 时的 `mismatch` 判定
- 补充 `spanSetStorageListDiff` 单测，验证 unknown 场景不生成 `query-storage-missing`

## 测试

- `go test ./tsdb/victoriaMetrics -run 'TestSpanSetStorageListDiff|TestVmResponse_VmQueryCluster|TestInstance_DirectQuery'`\n- `go test ./tsdb/victoriaMetrics`\n\nTAPD: #1010158081159709304