### PR TITLE
fix:(unify-query) 修复 BKSQL QuerySync 测试空指针风险 --bug=159714657

### DIFF
--- a/pkg/unify-query/tsdb/bksql/client_test.go
+++ b/pkg/unify-query/tsdb/bksql/client_test.go
@@ -99,12 +99,11 @@ func TestClient_QuerySync(t *testing.T) {
 
 	assert.Equal(t, bksql.StatusOK, res.Code)
 	d, ok := res.Data.(*bksql.QuerySyncResultData)
-	assert.True(t, ok)
-	assert.Equal(t, d.TotalRecords, 5)
+	require.True(t, ok)
+	require.NotNil(t, d)
 
-	if d != nil {
-		assert.NotEmpty(t, d.List)
-	}
+	assert.Equal(t, 5, d.TotalRecords)
+	assert.NotEmpty(t, d.List)
 }
 
 type captureCurl struct {


### PR DESCRIPTION
### 背景
   BKSQL QuerySync 单测中会将 res.Data 断言为 *bksql.QuerySyncResultData 后继续校验返回字段。原实现使用 assert.True(t, ok) 判断类型断言结果，但 assert 失败后测试不会立即停止，后续仍会访问 d.TotalRecords。当 res.Data 类型不符合预期或为 nil 时，测试可能出现空指针 panic，导致真实失败原因被掩盖。
### 修复说明
将类型断言和 nil 校验从 assert 调整为 require，确保 res.Data 类型不匹配或为空时测试立即终止。只有在确认 d 非 nil 后，才继续校验 TotalRecords 和 List 内容，避免单测因空指针访问异常退出，同时保留原有结果校验逻辑。
### 验证
已执行 go test ./tsdb/bksql，测试通过。