### PR TITLE
perf(bmw): 优化 ES 分段路由批量查询性能 --story=135505075

### DIFF
--- a/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
+++ b/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord.go
@@ -61,67 +61,241 @@ func (ClusterRecord) TableName() string {
 	return "metadata_storageclusterrecord"
 }
 
+const storageClusterRecordDBFilterSize = 500
+
+// TableIDStorageClusterRecordRequest describes one storage route composition request.
+type TableIDStorageClusterRecordRequest struct {
+	// TableID is the real table_id used to query metadata_storageclusterrecord.
+	TableID string
+	// CurrentTableID is the table_id currently being published to Redis.
+	CurrentTableID string
+}
+
 // ComposeTableIDStorageClusterRecords 组装指定 table_id 的历史存储集群分段路由。
 // 这里是 BMW 下发 storage_cluster_records 的字段补齐点：当历史分段切到 ES 或 Doris 时，
 // 需要把目标存储实际查询所需的 db/measurement/cluster_name 一并写入 route，避免 UQ 消费时混用外层 RT 配置。
 func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string, currentTableID ...string) ([]map[string]any, error) {
 	logger.Infof("compose_table_id_storage_cluster_records: try to get storage cluster records for table_id->[%s]", tableID)
-	routeTableID := tableID
+	current := ""
 	if len(currentTableID) > 0 && currentTableID[0] != "" {
-		// 虚拟 RT / Doris 迁移 RT 的历史记录按真实 tableID 查，但查询目标字段优先按当前下发的 RT 补齐。
-		routeTableID = currentTableID[0]
+		current = currentTableID[0]
 	}
 
-	var records []ClusterRecord
-	// metadata_storageclusterrecord 只记录某个时间点切到了哪个 cluster，不包含具体查询目标。
-	// 后续需要结合 cluster 类型和对应 storage 表补齐 db / measurement / cluster_name。
-	err := NewClusterRecordQuerySet(db).
-		TableIDEq(tableID).      // 过滤 table_id
-		IsDeletedEq(false).      // 过滤 is_deleted = false
-		OrderDescByCreateTime(). // 按 create_time 倒序
-		Select("cluster_id", "enable_time", "is_current").
-		All(&records)
+	request := TableIDStorageClusterRecordRequest{TableID: tableID, CurrentTableID: current}
+	recordsMap, err := ComposeTableIDStorageClusterRecordsBatch(db, []TableIDStorageClusterRecordRequest{request})
 	if err != nil {
-		logger.Errorf("compose_table_id_storage_cluster_records: failed to query records for table_id->[%s], error: %v", tableID, err)
 		return nil, err
 	}
 
-	// 历史记录中的 cluster_id 决定每个分段最终应该查 ES 还是 Doris。
-	// 查询 cluster_info 后可得到 cluster_type 和 cluster_name，其中 cluster_name 是 Doris/BKSQL 的路由属性。
-	clusterIDList := lo.Uniq(lo.FilterMap(records, func(record ClusterRecord, _ int) (uint, bool) {
-		if record.ClusterID > 0 {
-			return uint(record.ClusterID), true
-		}
-		return 0, false
-	}))
+	result := recordsMap[request]
+	if result == nil {
+		result = make([]map[string]any, 0)
+	}
+	logger.Infof("compose_table_id_storage_cluster_records: get storage cluster records for table_id->[%s] success, records->[%v]", tableID, result)
+	return result, nil
+}
 
-	clusterInfoMap := make(map[uint]ClusterInfo, len(clusterIDList))
-	hasDorisRoute := false
-	hasESRoute := false
-	if len(clusterIDList) > 0 {
-		var clusterInfoList []ClusterInfo
-		if err = NewClusterInfoQuerySet(db).
-			Select(ClusterInfoDBSchema.ClusterID, ClusterInfoDBSchema.ClusterName, ClusterInfoDBSchema.ClusterType).
-			ClusterIDIn(clusterIDList...).
-			All(&clusterInfoList); err != nil {
-			logger.Errorf("compose_table_id_storage_cluster_records: failed to query cluster info for table_id->[%s], error: %v", tableID, err)
-			return nil, err
+// ComposeTableIDStorageClusterRecordsBatch batch-composes storage_cluster_records for multiple table_ids.
+func ComposeTableIDStorageClusterRecordsBatch(db *gorm.DB, requests []TableIDStorageClusterRecordRequest) (map[TableIDStorageClusterRecordRequest][]map[string]any, error) {
+	result := make(map[TableIDStorageClusterRecordRequest][]map[string]any, len(requests))
+	contexts := make([]storageClusterRecordContext, 0, len(requests))
+	recordTableIDs := make([]string, 0, len(requests))
+	storageTableIDs := make([]string, 0, len(requests)*2)
+	for _, request := range requests {
+		if request.TableID == "" {
+			continue
 		}
-		for _, clusterInfo := range clusterInfoList {
-			clusterInfoMap[clusterInfo.ClusterID] = clusterInfo
+		routeTableID := storageClusterRecordRouteTableID(request.TableID, request.CurrentTableID)
+		contexts = append(contexts, storageClusterRecordContext{
+			tableID:      request.TableID,
+			routeTableID: routeTableID,
+			request:      request,
+		})
+		result[request] = make([]map[string]any, 0)
+		recordTableIDs = append(recordTableIDs, request.TableID)
+		storageTableIDs = append(storageTableIDs, request.TableID, routeTableID)
+	}
+	if len(contexts) == 0 {
+		return result, nil
+	}
+
+	recordsByTableID, err := getClusterRecordsByTableID(db, recordTableIDs)
+	if err != nil {
+		return nil, err
+	}
+	clusterInfoMap, err := getClusterInfoMapByRecords(db, recordsByTableID)
+	if err != nil {
+		return nil, err
+	}
+
+	hasStorageRoute := false
+	hasESRoute := false
+	for i := range contexts {
+		contexts[i].records = recordsByTableID[contexts[i].tableID]
+		for _, record := range contexts[i].records {
+			clusterInfo, ok := clusterInfoMap[uint(record.ClusterID)]
+			if !ok {
+				continue
+			}
 			switch clusterInfo.ClusterType {
 			case models.StorageTypeDoris:
-				hasDorisRoute = true
+				contexts[i].hasDorisRoute = true
+				hasStorageRoute = true
 			case models.StorageTypeES:
+				contexts[i].hasESRoute = true
+				hasStorageRoute = true
 				hasESRoute = true
 			}
 		}
 	}
 
-	var dorisStorage DorisStorage
-	if (hasDorisRoute || hasESRoute) && db.HasTable(DorisStorage{}) {
-		// 优先按当前下发 RT 查 Doris storage；虚拟 RT 或迁移场景查不到时，再回退到历史记录所属的真实 RT。
-		if err = NewDorisStorageQuerySet(db).
+	dorisStorageMap := make(map[string]DorisStorage)
+	if hasStorageRoute && db.HasTable(DorisStorage{}) {
+		dorisStorageMap, err = getDorisStorageMapByTableID(db, storageTableIDs)
+		if err != nil {
+			return nil, err
+		}
+
+		originTableIDs := make([]string, 0)
+		for _, context := range contexts {
+			if !context.hasDorisRoute {
+				continue
+			}
+			dorisStorage := selectDorisStorage(dorisStorageMap, context.tableID, context.routeTableID)
+			if dorisStorage.OriginTableId != "" && needOriginDorisStorage(dorisStorage) {
+				originTableIDs = append(originTableIDs, dorisStorage.OriginTableId)
+			}
+		}
+		if err = appendDorisStorageMapByTableID(db, dorisStorageMap, originTableIDs); err != nil {
+			return nil, err
+		}
+	}
+
+	esStorageMap := make(map[string]ESStorage)
+	if hasESRoute && db.HasTable(ESStorage{}) {
+		esStorageMap, err = getESStorageMapByTableID(db, storageTableIDs)
+		if err != nil {
+			return nil, err
+		}
+
+		originTableIDs := make([]string, 0)
+		for _, context := range contexts {
+			if !context.hasESRoute {
+				continue
+			}
+			esStorage := selectESStorage(esStorageMap, context.tableID, context.routeTableID)
+			if esStorage.IndexSet == "" && esStorage.OriginTableId != "" {
+				originTableIDs = append(originTableIDs, esStorage.OriginTableId)
+			}
+		}
+		if err = appendESStorageMapByTableID(db, esStorageMap, originTableIDs); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, context := range contexts {
+		dorisStorage := selectDorisStorage(dorisStorageMap, context.tableID, context.routeTableID)
+		dorisRoute := map[string]any{}
+		if context.hasDorisRoute {
+			dorisStorage = fillDorisStorageFromOrigin(dorisStorage, dorisStorageMap)
+			dorisRoute = buildDorisRoute(dorisStorage)
+		}
+
+		esRoute := map[string]any{}
+		if context.hasESRoute {
+			esStorage := fillESStorageFromOrigin(selectESStorage(esStorageMap, context.tableID, context.routeTableID), esStorageMap)
+			esRoute = buildESRoute(esStorage, dorisStorage)
+		}
+
+		result[context.request] = composeStorageClusterRecordRoutes(context.records, clusterInfoMap, dorisRoute, esRoute)
+	}
+
+	return result, nil
+}
+
+type storageClusterRecordContext struct {
+	tableID       string
+	routeTableID  string
+	request       TableIDStorageClusterRecordRequest
+	records       []ClusterRecord
+	hasDorisRoute bool
+	hasESRoute    bool
+}
+
+func storageClusterRecordRouteTableID(tableID string, currentTableID string) string {
+	if currentTableID != "" {
+		// 虚拟 RT / Doris 迁移 RT 的历史记录按真实 tableID 查，但查询目标字段优先按当前下发的 RT 补齐。
+		return currentTableID
+	}
+	return tableID
+}
+
+func getClusterRecordsByTableID(db *gorm.DB, tableIDs []string) (map[string][]ClusterRecord, error) {
+	recordsByTableID := make(map[string][]ClusterRecord)
+	for _, chunkTableIDs := range chunkStorageClusterRecordValues(filterStorageClusterRecordTableIDs(tableIDs)) {
+		var records []ClusterRecord
+		// metadata_storageclusterrecord 只记录某个时间点切到了哪个 cluster，不包含具体查询目标。
+		// 后续需要结合 cluster 类型和对应 storage 表补齐 db / measurement / cluster_name。
+		err := NewClusterRecordQuerySet(db).
+			TableIDIn(chunkTableIDs...). // 过滤 table_id
+			IsDeletedEq(false).          // 过滤 is_deleted = false
+			OrderDescByCreateTime().     // 按 create_time 倒序
+			Select(ClusterRecordDBSchema.TableID, ClusterRecordDBSchema.ClusterID, ClusterRecordDBSchema.EnableTime, ClusterRecordDBSchema.IsCurrent).
+			All(&records)
+		if err != nil {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query records for table_id_list->[%v], error: %v", chunkTableIDs, err)
+			return nil, err
+		}
+		for _, record := range records {
+			recordsByTableID[record.TableID] = append(recordsByTableID[record.TableID], record)
+		}
+	}
+	return recordsByTableID, nil
+}
+
+func getClusterInfoMapByRecords(db *gorm.DB, recordsByTableID map[string][]ClusterRecord) (map[uint]ClusterInfo, error) {
+	// 历史记录中的 cluster_id 决定每个分段最终应该查 ES 还是 Doris。
+	// 查询 cluster_info 后可得到 cluster_type 和 cluster_name，其中 cluster_name 是 Doris/BKSQL 的路由属性。
+	clusterIDList := make([]uint, 0)
+	for _, records := range recordsByTableID {
+		clusterIDList = append(clusterIDList, lo.FilterMap(records, func(record ClusterRecord, _ int) (uint, bool) {
+			if record.ClusterID > 0 {
+				return uint(record.ClusterID), true
+			}
+			return 0, false
+		})...)
+	}
+	clusterIDList = lo.Uniq(clusterIDList)
+
+	clusterInfoMap := make(map[uint]ClusterInfo, len(clusterIDList))
+	for _, chunkClusterIDs := range chunkStorageClusterRecordValues(clusterIDList) {
+		var clusterInfoList []ClusterInfo
+		if err := NewClusterInfoQuerySet(db).
+			Select(ClusterInfoDBSchema.ClusterID, ClusterInfoDBSchema.ClusterName, ClusterInfoDBSchema.ClusterType).
+			ClusterIDIn(chunkClusterIDs...).
+			All(&clusterInfoList); err != nil {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query cluster info for cluster_id_list->[%v], error: %v", chunkClusterIDs, err)
+			return nil, err
+		}
+		for _, clusterInfo := range clusterInfoList {
+			clusterInfoMap[clusterInfo.ClusterID] = clusterInfo
+		}
+	}
+	return clusterInfoMap, nil
+}
+
+func getDorisStorageMapByTableID(db *gorm.DB, tableIDs []string) (map[string]DorisStorage, error) {
+	dorisStorageMap := make(map[string]DorisStorage)
+	if err := appendDorisStorageMapByTableID(db, dorisStorageMap, tableIDs); err != nil {
+		return nil, err
+	}
+	return dorisStorageMap, nil
+}
+
+func appendDorisStorageMapByTableID(db *gorm.DB, dorisStorageMap map[string]DorisStorage, tableIDs []string) error {
+	for _, chunkTableIDs := range chunkMissingStorageClusterRecordTableIDs(tableIDs, dorisStorageMap) {
+		var dorisStorageList []DorisStorage
+		if err := NewDorisStorageQuerySet(db).
 			Select(
 				DorisStorageDBSchema.TableID,
 				DorisStorageDBSchema.BkbaseTableID,
@@ -130,121 +304,135 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string, currentTab
 				DorisStorageDBSchema.IndexSet,
 				DorisStorageDBSchema.SourceType,
 			).
-			TableIDEq(routeTableID).
-			One(&dorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
-			logger.Errorf("compose_table_id_storage_cluster_records: failed to query doris storage for table_id->[%s], error: %v", routeTableID, err)
-			return nil, err
+			TableIDIn(chunkTableIDs...).
+			All(&dorisStorageList); err != nil {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query doris storage for table_id_list->[%v], error: %v", chunkTableIDs, err)
+			return err
 		}
-		if dorisStorage.BkbaseTableID == "" && routeTableID != tableID {
-			if err = NewDorisStorageQuerySet(db).
-				Select(
-					DorisStorageDBSchema.TableID,
-					DorisStorageDBSchema.BkbaseTableID,
-					DorisStorageDBSchema.OriginTableId,
-					DorisStorageDBSchema.StorageClusterID,
-					DorisStorageDBSchema.IndexSet,
-					DorisStorageDBSchema.SourceType,
-				).
-				TableIDEq(tableID).
-				One(&dorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
-				logger.Errorf("compose_table_id_storage_cluster_records: failed to query doris storage for table_id->[%s], error: %v", tableID, err)
-				return nil, err
-			}
+		for _, dorisStorage := range dorisStorageList {
+			dorisStorageMap[dorisStorage.TableID] = dorisStorage
 		}
 	}
+	return nil
+}
 
+func selectDorisStorage(dorisStorageMap map[string]DorisStorage, tableID string, routeTableID string) DorisStorage {
+	// 优先按当前下发 RT 查 Doris storage；虚拟 RT 或迁移场景查不到时，再回退到历史记录所属的真实 RT。
+	dorisStorage := dorisStorageMap[routeTableID]
+	if dorisStorage.BkbaseTableID == "" && routeTableID != tableID {
+		if fallbackStorage, ok := dorisStorageMap[tableID]; ok {
+			dorisStorage = fallbackStorage
+		}
+	}
+	return dorisStorage
+}
+
+func needOriginDorisStorage(dorisStorage DorisStorage) bool {
+	return dorisStorage.BkbaseTableID == "" || dorisStorage.StorageClusterID == 0 ||
+		dorisStorage.IndexSet == "" || dorisStorage.SourceType == ""
+}
+
+func fillDorisStorageFromOrigin(dorisStorage DorisStorage, dorisStorageMap map[string]DorisStorage) DorisStorage {
+	if dorisStorage.OriginTableId == "" || !needOriginDorisStorage(dorisStorage) {
+		return dorisStorage
+	}
+	// 当前 Doris 记录可能只保留 origin_table_id，继续按 origin RT 查真实的 BKBase 表名和 ES 查询目标。
+	originDorisStorage := dorisStorageMap[dorisStorage.OriginTableId]
+	if dorisStorage.BkbaseTableID == "" {
+		dorisStorage.BkbaseTableID = originDorisStorage.BkbaseTableID
+	}
+	if dorisStorage.StorageClusterID == 0 {
+		dorisStorage.StorageClusterID = originDorisStorage.StorageClusterID
+	}
+	if dorisStorage.IndexSet == "" {
+		dorisStorage.IndexSet = originDorisStorage.IndexSet
+	}
+	if dorisStorage.SourceType == "" {
+		dorisStorage.SourceType = originDorisStorage.SourceType
+	}
+	return dorisStorage
+}
+
+func buildDorisRoute(dorisStorage DorisStorage) map[string]any {
 	// Doris 分段路由需要携带 BKBase 表名和 doris measurement，用于 UQ 生成该时间段的 BKSQL 查询目标。
 	// 如果这里没有补齐，UQ 会拒绝消费 ES -> Doris 的 bk_sql 分段 route，防止 fallback 到外层 ES db/measurement。
 	dorisRoute := map[string]any{}
-	if hasDorisRoute {
-		if dorisStorage.OriginTableId != "" &&
-			(dorisStorage.BkbaseTableID == "" || dorisStorage.StorageClusterID == 0 ||
-				dorisStorage.IndexSet == "" || dorisStorage.SourceType == "") {
-			// 当前 Doris 记录可能只保留 origin_table_id，继续按 origin RT 查真实的 BKBase 表名和 ES 查询目标。
-			var originDorisStorage DorisStorage
-			if err = NewDorisStorageQuerySet(db).
-				Select(
-					DorisStorageDBSchema.TableID,
-					DorisStorageDBSchema.BkbaseTableID,
-					DorisStorageDBSchema.StorageClusterID,
-					DorisStorageDBSchema.IndexSet,
-					DorisStorageDBSchema.SourceType,
-				).
-				TableIDEq(dorisStorage.OriginTableId).
-				One(&originDorisStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
-				logger.Errorf("compose_table_id_storage_cluster_records: failed to query origin doris storage for table_id->[%s], origin_table_id->[%s], error: %v", tableID, dorisStorage.OriginTableId, err)
-				return nil, err
-			}
-			if dorisStorage.BkbaseTableID == "" {
-				dorisStorage.BkbaseTableID = originDorisStorage.BkbaseTableID
-			}
-			if dorisStorage.StorageClusterID == 0 {
-				dorisStorage.StorageClusterID = originDorisStorage.StorageClusterID
-			}
-			if dorisStorage.IndexSet == "" {
-				dorisStorage.IndexSet = originDorisStorage.IndexSet
-			}
-			if dorisStorage.SourceType == "" {
-				dorisStorage.SourceType = originDorisStorage.SourceType
-			}
+	if dorisStorage.BkbaseTableID != "" {
+		dorisRoute["db"] = dorisStorage.BkbaseTableID
+		dorisRoute["measurement"] = models.DorisMeasurement
+	}
+	return dorisRoute
+}
+
+func getESStorageMapByTableID(db *gorm.DB, tableIDs []string) (map[string]ESStorage, error) {
+	esStorageMap := make(map[string]ESStorage)
+	if err := appendESStorageMapByTableID(db, esStorageMap, tableIDs); err != nil {
+		return nil, err
+	}
+	return esStorageMap, nil
+}
+
+func appendESStorageMapByTableID(db *gorm.DB, esStorageMap map[string]ESStorage, tableIDs []string) error {
+	for _, chunkTableIDs := range chunkMissingStorageClusterRecordTableIDs(tableIDs, esStorageMap) {
+		var esStorageList []ESStorage
+		if err := NewESStorageQuerySet(db).
+			Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.OriginTableId, ESStorageDBSchema.SourceType).
+			TableIDIn(chunkTableIDs...).
+			All(&esStorageList); err != nil {
+			logger.Errorf("compose_table_id_storage_cluster_records: failed to query es storage for table_id_list->[%v], error: %v", chunkTableIDs, err)
+			return err
 		}
-		if dorisStorage.BkbaseTableID != "" {
-			dorisRoute["db"] = dorisStorage.BkbaseTableID
-			dorisRoute["measurement"] = models.DorisMeasurement
+		for _, esStorage := range esStorageList {
+			esStorageMap[esStorage.TableID] = esStorage
 		}
 	}
+	return nil
+}
 
+func selectESStorage(esStorageMap map[string]ESStorage, tableID string, routeTableID string) ESStorage {
+	// 优先按当前下发 RT 查 ES storage；查不到 index_set 时再回退到历史记录所属的真实 RT。
+	esStorage := esStorageMap[routeTableID]
+	if esStorage.IndexSet == "" && routeTableID != tableID {
+		if fallbackStorage, ok := esStorageMap[tableID]; ok {
+			esStorage = fallbackStorage
+		}
+	}
+	return esStorage
+}
+
+func fillESStorageFromOrigin(esStorage ESStorage, esStorageMap map[string]ESStorage) ESStorage {
+	if esStorage.IndexSet != "" || esStorage.OriginTableId == "" {
+		return esStorage
+	}
+	// ES 迁移记录可能通过 origin_table_id 指向真实索引配置。
+	originESStorage := esStorageMap[esStorage.OriginTableId]
+	if esStorage.IndexSet == "" {
+		esStorage.IndexSet = originESStorage.IndexSet
+	}
+	if esStorage.SourceType == "" {
+		esStorage.SourceType = originESStorage.SourceType
+	}
+	return esStorage
+}
+
+func buildESRoute(esStorage ESStorage, dorisStorage DorisStorage) map[string]any {
 	// ES 路由同样补齐 index_set 和默认 measurement，支持外层是 Doris 时按时间段回查 ES。
 	// 这里补齐的是 ES 查询目标，不能和 Doris 的 bkbase_table_id / doris measurement 混用。
 	esRoute := map[string]any{}
-	if hasESRoute && db.HasTable(ESStorage{}) {
-		var esStorage ESStorage
-		// 优先按当前下发 RT 查 ES storage；查不到 index_set 时再回退到历史记录所属的真实 RT。
-		if err = NewESStorageQuerySet(db).
-			Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.OriginTableId, ESStorageDBSchema.SourceType).
-			TableIDEq(routeTableID).
-			One(&esStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
-			logger.Errorf("compose_table_id_storage_cluster_records: failed to query es storage for table_id->[%s], error: %v", routeTableID, err)
-			return nil, err
-		}
-		if esStorage.IndexSet == "" && routeTableID != tableID {
-			if err = NewESStorageQuerySet(db).
-				Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.OriginTableId, ESStorageDBSchema.SourceType).
-				TableIDEq(tableID).
-				One(&esStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
-				logger.Errorf("compose_table_id_storage_cluster_records: failed to query es storage for table_id->[%s], error: %v", tableID, err)
-				return nil, err
-			}
-		}
-		if esStorage.IndexSet == "" && esStorage.OriginTableId != "" {
-			// ES 迁移记录可能通过 origin_table_id 指向真实索引配置。
-			var originESStorage ESStorage
-			if err = NewESStorageQuerySet(db).
-				Select(ESStorageDBSchema.TableID, ESStorageDBSchema.IndexSet, ESStorageDBSchema.SourceType).
-				TableIDEq(esStorage.OriginTableId).
-				One(&originESStorage); err != nil && !gorm.IsRecordNotFoundError(err) {
-				logger.Errorf("compose_table_id_storage_cluster_records: failed to query origin es storage for table_id->[%s], origin_table_id->[%s], error: %v", tableID, esStorage.OriginTableId, err)
-				return nil, err
-			}
-			if esStorage.IndexSet == "" {
-				esStorage.IndexSet = originESStorage.IndexSet
-			}
-			if esStorage.SourceType == "" {
-				esStorage.SourceType = originESStorage.SourceType
-			}
-		}
-		if esStorage.IndexSet == "" {
-			// Doris 结果表的历史 ES 索引可能保存在 metadata_dorisstorage 上，而没有对应 metadata_esstorage 行。
-			esStorage.IndexSet = dorisStorage.IndexSet
-			esStorage.SourceType = dorisStorage.SourceType
-		}
-		if esStorage.IndexSet != "" {
-			esRoute["db"] = esStorage.IndexSet
-			esRoute["measurement"] = models.TSGroupDefaultMeasurement
-			esRoute["source_type"] = esStorage.SourceType
-		}
+	if esStorage.IndexSet == "" {
+		// Doris 结果表的历史 ES 索引可能保存在 metadata_dorisstorage 上，而没有对应 metadata_esstorage 行。
+		esStorage.IndexSet = dorisStorage.IndexSet
+		esStorage.SourceType = dorisStorage.SourceType
 	}
+	if esStorage.IndexSet != "" {
+		esRoute["db"] = esStorage.IndexSet
+		esRoute["measurement"] = models.TSGroupDefaultMeasurement
+		esRoute["source_type"] = esStorage.SourceType
+	}
+	return esRoute
+}
 
+func composeStorageClusterRecordRoutes(records []ClusterRecord, clusterInfoMap map[uint]ClusterInfo, dorisRoute map[string]any, esRoute map[string]any) []map[string]any {
 	// 组装结果集
 	result := make([]map[string]any, 0)
 	for _, record := range records {
@@ -283,6 +471,25 @@ func ComposeTableIDStorageClusterRecords(db *gorm.DB, tableID string, currentTab
 		result = append(result, route)
 	}
 
-	logger.Infof("compose_table_id_storage_cluster_records: get storage cluster records for table_id->[%s] success, records->[%v]", tableID, result)
-	return result, nil
+	return result
+}
+
+func filterStorageClusterRecordTableIDs(tableIDs []string) []string {
+	return lo.Uniq(lo.Filter(tableIDs, func(tableID string, _ int) bool {
+		return tableID != ""
+	}))
+}
+
+func chunkMissingStorageClusterRecordTableIDs[T any](tableIDs []string, storageMap map[string]T) [][]string {
+	return chunkStorageClusterRecordValues(lo.Filter(filterStorageClusterRecordTableIDs(tableIDs), func(tableID string, _ int) bool {
+		_, ok := storageMap[tableID]
+		return !ok
+	}))
+}
+
+func chunkStorageClusterRecordValues[T any](values []T) [][]T {
+	if len(values) == 0 {
+		return nil
+	}
+	return lo.Chunk(values, storageClusterRecordDBFilterSize)
 }

--- a/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord_test.go
+++ b/pkg/bk-monitor-worker/internal/metadata/models/storage/storageclusterrecord_test.go
@@ -274,3 +274,165 @@ func TestComposeTableIDStorageClusterRecordsCompletesESRouteFromOriginDorisStora
 	assert.Equal(t, "bklog_origin_doris_history_es_current", dorisRoute["db"])
 	assert.Equal(t, models.DorisMeasurement, dorisRoute["measurement"])
 }
+
+func TestComposeTableIDStorageClusterRecordsBatchUsesSharedQueries(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	db.DB().SetMaxOpenConns(1)
+	db.LogMode(false)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_storageclusterrecord (
+		table_id text,
+		cluster_id integer,
+		is_deleted boolean,
+		is_current boolean,
+		create_time datetime,
+		enable_time datetime
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_clusterinfo (
+		cluster_id integer,
+		cluster_name text,
+		cluster_type text
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_dorisstorage (
+		table_id text,
+		bkbase_table_id text,
+		origin_table_id text,
+		storage_cluster_id integer,
+		index_set text,
+		source_type text
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_esstorage (
+		table_id text,
+		index_set text,
+		origin_table_id text,
+		source_type text
+	)`).Error)
+
+	const esClusterID = uint(196001)
+	realTableID1 := "bklog.batch_route_real_1"
+	currentTableID1 := "bklog.batch_route_current_1"
+	realTableID2 := "bklog.batch_route_real_2"
+	currentTableID2 := "bklog.batch_route_current_2"
+	enable1 := time.Unix(1000, 0)
+	enable2 := time.Unix(2000, 0)
+
+	require.NoError(t, db.Exec(
+		"INSERT INTO metadata_clusterinfo (cluster_id, cluster_name, cluster_type) VALUES (?, ?, ?)",
+		esClusterID, "es_batch_route", models.StorageTypeES,
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO metadata_esstorage (table_id, index_set, source_type) VALUES (?, ?, ?), (?, ?, ?)",
+		currentTableID1, "bklog_batch_route_es_1", models.EsSourceTypeBKDATA,
+		currentTableID2, "bklog_batch_route_es_2", models.EsSourceTypeBKDATA,
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO metadata_storageclusterrecord (table_id, cluster_id, is_deleted, is_current, create_time, enable_time) VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)",
+		realTableID1, esClusterID, false, true, enable1.Add(time.Minute), enable1,
+		realTableID2, esClusterID, false, true, enable2.Add(time.Minute), enable2,
+	).Error)
+
+	queryCount := make(map[string]int)
+	callbackName := "test:count_storage_cluster_record_batch_query"
+	db.Callback().Query().Before("gorm:query").Register(callbackName, func(scope *gorm.Scope) {
+		switch scope.TableName() {
+		case "metadata_storageclusterrecord", "metadata_clusterinfo", "metadata_dorisstorage", "metadata_esstorage":
+			queryCount[scope.TableName()]++
+		}
+	})
+	defer db.Callback().Query().Remove(callbackName)
+
+	request1 := TableIDStorageClusterRecordRequest{TableID: realTableID1, CurrentTableID: currentTableID1}
+	request2 := TableIDStorageClusterRecordRequest{TableID: realTableID2, CurrentTableID: currentTableID2}
+	recordsMap, err := ComposeTableIDStorageClusterRecordsBatch(db, []TableIDStorageClusterRecordRequest{request1, request2})
+	require.NoError(t, err)
+
+	records1 := recordsMap[request1]
+	require.Len(t, records1, 1)
+	assert.Equal(t, "bklog_batch_route_es_1", records1[0]["db"])
+	assert.Equal(t, enable1.Unix(), records1[0]["enable_time"])
+	records2 := recordsMap[request2]
+	require.Len(t, records2, 1)
+	assert.Equal(t, "bklog_batch_route_es_2", records2[0]["db"])
+	assert.Equal(t, enable2.Unix(), records2[0]["enable_time"])
+
+	assert.Equal(t, 1, queryCount["metadata_storageclusterrecord"])
+	assert.Equal(t, 1, queryCount["metadata_clusterinfo"])
+	assert.Equal(t, 1, queryCount["metadata_dorisstorage"])
+	assert.Equal(t, 1, queryCount["metadata_esstorage"])
+}
+
+func TestComposeTableIDStorageClusterRecordsBatchSeparatesRealAndCurrentTableIDKeys(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	db.DB().SetMaxOpenConns(1)
+	db.LogMode(false)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_storageclusterrecord (
+		table_id text,
+		cluster_id integer,
+		is_deleted boolean,
+		is_current boolean,
+		create_time datetime,
+		enable_time datetime
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_clusterinfo (
+		cluster_id integer,
+		cluster_name text,
+		cluster_type text
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_dorisstorage (
+		table_id text,
+		bkbase_table_id text,
+		origin_table_id text,
+		storage_cluster_id integer,
+		index_set text,
+		source_type text
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE metadata_esstorage (
+		table_id text,
+		index_set text,
+		origin_table_id text,
+		source_type text
+	)`).Error)
+
+	directTableID := "bklog.batch_result_key_shared"
+	realTableID := "bklog.batch_result_key_real"
+	currentTableID := directTableID
+	const (
+		directClusterID  = uint(197001)
+		virtualClusterID = uint(197002)
+	)
+	directEnable := time.Unix(1000, 0)
+	virtualEnable := time.Unix(2000, 0)
+
+	require.NoError(t, db.Exec(
+		"INSERT INTO metadata_clusterinfo (cluster_id, cluster_name, cluster_type) VALUES (?, ?, ?), (?, ?, ?)",
+		directClusterID, "es_batch_result_key_direct", models.StorageTypeES,
+		virtualClusterID, "es_batch_result_key_virtual", models.StorageTypeES,
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO metadata_esstorage (table_id, index_set, source_type) VALUES (?, ?, ?)",
+		currentTableID, "bklog_batch_result_key_es", models.EsSourceTypeBKDATA,
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO metadata_storageclusterrecord (table_id, cluster_id, is_deleted, is_current, create_time, enable_time) VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)",
+		directTableID, directClusterID, false, true, directEnable.Add(time.Minute), directEnable,
+		realTableID, virtualClusterID, false, true, virtualEnable.Add(time.Minute), virtualEnable,
+	).Error)
+
+	directRequest := TableIDStorageClusterRecordRequest{TableID: directTableID}
+	virtualRequest := TableIDStorageClusterRecordRequest{TableID: realTableID, CurrentTableID: currentTableID}
+	recordsMap, err := ComposeTableIDStorageClusterRecordsBatch(db, []TableIDStorageClusterRecordRequest{directRequest, virtualRequest})
+	require.NoError(t, err)
+
+	directRecords := recordsMap[directRequest]
+	require.Len(t, directRecords, 1)
+	assert.Equal(t, int64(directClusterID), directRecords[0]["storage_id"])
+	assert.Equal(t, directEnable.Unix(), directRecords[0]["enable_time"])
+
+	virtualRecords := recordsMap[virtualRequest]
+	require.Len(t, virtualRecords, 1)
+	assert.Equal(t, int64(virtualClusterID), virtualRecords[0]["storage_id"])
+	assert.Equal(t, virtualEnable.Unix(), virtualRecords[0]["enable_time"])
+}

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis.go
@@ -787,6 +787,7 @@ func (s *SpacePusher) PushEsTableIdDetail(bkTenantId string, tableIdList []strin
 		storage.ESStorageDBSchema.StorageClusterID,
 		storage.ESStorageDBSchema.SourceType,
 		storage.ESStorageDBSchema.IndexSet,
+		storage.ESStorageDBSchema.OriginTableId,
 	)
 
 	// 如果过滤结果表存在，则添加过滤条件
@@ -814,6 +815,32 @@ func (s *SpacePusher) PushEsTableIdDetail(bkTenantId string, tableIdList []strin
 	// 组装结果表对应的选项
 	tidOptionMap := s.composeEsTableIdOptions(bkTenantId, tidList)
 
+	rtMetaMap, err := s.getESResultTableDetailMetaMap(bkTenantId, tidList)
+	if err != nil {
+		logger.Errorf("PushEsTableIdDetail: failed to get result table metadata map, error: %s", err)
+		return err
+	}
+
+	clusterRecordRequests := make([]storage.TableIDStorageClusterRecordRequest, 0, len(esStorageList))
+	clusterRecordRequestMap := make(map[string]storage.TableIDStorageClusterRecordRequest, len(esStorageList))
+	for _, es := range esStorageList {
+		realTableId := es.TableID
+		if es.OriginTableId != "" {
+			realTableId = es.OriginTableId
+		}
+		request := storage.TableIDStorageClusterRecordRequest{
+			TableID:        realTableId,
+			CurrentTableID: es.TableID,
+		}
+		clusterRecordRequests = append(clusterRecordRequests, request)
+		clusterRecordRequestMap[es.TableID] = request
+	}
+	clusterRecordsMap, err := storage.ComposeTableIDStorageClusterRecordsBatch(db, clusterRecordRequests)
+	if err != nil {
+		logger.Errorf("PushEsTableIdDetail: failed to get storage cluster records map, error: %s", err)
+		return err
+	}
+
 	// 获取查询别名映射关系
 	fieldAliasMap, err := s.getFieldAliasMap(bkTenantId, tidList)
 	if err != nil {
@@ -825,6 +852,7 @@ func (s *SpacePusher) PushEsTableIdDetail(bkTenantId string, tableIdList []strin
 	wg := &sync.WaitGroup{}
 	// 因为每个处理任务完全独立，可以并发执行
 	ch := make(chan struct{}, 50)
+	errCh := make(chan error, len(esStorageList))
 	wg.Add(len(esStorageList))
 	for _, es := range esStorageList {
 		// 获取 option 数据
@@ -850,9 +878,19 @@ func (s *SpacePusher) PushEsTableIdDetail(bkTenantId string, tableIdList []strin
 				fieldAliasSettings = fieldAliasMap[tableId]
 			}
 
-			composedTableId, detailStr, err := s.composeEsTableIdDetail(bkTenantId, tableId, options, es.StorageClusterID, sourceType, indexSet, fieldAliasSettings)
+			composedTableId, detailStr, err := s.composeEsTableIdDetail(
+				tableId,
+				options,
+				es.StorageClusterID,
+				sourceType,
+				indexSet,
+				clusterRecordsMap[clusterRecordRequestMap[tableId]],
+				rtMetaMap[tableId],
+				fieldAliasSettings,
+			)
 			if err != nil {
 				logger.Errorf("PushEsTableIdDetail:compose es table id detail error, table_id: %s, error: %s", tableId, err)
+				errCh <- errors.Wrapf(err, "compose es table id detail error, table_id: %s", tableId)
 				return
 			}
 			// 多租户模式下，redis key 需要补充租户ID后缀
@@ -863,12 +901,17 @@ func (s *SpacePusher) PushEsTableIdDetail(bkTenantId string, tableIdList []strin
 			isSuccess, err := client.HSetWithCompareAndPublish(cfg.ResultTableDetailKey, redisKey, detailStr, cfg.ResultTableDetailChannel, redisKey)
 			if err != nil {
 				logger.Errorf("PushEsTableIdDetail:push and publish es table id detail error, table_id->[%s], error->[%s]", tableId, err)
+				errCh <- errors.Wrapf(err, "push and publish es table id detail error, table_id: %s", tableId)
 				return
 			}
 			logger.Infof("PushEsTableIdDetail:push es table id detail success, table_id->[%s], is_success->[%v]", tableId, isSuccess)
 		}(es, options, wg, ch)
 	}
 	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		return err
+	}
 	logger.Infof("PushEsTableIdDetail:push es table id detail success, table_id_list [%v]", tableIdList)
 	return nil
 }
@@ -1115,6 +1158,11 @@ type resultTableDetailMeta struct {
 	Labels    map[string]any
 }
 
+type esResultTableDetailMeta struct {
+	DataLabel *string
+	Labels    map[string]any
+}
+
 func resultTableDataLabel(dataLabel *string) string {
 	if dataLabel == nil {
 		return ""
@@ -1145,6 +1193,40 @@ func (s *SpacePusher) getResultTableDetailMetaMap(bkTenantId string, tableIDList
 				DataLabel: resultTableDataLabel(rt.DataLabel),
 				Labels:    normalizeResultTableLabels(rt.TableId, rt.Labels),
 			}
+		}
+	}
+
+	return metaMap, nil
+}
+
+func (s *SpacePusher) getESResultTableDetailMetaMap(bkTenantId string, tableIDList []string) (map[string]esResultTableDetailMeta, error) {
+	db := mysql.GetDBSession().DB
+	metaMap := make(map[string]esResultTableDetailMeta)
+	if len(tableIDList) == 0 {
+		return metaMap, nil
+	}
+
+	for _, chunkTableIDList := range slicex.ChunkSlice(tableIDList, 0) {
+		var resultTables []resulttable.ResultTable
+		if err := resulttable.NewResultTableQuerySet(db).Select(
+			resulttable.ResultTableDBSchema.TableId,
+			resulttable.ResultTableDBSchema.DataLabel,
+			resulttable.ResultTableDBSchema.Labels,
+		).BkTenantIdEq(bkTenantId).TableIdIn(chunkTableIDList...).All(&resultTables); err != nil {
+			return nil, err
+		}
+
+		for _, rt := range resultTables {
+			metaMap[rt.TableId] = esResultTableDetailMeta{
+				DataLabel: rt.DataLabel,
+				Labels:    normalizeResultTableLabels(rt.TableId, rt.Labels),
+			}
+		}
+	}
+
+	for _, tableID := range tableIDList {
+		if _, ok := metaMap[tableID]; !ok {
+			return nil, errors.Errorf("result table not found, table_id: %s", tableID)
 		}
 	}
 
@@ -1315,42 +1397,26 @@ func (s *SpacePusher) composeRecordRuleTableIdDetail(bkTenantId string) (map[str
 	return tableIdDetail, nil
 }
 
-func (s *SpacePusher) composeEsTableIdDetail(bkTenantId string, tableId string, options map[string]any, storageClusterId uint, sourceType, indexSet string, fieldAliasSettings map[string]string) (string, string, error) {
-	logger.Infof("compose es table id detail, bk_tenant_id [%s], table_id [%s], options [%+v], storage_cluster_id [%d], source_type [%s], index_set [%s]", bkTenantId, tableId, options, storageClusterId, sourceType, indexSet)
-
-	// 获取历史存储集群记录
-	db := mysql.GetDBSession().DB
-
-	// 若该RT是虚拟RT,则使用其关联的真实RT去查询存储集群记录信息
-	var storageIns storage.ESStorage
-	realTableId := tableId
-	if err := storage.NewESStorageQuerySet(db).Select(storage.ESStorageDBSchema.OriginTableId).TableIDEq(tableId).One(&storageIns); err != nil {
-		logger.Errorf("composeEsTableIdDetail: failed to get origin table_id for table_id [%s], error: %v", tableId, err)
-		return tableId, "", err
-	}
-
-	if storageIns.OriginTableId != "" {
-		logger.Infof("composeEsTableIdDetail: origin table_id [%s] found for table_id [%s]", storageIns.OriginTableId, tableId)
-		realTableId = storageIns.OriginTableId
-	}
-
-	clusterRecords, err := storage.ComposeTableIDStorageClusterRecords(db, realTableId, tableId)
-	if err != nil {
-		logger.Errorf("composeEsTableIdDetail: failed to get storage cluster records for table_id [%s], error: %v", realTableId, err)
-		return "", "", err
-	}
-
-	// 按租户过滤, 避免 table_id 在不同租户下重复时取到其他租户的元数据
-	var rt resulttable.ResultTable
-	if err := resulttable.NewResultTableQuerySet(db).Select(
-		resulttable.ResultTableDBSchema.DataLabel,
-		resulttable.ResultTableDBSchema.Labels,
-	).BkTenantIdEq(bkTenantId).TableIdEq(tableId).One(&rt); err != nil {
-		return tableId, "", err
-	}
+func (s *SpacePusher) composeEsTableIdDetail(
+	tableId string,
+	options map[string]any,
+	storageClusterId uint,
+	sourceType string,
+	indexSet string,
+	clusterRecords []map[string]any,
+	rtMeta esResultTableDetailMeta,
+	fieldAliasSettings map[string]string,
+) (string, string, error) {
+	logger.Infof("compose es table id detail, table_id [%s], options [%+v], storage_cluster_id [%d], source_type [%s], index_set [%s]", tableId, options, storageClusterId, sourceType, indexSet)
 
 	if fieldAliasSettings == nil {
 		fieldAliasSettings = make(map[string]string)
+	}
+	if clusterRecords == nil {
+		clusterRecords = make([]map[string]any, 0)
+	}
+	if rtMeta.Labels == nil {
+		rtMeta.Labels = make(map[string]any)
 	}
 
 	// 组装数据
@@ -1362,8 +1428,8 @@ func (s *SpacePusher) composeEsTableIdDetail(bkTenantId string, tableId string, 
 		"source_type":             sourceType,
 		"options":                 options,
 		"storage_cluster_records": clusterRecords,
-		"data_label":              rt.DataLabel,
-		"labels":                  normalizeResultTableLabels(tableId, rt.Labels),
+		"data_label":              rtMeta.DataLabel,
+		"labels":                  rtMeta.Labels,
 		"field_alias":             fieldAliasSettings, // 添加字段别名
 	})
 	if err != nil {

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
@@ -2173,11 +2173,6 @@ func TestSpacePusher_ComposeData(t *testing.T) {
 }
 
 func TestSpacePusher_composeEsTableIdDetail(t *testing.T) {
-	// 初始化数据库
-	mocker.InitTestDBConfig("../../../bmw_test.yaml")
-	db := mysql.GetDBSession().DB
-	db.AutoMigrate(&storage.ESStorage{}, &resulttable.ResultTable{}, &storage.ClusterRecord{})
-
 	// 准备测试数据
 	tableID1 := "1001_bkmonitor_time_series_50010.__default__"
 	tableID2 := "1001_bkmonitor_time_series_50011.__default__"
@@ -2186,51 +2181,17 @@ func TestSpacePusher_composeEsTableIdDetail(t *testing.T) {
 	labels1 := json.RawMessage(`{"env":"prod","region":"sh"}`)
 	labels3 := json.RawMessage(`["unexpected"]`)
 
-	// 插入 ResultTable 数据
-	resultTables := []resulttable.ResultTable{
-		{
-			TableId:      tableID1,
-			BkBizId:      1001,
-			BkBizIdAlias: "appid",
-			DataLabel:    &dataLabel1, // 使用字符串指针
-			Labels:       labels1,
-		},
-		{
-			TableId:      tableID2,
-			BkBizId:      1001,
-			BkBizIdAlias: "",
-			DataLabel:    nil,
-		},
-		{
-			TableId:      tableID3,
-			BkBizId:      1001,
-			BkBizIdAlias: "",
-			DataLabel:    nil,
-			Labels:       labels3,
-		},
-	}
-	for _, rt := range resultTables {
-		db.Delete(&resulttable.ResultTable{}, "table_id = ?", rt.TableId)
-		assert.NoError(t, db.Create(&rt).Error, "Failed to insert ResultTable")
-	}
-
-	// composeEsTableIdDetail 会先查询 ESStorage 获取 origin_table_id, 需保证存在对应记录
-	for _, tableID := range []string{tableID1, tableID2, tableID3} {
-		db.Delete(&storage.ESStorage{}, "table_id = ?", tableID)
-		esStorage := storage.ESStorage{TableID: tableID, StorageClusterID: 1, SourceType: "sourceType1", IndexSet: "indexSet1", NeedCreateIndex: true}
-		assert.NoError(t, db.Create(&esStorage).Error, "Failed to insert ESStorage")
-	}
-
 	// 准备 SpacePusher 实例
 	spacePusher := SpacePusher{}
 	// 调用测试方法
 	tableID, detailStr, err := spacePusher.composeEsTableIdDetail(
-		"",
 		tableID1,
 		map[string]any{"option1": "value1"},
 		1,
 		"sourceType1",
 		"indexSet1",
+		nil,
+		esResultTableDetailMeta{DataLabel: &dataLabel1, Labels: normalizeResultTableLabels(tableID1, labels1)},
 		nil,
 	)
 
@@ -2261,12 +2222,13 @@ func TestSpacePusher_composeEsTableIdDetail(t *testing.T) {
 	assert.Equal(t, expectedDetail, actualDetail, "detailStr should match expected JSON")
 	// 调用测试方法
 	resTid, detailStr2, err := spacePusher.composeEsTableIdDetail(
-		"",
 		tableID2,
 		map[string]any{"option1": "value1"},
 		1,
 		"sourceType1",
 		"indexSet1",
+		nil,
+		esResultTableDetailMeta{Labels: map[string]any{}},
 		nil,
 	)
 
@@ -2294,12 +2256,13 @@ func TestSpacePusher_composeEsTableIdDetail(t *testing.T) {
 	assert.Equal(t, expectedDetail2, actualDetail2, "detailStr should match expected JSON")
 
 	resTid3, detailStr3, err := spacePusher.composeEsTableIdDetail(
-		"",
 		tableID3,
 		map[string]any{"option1": "value1"},
 		1,
 		"sourceType1",
 		"indexSet1",
+		nil,
+		esResultTableDetailMeta{Labels: normalizeResultTableLabels(tableID3, labels3)},
 		nil,
 	)
 	assert.NoError(t, err, "composeEsTableIdDetail should not return an error")


### PR DESCRIPTION
## 变更内容
- 为 `ComposeTableIDStorageClusterRecords` 增加批量组装入口，批量预取 storage cluster records、cluster info、ES/Doris storage，避免 ES 路由发布时按 table_id 重复查询。
- `PushEsTableIdDetail` 预取 `origin_table_id`、result table meta 和 storage cluster records，`composeEsTableIdDetail` 改为纯组装逻辑。
- 增加批量查询次数断言，覆盖多个 ES RT 共享一次核心元数据查询的场景。