### PR TITLE
fix: 修复 timesync 时钟偏移指标：本地时钟超前(负偏移)时 max 恒为 0，且无有效样本时 min 输出异常大初值 --story=135582882

### DIFF
--- a/pkg/bkmonitorbeat/tasks/timesync/client_linux.go
+++ b/pkg/bkmonitorbeat/tasks/timesync/client_linux.go
@@ -14,7 +14,6 @@ package timesync
 import (
 	"bufio"
 	"bytes"
-	"math"
 	"net"
 	"os"
 	"strings"
@@ -72,10 +71,7 @@ func (c *Client) queryNtpd() (*Stat, error) {
 		return nil, err
 	}
 
-	stat := &Stat{
-		Source: "ntpd",
-		Min:    math.MaxInt64,
-	}
+	stat := newStat("ntpd")
 	scanner := bufio.NewScanner(bytes.NewBuffer(b))
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -97,14 +93,7 @@ func (c *Client) queryNtpd() (*Stat, error) {
 			continue
 		}
 
-		stat.Count++
-		stat.Sum += delay
-		if stat.Max < delay {
-			stat.Max = delay
-		}
-		if stat.Min > delay {
-			stat.Min = delay
-		}
+		stat.Add(delay)
 	}
 	return stat, nil
 }
@@ -129,10 +118,7 @@ func (c *Client) queryChrony() (*Stat, error) {
 		return nil, errors.Errorf("want *chrony.ReplySources type, but got %T", packet)
 	}
 
-	stat := &Stat{
-		Source: "chrony",
-		Min:    math.MaxInt64,
-	}
+	stat := newStat("chrony")
 	for i := 0; i < sources.NSources; i++ {
 		packet, err = client.Communicate(chrony.NewSourceDataPacket(int32(i)))
 		if err != nil {
@@ -157,14 +143,7 @@ func (c *Client) queryChrony() (*Stat, error) {
 			continue
 		}
 
-		stat.Count++
-		stat.Sum += sourceData.LatestMeas
-		if stat.Max < sourceData.LatestMeas {
-			stat.Max = sourceData.LatestMeas
-		}
-		if stat.Min > sourceData.LatestMeas {
-			stat.Min = sourceData.LatestMeas
-		}
+		stat.Add(sourceData.LatestMeas)
 	}
 	return stat, nil
 }

--- a/pkg/bkmonitorbeat/tasks/timesync/client_other.go
+++ b/pkg/bkmonitorbeat/tasks/timesync/client_other.go
@@ -12,7 +12,6 @@
 package timesync
 
 import (
-	"math"
 	"strings"
 	"time"
 
@@ -67,10 +66,7 @@ func (c *Client) getTimeServer() ([]string, error) {
 }
 
 func (c *Client) queryNtpd() (*Stat, error) {
-	stat := &Stat{
-		Source: "ntpd",
-		Min:    math.MaxInt64,
-	}
+	stat := newStat("ntpd")
 
 	lst, err := c.getTimeServer()
 	if err != nil {
@@ -89,14 +85,7 @@ func (c *Client) queryNtpd() (*Stat, error) {
 			continue
 		}
 
-		stat.Count++
-		stat.Sum += delay
-		if stat.Max < delay {
-			stat.Max = delay
-		}
-		if stat.Min > delay {
-			stat.Min = delay
-		}
+		stat.Add(delay)
 	}
 	return stat, nil
 }

--- a/pkg/bkmonitorbeat/tasks/timesync/gather.go
+++ b/pkg/bkmonitorbeat/tasks/timesync/gather.go
@@ -12,6 +12,7 @@ package timesync
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -86,14 +87,18 @@ func stats2Metrics(env string, stat *Stat) *Metrics {
 		return env + "_" + s
 	}
 
-	var avg float64
+	// Count == 0 时没有有效样本，Min/Max 仍是初始哨兵值（MaxFloat64 / -MaxFloat64），
+	// 不能作为指标发出，统一置 0，由 timesync_query_count == 0 表达"无数据"。
+	var minSeconds, maxSeconds, avg float64
 	if stat.Count > 0 {
+		minSeconds = stat.Min
+		maxSeconds = stat.Max
 		avg = stat.Sum / float64(stat.Count)
 	}
 
 	metrics := map[string]float64{
-		named("timesync_query_seconds_min"): stat.Min,
-		named("timesync_query_seconds_max"): stat.Max,
+		named("timesync_query_seconds_min"): minSeconds,
+		named("timesync_query_seconds_max"): maxSeconds,
 		named("timesync_query_seconds_avg"): avg,
 		named("timesync_query_count"):       float64(stat.Count),
 		named("timesync_query_err"):         float64(stat.Err),
@@ -170,6 +175,29 @@ type Stat struct {
 	Sum    float64
 	Err    int
 	Count  int
+}
+
+// newStat 构造统计对象。Min/Max 初值取 +MaxFloat64 / -MaxFloat64，
+// 保证首个样本（含负偏移，即本地时钟超前 NTP 源的场景）也能正确更新 Max。
+// 历史实现 Max 初值为 0，导致一次采集内偏移全为负时 Max 恒为 0。
+func newStat(source string) *Stat {
+	return &Stat{
+		Source: source,
+		Min:    math.MaxFloat64,
+		Max:    -math.MaxFloat64,
+	}
+}
+
+// Add 累加一个有效偏移样本（秒，带符号），并维护 Count/Sum/Min/Max。
+func (s *Stat) Add(v float64) {
+	s.Count++
+	s.Sum += v
+	if v > s.Max {
+		s.Max = v
+	}
+	if v < s.Min {
+		s.Min = v
+	}
 }
 
 type Option struct {

--- a/pkg/bkmonitorbeat/tasks/timesync/gather_test.go
+++ b/pkg/bkmonitorbeat/tasks/timesync/gather_test.go
@@ -1,0 +1,73 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package timesync
+
+import "testing"
+
+// 全负偏移（本地时钟超前 NTP 源，即"时间调至未来"）时，Max 应取最接近 0 的负值，
+// 而不是历史 bug 中被钳在 0。
+func TestStatAddNegativeOffsets(t *testing.T) {
+	s := newStat("ntpd")
+	s.Add(-3.5)
+	s.Add(-1.2)
+	if s.Max != -1.2 {
+		t.Fatalf("Max = %v, want -1.2 (must not clamp at 0)", s.Max)
+	}
+	if s.Min != -3.5 {
+		t.Fatalf("Min = %v, want -3.5", s.Min)
+	}
+}
+
+// 单样本时 Min == Max == 样本值，杜绝出现 max < min 这类自相矛盾。
+func TestStatAddSingleSampleConsistent(t *testing.T) {
+	s := newStat("chrony")
+	s.Add(-2.0)
+	if s.Min != -2.0 || s.Max != -2.0 {
+		t.Fatalf("single negative sample: min=%v max=%v, want both -2.0", s.Min, s.Max)
+	}
+}
+
+// Count == 0：不得把哨兵初值（±MaxFloat64）或 NaN 当指标发出，min/max/avg 统一为 0。
+func TestStats2MetricsEmptyNoSentinelLeak(t *testing.T) {
+	m := stats2Metrics("test", newStat("ntpd")).Metrics
+	for _, k := range []string{
+		"test_timesync_query_seconds_min",
+		"test_timesync_query_seconds_max",
+		"test_timesync_query_seconds_avg",
+	} {
+		v, ok := m[k]
+		if !ok {
+			t.Fatalf("missing metric %s", k)
+		}
+		// v != 0 同时覆盖哨兵值（±1.8e308）与 NaN（NaN != 0 恒为 true）。
+		if v != 0 {
+			t.Fatalf("%s = %v, want 0 (no sentinel/NaN leak)", k, v)
+		}
+	}
+	if m["test_timesync_query_count"] != 0 {
+		t.Fatalf("count = %v, want 0", m["test_timesync_query_count"])
+	}
+}
+
+// Count > 0 且偏移为负：min/max/avg 应如实反映负值，max 不被钳在 0。
+func TestStats2MetricsNegativeOffset(t *testing.T) {
+	s := newStat("ntpd")
+	s.Add(-3.5)
+	m := stats2Metrics("test", s).Metrics
+	if got := m["test_timesync_query_seconds_max"]; got != -3.5 {
+		t.Fatalf("max = %v, want -3.5", got)
+	}
+	if got := m["test_timesync_query_seconds_min"]; got != -3.5 {
+		t.Fatalf("min = %v, want -3.5", got)
+	}
+	if got := m["test_timesync_query_seconds_avg"]; got != -3.5 {
+		t.Fatalf("avg = %v, want -3.5", got)
+	}
+}


### PR DESCRIPTION
## 问题

timesync 采集器从 NTP/chrony 的时钟偏移样本产出 `*_timesync_query_seconds_{min,max,avg}`，统计聚合有两处缺陷：

1. **`_max` 在负偏移时恒为 0。** `Stat.Max` 初值为 0，更新条件 `if Max < delay`。当一次采集内所有偏移为负（本地时钟超前 NTP/chrony 源）时，`0 < 负数` 恒为 false，`_max` 一直是 0。单样本场景下会出现 `min < 0` 但 `max == 0`，即 `max < min` 这种不可能的结果。
2. **无有效样本时 `_min` 泄漏哨兵初值。** `Min` 初值为 `math.MaxInt64`（约 9.2e18）；`Count == 0` 时该哨兵被当作真实指标值发出。（`_avg` 的 `0/0=NaN` 此前已用 `if Count > 0` 守卫。）

## 修复

- 新增 `newStat()`，将 `Min/Max` 初值设为 `+/-math.MaxFloat64`；新增共享方法 `(*Stat).Add()`，替换原先在 `client_linux.go`（ntpd/chrony）与 `client_other.go` 中三处重复、且把错误初值复制了三遍的内联累加块。
- 把 `stats2Metrics` 中已有的 `Count > 0` 守卫扩展到 `_min`/`_max`：无样本采集时三个 seconds 指标统一为 0（由 `_count == 0` 区分"无数据"），不再泄漏哨兵值。
- 新增针对负偏移与空样本的单元测试。

## 验证

`gofmt`/`go vet` 干净；`GOOS=linux`、`GOOS=windows` 包均编译通过；完整 bkmonitorbeat 二进制 linux 交叉编译通过。

close #1010158081135582882
