### PR TITLE
feat: implement kube_hpa_spec_target_metric in bkm-ksm-exporter for kube-state-metrics v1.9.7 HPA parity

### DIFF
--- a/pkg/bkm-ksm-exporter/README.md
+++ b/pkg/bkm-ksm-exporter/README.md
@@ -30,10 +30,18 @@ All gauges, with default labels `namespace` and `hpa`:
 | `kube_hpa_status_desired_replicas` | `.status.desiredReplicas` |
 | `kube_hpa_labels` | object labels, as `label_<key>` (value `1`) |
 | `kube_hpa_status_condition` | `.status.conditions[]` (labels `condition`, `status`) |
+| `kube_hpa_spec_target_metric` | `.spec.metrics[]` target (labels `metric_name`, `metric_target_type` one of `utilization`/`value`/`average`) |
 
-> `kube_hpa_spec_target_metric` (the 8th kube-state-metrics HPA family) is not
-> emitted yet — it requires mapping the `autoscaling/v2` `MetricSpec` shape and is
-> tracked as a follow-up.
+> `kube_hpa_spec_target_metric` maps the `autoscaling/v2` `MetricSpec` to the same
+> labels and values as kube-state-metrics v1.9.7: one series per target field that
+> is set, with `metric_target_type` one of `utilization`/`value`/`average`. Like
+> v1.9.7, a `Quantity` target that is not an exact integer (e.g. `1500m`) is
+> skipped (`AsInt64` reports it cannot be represented), not emitted as `0`. The
+> `autoscaling/v2`-only `ContainerResource` source (absent from the
+> `autoscaling/v2beta1` that v1.9.7 read) is **not** emitted: the metric has no
+> `container` label, so multiple `ContainerResource` targets differing only by
+> container — e.g. the old/new pair recommended during a container rename — would
+> collide into duplicate samples.
 
 ## Run
 

--- a/pkg/bkm-ksm-exporter/collectors/hpa/hpa.go
+++ b/pkg/bkm-ksm-exporter/collectors/hpa/hpa.go
@@ -51,6 +51,7 @@ const (
 	helpDesiredReplicas = "Desired number of replicas of pods managed by this autoscaler."
 	helpLabels          = "Kubernetes labels converted to Prometheus labels."
 	helpCondition       = "The condition of this autoscaler."
+	helpTargetMetric    = "The metric specifications used by this autoscaler when calculating the desired replica count."
 )
 
 // conditionStatuses mirrors kube-state-metrics: every condition is emitted as
@@ -58,10 +59,6 @@ const (
 var conditionStatuses = []string{"true", "false", "unknown"}
 
 // Write renders all kube_hpa_* metrics in Prometheus text exposition format.
-//
-// kube_hpa_spec_target_metric (the 8th kube-state-metrics family) is intentionally
-// not emitted yet: it requires mapping the autoscaling/v2 MetricSpec shape and is
-// not consumed by current strategies. It is tracked as a follow-up.
 func (c *Collector) Write(w io.Writer) error {
 	hpas, err := c.lister.List(labels.Everything())
 	if err != nil {
@@ -130,7 +127,105 @@ func writeMetrics(w io.Writer, hpas []*autoscalingv2.HorizontalPodAutoscaler) er
 		}
 	}
 
+	mw.help("kube_hpa_spec_target_metric", helpTargetMetric)
+	for _, h := range hpas {
+		for _, m := range h.Spec.Metrics {
+			name, target, ok := metricSpecTarget(m)
+			if !ok {
+				continue
+			}
+			for _, tv := range targetTypeValues(target) {
+				extra := &labelSet{
+					keys: []string{"metric_name", "metric_target_type"},
+					vals: []string{name, tv.typ},
+				}
+				mw.sample("kube_hpa_spec_target_metric", base(h), extra, tv.val)
+			}
+		}
+	}
+
 	return mw.err
+}
+
+// targetTypeValue is one (metric_target_type, value) pair derived from a v2
+// MetricTarget for kube_hpa_spec_target_metric.
+type targetTypeValue struct {
+	typ string
+	val float64
+}
+
+// metricSpecTarget extracts the metric name and target from a v2 MetricSpec,
+// matching kube-state-metrics v1.9.7's per-source-type handling. ok is false for
+// a source v1.9.7 did not emit (ContainerResource; see the case below) and for a
+// malformed (nil) source struct or an unknown type.
+func metricSpecTarget(m autoscalingv2.MetricSpec) (name string, target autoscalingv2.MetricTarget, ok bool) {
+	switch m.Type {
+	case autoscalingv2.ResourceMetricSourceType:
+		if m.Resource == nil {
+			return "", autoscalingv2.MetricTarget{}, false
+		}
+		return string(m.Resource.Name), m.Resource.Target, true
+	case autoscalingv2.ContainerResourceMetricSourceType:
+		// Not emitted. kube-state-metrics v1.9.7 read autoscaling/v2beta1, which has
+		// no ContainerResource source, so there is no v1.9.7 series to match. It is
+		// also unsafe to emit here: kube_hpa_spec_target_metric has no container
+		// label, so two ContainerResource targets differing only by container -- e.g.
+		// the old/new pair the autoscaling docs recommend keeping during a container
+		// rename -- would collide into duplicate, conflicting samples.
+		return "", autoscalingv2.MetricTarget{}, false
+	case autoscalingv2.PodsMetricSourceType:
+		if m.Pods == nil {
+			return "", autoscalingv2.MetricTarget{}, false
+		}
+		return m.Pods.Metric.Name, m.Pods.Target, true
+	case autoscalingv2.ObjectMetricSourceType:
+		if m.Object == nil {
+			return "", autoscalingv2.MetricTarget{}, false
+		}
+		return m.Object.Metric.Name, m.Object.Target, true
+	case autoscalingv2.ExternalMetricSourceType:
+		if m.External == nil {
+			return "", autoscalingv2.MetricTarget{}, false
+		}
+		return m.External.Metric.Name, m.External.Target, true
+	default:
+		return "", autoscalingv2.MetricTarget{}, false
+	}
+}
+
+// targetTypeValues renders a v2 MetricTarget into kube-state-metrics v1.9.7's
+// (metric_target_type, value) pairs, one series per target field that is set, in
+// v1.9.7's value/utilization/average order.
+//
+// The Quantity fields (Value, AverageValue) are gated on Quantity.AsInt64's ok
+// flag exactly as v1.9.7 is: AsInt64 returns ok=false for any non-integer
+// Quantity (e.g. "1500m"), and v1.9.7 then emits no series for it. Discarding ok
+// would instead emit a misleading 0-valued series, so we skip when !ok.
+// AverageUtilization is an *int32 (no Quantity), so it is emitted whenever set,
+// matching v1.9.7's nil check.
+//
+// Note: v1.9.7 read a fixed set of target fields per source type; autoscaling/v2
+// unifies them into one MetricTarget whose single set field matches Target.Type.
+// This source-type-agnostic sweep reproduces v1.9.7 for the field a valid v2
+// object actually sets, but cannot recreate v2beta1-only shapes (e.g. an
+// averageValue Object, where v2beta1 also carried a separate required TargetValue
+// row that has no v2 counterpart).
+func targetTypeValues(t autoscalingv2.MetricTarget) []targetTypeValue {
+	var out []targetTypeValue
+	if t.Value != nil {
+		if v, ok := t.Value.AsInt64(); ok {
+			out = append(out, targetTypeValue{typ: "value", val: float64(v)})
+		}
+	}
+	if t.AverageUtilization != nil {
+		out = append(out, targetTypeValue{typ: "utilization", val: float64(*t.AverageUtilization)})
+	}
+	if t.AverageValue != nil {
+		if v, ok := t.AverageValue.AsInt64(); ok {
+			out = append(out, targetTypeValue{typ: "average", val: float64(v)})
+		}
+	}
+	return out
 }
 
 // labelSet is an ordered list of label key/value pairs.

--- a/pkg/bkm-ksm-exporter/collectors/hpa/hpa_test.go
+++ b/pkg/bkm-ksm-exporter/collectors/hpa/hpa_test.go
@@ -16,10 +16,16 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func i32(v int32) *int32 { return &v }
+
+func qty(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
 
 func TestWriteMetrics(t *testing.T) {
 	minR := i32(2)
@@ -137,5 +143,151 @@ func TestLargeValueNoScientificNotation(t *testing.T) {
 	}
 	if strings.Contains(out, "e+0") || strings.Contains(out, "E+0") {
 		t.Errorf("output contains scientific notation:\n%s", out)
+	}
+}
+
+// TestWriteTargetMetric covers kube_hpa_spec_target_metric for the autoscaling/v2
+// MetricSpec source types kube-state-metrics v1.9.7 emits (Resource/Pods/Object/
+// External): metric_name / metric_target_type / value conventions (utilization
+// from AverageUtilization, value from Value, average from AverageValue), one
+// series per target field that is set. ContainerResource is asserted to emit
+// nothing (no v1.9.7 equivalent).
+func TestWriteTargetMetric(t *testing.T) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "h"},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MaxReplicas: 5,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name:   corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{Type: autoscalingv2.UtilizationMetricType, AverageUtilization: i32(80)},
+					},
+				},
+				{
+					Type: autoscalingv2.PodsMetricSourceType,
+					Pods: &autoscalingv2.PodsMetricSource{
+						Metric: autoscalingv2.MetricIdentifier{Name: "packets-per-second"},
+						Target: autoscalingv2.MetricTarget{Type: autoscalingv2.AverageValueMetricType, AverageValue: qty("1k")},
+					},
+				},
+				{
+					Type: autoscalingv2.ObjectMetricSourceType,
+					Object: &autoscalingv2.ObjectMetricSource{
+						Metric: autoscalingv2.MetricIdentifier{Name: "requests-per-second"},
+						Target: autoscalingv2.MetricTarget{Type: autoscalingv2.ValueMetricType, Value: qty("100")},
+					},
+				},
+				{
+					// Both value and averageValue set -> two series, like v1.9.7.
+					Type: autoscalingv2.ExternalMetricSourceType,
+					External: &autoscalingv2.ExternalMetricSource{
+						Metric: autoscalingv2.MetricIdentifier{Name: "queue-length"},
+						Target: autoscalingv2.MetricTarget{Value: qty("30"), AverageValue: qty("3")},
+					},
+				},
+				{
+					// ContainerResource has no v1.9.7 equivalent and no container label
+					// to disambiguate; it must emit nothing (asserted below).
+					Type: autoscalingv2.ContainerResourceMetricSourceType,
+					ContainerResource: &autoscalingv2.ContainerResourceMetricSource{
+						Name:      corev1.ResourceMemory,
+						Container: "app",
+						Target:    autoscalingv2.MetricTarget{Type: autoscalingv2.AverageValueMetricType, AverageValue: qty("256Mi")},
+					},
+				},
+				{
+					// Malformed: type set but source struct nil -> skipped, no panic.
+					Type: autoscalingv2.ResourceMetricSourceType,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := writeMetrics(&buf, []*autoscalingv2.HorizontalPodAutoscaler{hpa}); err != nil {
+		t.Fatalf("writeMetrics: %v", err)
+	}
+	out := buf.String()
+
+	want := []string{
+		"# HELP kube_hpa_spec_target_metric The metric specifications used by this autoscaler",
+		"# TYPE kube_hpa_spec_target_metric gauge",
+		`kube_hpa_spec_target_metric{namespace="ns",hpa="h",metric_name="cpu",metric_target_type="utilization"} 80`,
+		`kube_hpa_spec_target_metric{namespace="ns",hpa="h",metric_name="packets-per-second",metric_target_type="average"} 1000`,
+		`kube_hpa_spec_target_metric{namespace="ns",hpa="h",metric_name="requests-per-second",metric_target_type="value"} 100`,
+		`kube_hpa_spec_target_metric{namespace="ns",hpa="h",metric_name="queue-length",metric_target_type="value"} 30`,
+		`kube_hpa_spec_target_metric{namespace="ns",hpa="h",metric_name="queue-length",metric_target_type="average"} 3`,
+	}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("output missing line:\n%s\n--- full output ---\n%s", w, out)
+		}
+	}
+
+	// ContainerResource is not emitted (no v1.9.7 equivalent; the metric has no
+	// container label to disambiguate), so the memory ContainerResource above must
+	// produce no series.
+	if strings.Contains(out, `metric_name="memory"`) {
+		t.Errorf("ContainerResource must not emit a target metric series:\n%s", out)
+	}
+}
+
+// TestWriteTargetMetricFractionalSkipped guards parity with kube-state-metrics
+// v1.9.7: a target Quantity that is not an exact integer (AsInt64 ok=false, e.g.
+// "1500m") must be dropped, not emitted as a phantom 0-valued series. A Resource
+// averageValue that IS an exact integer must still be emitted.
+func TestWriteTargetMetricFractionalSkipped(t *testing.T) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "h"},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MaxReplicas: 5,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					// Fractional averageValue -> AsInt64 ok=false -> no series.
+					Type: autoscalingv2.PodsMetricSourceType,
+					Pods: &autoscalingv2.PodsMetricSource{
+						Metric: autoscalingv2.MetricIdentifier{Name: "frac"},
+						Target: autoscalingv2.MetricTarget{Type: autoscalingv2.AverageValueMetricType, AverageValue: qty("1500m")},
+					},
+				},
+				{
+					// Fractional value (0.5) -> AsInt64 ok=false -> no series.
+					Type: autoscalingv2.ObjectMetricSourceType,
+					Object: &autoscalingv2.ObjectMetricSource{
+						Metric: autoscalingv2.MetricIdentifier{Name: "half"},
+						Target: autoscalingv2.MetricTarget{Type: autoscalingv2.ValueMetricType, Value: qty("0.5")},
+					},
+				},
+				{
+					// Integer Resource averageValue -> emitted (covers the Resource
+					// + averageValue branch).
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name:   corev1.ResourceMemory,
+						Target: autoscalingv2.MetricTarget{Type: autoscalingv2.AverageValueMetricType, AverageValue: qty("2Gi")},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := writeMetrics(&buf, []*autoscalingv2.HorizontalPodAutoscaler{hpa}); err != nil {
+		t.Fatalf("writeMetrics: %v", err)
+	}
+	out := buf.String()
+
+	for _, frac := range []string{`metric_name="frac"`, `metric_name="half"`} {
+		if strings.Contains(out, frac) {
+			t.Errorf("fractional Quantity target must be skipped (matching v1.9.7), got %s:\n%s", frac, out)
+		}
+	}
+	if !strings.Contains(out, "# TYPE kube_hpa_spec_target_metric gauge") {
+		t.Errorf("family HELP/TYPE line missing:\n%s", out)
+	}
+	if !strings.Contains(out, `kube_hpa_spec_target_metric{namespace="ns",hpa="h",metric_name="memory",metric_target_type="average"} 2147483648`) {
+		t.Errorf("integer Resource averageValue (2Gi) should be emitted:\n%s", out)
 	}
 }


### PR DESCRIPTION
## What

bkm-ksm-exporter previously emitted 7 of the 8 `kube_hpa_*` families that
kube-state-metrics v1.9.7 produces. The 8th, `kube_hpa_spec_target_metric`, was
deferred in #1362. This implements it, bringing the exporter's `kube_hpa_*`
output in line with kube-state-metrics v1.9.7 on clusters >= 1.25.

## How

Each `autoscaling/v2` `MetricSpec` is mapped to the same labels and values as
kube-state-metrics v1.9.7:

- labels `metric_name` + `metric_target_type` (`value` / `utilization` / `average`)
- one series per target field that is set
- `Quantity` targets use `AsInt64`, and — like v1.9.7 — a non-integer `Quantity`
  (e.g. `1500m`) is skipped (its `AsInt64` reports it cannot be represented)
  rather than emitted as a `0`-valued series
- `ContainerResource` (an `autoscaling/v2`-only source, absent from the
  `autoscaling/v2beta1` that v1.9.7 read) is **not** emitted:
  `kube_hpa_spec_target_metric` has no `container` label, so multiple
  `ContainerResource` targets differing only by container (e.g. the old/new pair
  recommended during a container rename) would otherwise collide into duplicate
  samples

`autoscaling/v2` unifies the per-source-type target fields that v2beta1 (what
v1.9.7 read) kept separate, so this reproduces v1.9.7 for the field a valid v2
HPA actually sets; v2beta1-only shapes have no v2 counterpart.

## Tests

Cover the Resource/Pods/Object/External source types, dual value+average
emission, the fractional-`Quantity` skip, the `ContainerResource` skip, and a
nil-source guard. `go test ./...` passes; `gofmt` / `go vet` clean.

--story=135301331
