### PR TITLE
feat: bmw同步SurrealDBBinding路由到Redis --story=133245352

### DIFF
--- a/pkg/bk-monitor-worker/config/metadata_config.go
+++ b/pkg/bk-monitor-worker/config/metadata_config.go
@@ -93,6 +93,12 @@ var (
 	ResultTableDetailKey string
 	// ResultTableDetailChannel 结果表详情channel
 	ResultTableDetailChannel string
+	// SurrealDBBindingKey SurrealDBBinding 路由详情 key
+	SurrealDBBindingKey string
+	// SurrealDBBindingChannel SurrealDBBinding 路由详情 channel
+	SurrealDBBindingChannel string
+	// SurrealDBBindingResourceAPIURL bkbase SurrealDBBinding 资源 API 地址
+	SurrealDBBindingResourceAPIURL string
 	// SpaceToResultTableKey 空间关联的结果表key
 	SpaceToResultTableKey string
 	// SpaceToResultTableChannel 空间关联的结果表channel
@@ -193,6 +199,9 @@ func initMetadataVariables() {
 	DataLabelToResultTableChannel = GetValue("taskConfig.metadata.space.dataLabelToResultTableChannel", fmt.Sprintf("%s:data_label_to_result_table:channel", SpaceRedisKey))
 	ResultTableDetailKey = GetValue("taskConfig.metadata.space.resultTableDetailKey", fmt.Sprintf("%s:result_table_detail", SpaceRedisKey))
 	ResultTableDetailChannel = GetValue("taskConfig.metadata.space.resultTableDetailChannel", fmt.Sprintf("%s:result_table_detail:channel", SpaceRedisKey))
+	SurrealDBBindingKey = GetValue("taskConfig.metadata.space.surrealDBBindingKey", fmt.Sprintf("%s:surrealdb_binding", SpaceRedisKey))
+	SurrealDBBindingChannel = GetValue("taskConfig.metadata.space.surrealDBBindingChannel", fmt.Sprintf("%s:surrealdb_binding:channel", SpaceRedisKey))
+	SurrealDBBindingResourceAPIURL = GetValue("taskConfig.metadata.space.surrealDBBindingResourceAPIURL", "")
 	SpaceToResultTableKey = GetValue("taskConfig.metadata.space.spaceToResultTableKey", fmt.Sprintf("%s:space_to_result_table", SpaceRedisKey))
 	SpaceToResultTableChannel = GetValue("taskConfig.metadata.space.spaceToResultTableChannel", fmt.Sprintf("%s:space_to_result_table:channel", SpaceRedisKey))
 	BuildInResultTableDetailKey = GetValue("taskConfig.metadata.space.buildInResultTableDetailKey", fmt.Sprintf("%s:built_in_result_table_detail", SpaceRedisKey))

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
@@ -16,6 +16,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"sort"
 	"strconv"
 	"testing"
@@ -77,6 +79,19 @@ func setMultiTenantModeForTest(t *testing.T, enabled bool) {
 	cfg.EnableMultiTenantMode = enabled
 	t.Cleanup(func() {
 		cfg.EnableMultiTenantMode = old
+	})
+}
+
+func setSurrealDBBindingRedisConfigForTest(t *testing.T, key, channel string) {
+	t.Helper()
+
+	oldKey := cfg.SurrealDBBindingKey
+	oldChannel := cfg.SurrealDBBindingChannel
+	cfg.SurrealDBBindingKey = key
+	cfg.SurrealDBBindingChannel = channel
+	t.Cleanup(func() {
+		cfg.SurrealDBBindingKey = oldKey
+		cfg.SurrealDBBindingChannel = oldChannel
 	})
 }
 
@@ -1413,6 +1428,141 @@ func TestSpacePusher_PushBkAppToSpace(t *testing.T) {
 		"other_code":       `[]`,
 	}
 	assert.Equal(t, expected, actual)
+}
+
+func TestSpacePusher_PushSurrealDBBindingDetailsMultiTenant(t *testing.T) {
+	setupStorageRedisForTest(t)
+	setMultiTenantModeForTest(t, true)
+	setSurrealDBBindingRedisConfigForTest(t, "test:surrealdb_binding", "test:surrealdb_binding:channel")
+
+	client := redis.GetStorageRedisInstance()
+	assert.NoError(t, client.Delete(cfg.SurrealDBBindingKey))
+
+	details := []SurrealDBBindingDetail{
+		{
+			Name:        "binding-a",
+			BkBizID:     "2",
+			Database:    "2_graph_rt",
+			Namespace:   "mapleleaf_2",
+			ClusterName: "surrealdb-main",
+			Phase:       "Ok",
+		},
+	}
+
+	err := NewSpacePusher().PushSurrealDBBindingDetails("tenant-a", details, false)
+	assert.NoError(t, err)
+
+	value := client.HGet(cfg.SurrealDBBindingKey, "bkcc__2|tenant-a")
+	assert.NotEmpty(t, value)
+	assert.Empty(t, client.HGet(cfg.SurrealDBBindingKey, "bkcc__2"))
+
+	var actual SurrealDBBindingDetail
+	assert.NoError(t, json.Unmarshal([]byte(value), &actual))
+	assert.Equal(t, details[0], actual)
+}
+
+func TestSelectSurrealDBBindingDetailsPrefersGraphRelationLabel(t *testing.T) {
+	defaultBinding := newBKBaseSurrealDBBindingForTest("binding-default", "2", "2_default_rt", "mapleleaf_2", "Ok", nil)
+	preferredBinding := newBKBaseSurrealDBBindingForTest("binding-graph", "2", "2_graph_rt", "mapleleaf_2", "Ok", map[string]string{
+		graphRelationBindingLabelKey: graphRelationBindingLabelValue,
+	})
+
+	details, err := selectSurrealDBBindingDetails([]bkbaseSurrealDBBinding{defaultBinding, preferredBinding})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []SurrealDBBindingDetail{
+		{
+			Name:      "binding-graph",
+			BkBizID:   "2",
+			Database:  "2_graph_rt",
+			Namespace: "mapleleaf_2",
+			Phase:     "Ok",
+		},
+	}, details)
+
+	details, err = selectSurrealDBBindingDetails([]bkbaseSurrealDBBinding{defaultBinding})
+
+	assert.NoError(t, err)
+	assert.Empty(t, details)
+}
+
+func TestBKBaseSurrealDBBindingSourceListAddsGraphRelationLabelSelector(t *testing.T) {
+	oldMultiTenantMode := cfg.EnableMultiTenantMode
+	cfg.EnableMultiTenantMode = false
+	t.Cleanup(func() {
+		cfg.EnableMultiTenantMode = oldMultiTenantMode
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v4/namespaces/bkmonitor/surrealdbbindings/", r.URL.Path)
+		assert.Equal(t, fmt.Sprintf("%s=%s", graphRelationBindingLabelKey, graphRelationBindingLabelValue), r.URL.Query().Get("label_selector"))
+		assert.Equal(t, "system", r.Header.Get("X-Bk-Tenant-Id"))
+		assert.NotEmpty(t, r.Header.Get("X-Bkapi-Authorization"))
+		assert.NotEmpty(t, r.Header.Get("X-Bkbase-Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"result": true,
+			"data": []any{
+				map[string]any{
+					"metadata": map[string]any{
+						"name": "binding-graph",
+						"labels": map[string]string{
+							"bk_biz_id":                  "2",
+							graphRelationBindingLabelKey: graphRelationBindingLabelValue,
+						},
+						"annotations": map[string]string{
+							"database":  "2_graph_rt",
+							"namespace": "mapleleaf_2",
+						},
+					},
+					"spec": map[string]any{
+						"storage": map[string]string{
+							"name": "surrealdb-main",
+						},
+					},
+					"status": map[string]string{
+						"phase": "Ok",
+					},
+				},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	source := &BKBaseSurrealDBBindingSource{
+		baseURL:    server.URL + "/v4/namespaces/bkmonitor",
+		httpClient: server.Client(),
+	}
+
+	details, err := source.ListSurrealDBBindings(context.Background(), "system")
+
+	assert.NoError(t, err)
+	assert.Equal(t, []SurrealDBBindingDetail{
+		{
+			Name:        "binding-graph",
+			BkBizID:     "2",
+			Database:    "2_graph_rt",
+			Namespace:   "mapleleaf_2",
+			ClusterName: "surrealdb-main",
+			Phase:       "Ok",
+		},
+	}, details)
+}
+
+func newBKBaseSurrealDBBindingForTest(name, bizID, database, namespace, phase string, labels map[string]string) bkbaseSurrealDBBinding {
+	item := bkbaseSurrealDBBinding{}
+	item.Metadata.Name = name
+	item.Metadata.Labels = map[string]string{"bk_biz_id": bizID}
+	for key, value := range labels {
+		item.Metadata.Labels[key] = value
+	}
+	item.Metadata.Annotations = map[string]string{
+		"database":  database,
+		"namespace": namespace,
+	}
+	item.Status.Phase = phase
+	return item
 }
 
 func TestSpacePusher_PushEsTableIdDetail(t *testing.T) {

--- a/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/spaceredis_test.go
@@ -1461,6 +1461,105 @@ func TestSpacePusher_PushSurrealDBBindingDetailsMultiTenant(t *testing.T) {
 	assert.Equal(t, details[0], actual)
 }
 
+func TestSpacePusher_PushSurrealDBBindingDetailsClearsStaleTenantRoutes(t *testing.T) {
+	setupStorageRedisForTest(t)
+	setMultiTenantModeForTest(t, true)
+	setSurrealDBBindingRedisConfigForTest(t, "test:surrealdb_binding:stale", "test:surrealdb_binding:stale:channel")
+
+	client := redis.GetStorageRedisInstance()
+	pusher := NewSpacePusher()
+	newDetail := func(name, bizID string) SurrealDBBindingDetail {
+		return SurrealDBBindingDetail{
+			Name:        name,
+			BkBizID:     bizID,
+			Database:    fmt.Sprintf("%s_graph_rt", bizID),
+			Namespace:   fmt.Sprintf("mapleleaf_%s", bizID),
+			ClusterName: "surrealdb-main",
+			Phase:       "Ok",
+		}
+	}
+
+	tests := []struct {
+		name                 string
+		initialTenantADetail []SurrealDBBindingDetail
+		nextTenantADetail    []SurrealDBBindingDetail
+		missingFields        []string
+		keptFields           []string
+	}{
+		{
+			name:                 "部分结果清理同租户缺失业务",
+			initialTenantADetail: []SurrealDBBindingDetail{newDetail("binding-a", "2"), newDetail("binding-b", "3")},
+			nextTenantADetail:    []SurrealDBBindingDetail{newDetail("binding-b", "3")},
+			missingFields:        []string{"bkcc__2|tenant-a"},
+			keptFields:           []string{"bkcc__3|tenant-a", "bkcc__4|tenant-b"},
+		},
+		{
+			name:                 "空结果清理同租户全部旧路由",
+			initialTenantADetail: []SurrealDBBindingDetail{newDetail("binding-a", "2")},
+			nextTenantADetail:    nil,
+			missingFields:        []string{"bkcc__2|tenant-a"},
+			keptFields:           []string{"bkcc__4|tenant-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NoError(t, client.Delete(cfg.SurrealDBBindingKey))
+			assert.NoError(t, pusher.PushSurrealDBBindingDetails("tenant-a", tt.initialTenantADetail, false))
+			assert.NoError(t, pusher.PushSurrealDBBindingDetails("tenant-b", []SurrealDBBindingDetail{newDetail("binding-c", "4")}, false))
+
+			err := pusher.PushSurrealDBBindingDetails("tenant-a", tt.nextTenantADetail, false)
+			assert.NoError(t, err)
+
+			for _, field := range tt.missingFields {
+				assert.Empty(t, client.HGet(cfg.SurrealDBBindingKey, field), "stale field should be deleted: %s", field)
+			}
+			for _, field := range tt.keptFields {
+				assert.NotEmpty(t, client.HGet(cfg.SurrealDBBindingKey, field), "active or other tenant field should remain: %s", field)
+			}
+		})
+	}
+}
+
+func TestSpacePusher_PushSurrealDBBindingDetailsPublishesDeletedRoutes(t *testing.T) {
+	setupStorageRedisForTest(t)
+	setMultiTenantModeForTest(t, true)
+	setSurrealDBBindingRedisConfigForTest(t, "test:surrealdb_binding:publish", "test:surrealdb_binding:publish:channel")
+
+	client := redis.GetStorageRedisInstance()
+	assert.NoError(t, client.Delete(cfg.SurrealDBBindingKey))
+
+	pubsub := client.Client.Subscribe(context.Background(), cfg.SurrealDBBindingChannel)
+	defer pubsub.Close()
+	_, err := pubsub.Receive(context.Background())
+	assert.NoError(t, err)
+	ch := pubsub.Channel()
+
+	details := []SurrealDBBindingDetail{
+		{
+			Name:        "binding-a",
+			BkBizID:     "2",
+			Database:    "2_graph_rt",
+			Namespace:   "mapleleaf_2",
+			ClusterName: "surrealdb-main",
+			Phase:       "Ok",
+		},
+	}
+	assert.NoError(t, NewSpacePusher().PushSurrealDBBindingDetails("tenant-a", details, false))
+
+	err = NewSpacePusher().PushSurrealDBBindingDetails("tenant-a", nil, true)
+	assert.NoError(t, err)
+	assert.Empty(t, client.HGet(cfg.SurrealDBBindingKey, "bkcc__2|tenant-a"))
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, cfg.SurrealDBBindingChannel, msg.Channel)
+		assert.Equal(t, "bkcc__2|tenant-a", msg.Payload)
+	case <-time.After(time.Second):
+		t.Fatal("expected stale SurrealDBBinding route deletion to publish the deleted field")
+	}
+}
+
 func TestSelectSurrealDBBindingDetailsPrefersGraphRelationLabel(t *testing.T) {
 	defaultBinding := newBKBaseSurrealDBBindingForTest("binding-default", "2", "2_default_rt", "mapleleaf_2", "Ok", nil)
 	preferredBinding := newBKBaseSurrealDBBindingForTest("binding-graph", "2", "2_graph_rt", "mapleleaf_2", "Ok", map[string]string{

--- a/pkg/bk-monitor-worker/internal/metadata/service/surrealdb_binding.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/surrealdb_binding.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -206,20 +207,17 @@ func (s *SpacePusher) PushSurrealDBBindings(ctx context.Context, bkTenantId stri
 }
 
 func (s *SpacePusher) PushSurrealDBBindingDetails(bkTenantId string, details []SurrealDBBindingDetail, isPublish bool) error {
-	if len(details) == 0 {
-		logger.Infof("PushSurrealDBBindingDetails: no SurrealDBBinding route to push, bk_tenant_id [%s]", bkTenantId)
-		return nil
-	}
-
 	client := redis.GetStorageRedisInstance()
 	key := surrealDBBindingRedisKey()
 	channel := surrealDBBindingRedisChannel()
+	activeFields := make(map[string]struct{}, len(details))
 	for _, detail := range details {
 		if detail.BkBizID == "" || detail.Database == "" || detail.Namespace == "" {
 			return fmt.Errorf("invalid SurrealDBBinding route detail: %+v", detail)
 		}
 
 		field := composeTenantRedisKey(SpaceRouteKey(models.SpaceTypeBKCC, detail.BkBizID), bkTenantId)
+		activeFields[field] = struct{}{}
 		value, err := jsonx.MarshalString(detail)
 		if err != nil {
 			return err
@@ -236,7 +234,59 @@ func (s *SpacePusher) PushSurrealDBBindingDetails(bkTenantId string, details []S
 			return err
 		}
 	}
+
+	return clearStaleSurrealDBBindingDetails(client, key, channel, bkTenantId, activeFields, isPublish)
+}
+
+func clearStaleSurrealDBBindingDetails(
+	client *redis.Instance,
+	key string,
+	channel string,
+	bkTenantId string,
+	activeFields map[string]struct{},
+	isPublish bool,
+) error {
+	fields, err := client.HKeys(key)
+	if err != nil {
+		return err
+	}
+
+	staleFields := make([]string, 0)
+	for _, field := range fields {
+		if _, ok := activeFields[field]; ok {
+			continue
+		}
+		if !surrealDBBindingFieldBelongsToTenant(field, bkTenantId) {
+			continue
+		}
+		staleFields = append(staleFields, field)
+	}
+	if len(staleFields) == 0 {
+		logger.Infof("clearStaleSurrealDBBindingDetails: no stale SurrealDBBinding route, bk_tenant_id [%s]", bkTenantId)
+		return nil
+	}
+	sort.Strings(staleFields)
+
+	logger.Infof("clearStaleSurrealDBBindingDetails: delete stale SurrealDBBinding routes, bk_tenant_id [%s], fields [%v]", bkTenantId, staleFields)
+	if err := client.HDel(key, staleFields...); err != nil {
+		return err
+	}
+	if !isPublish {
+		return nil
+	}
+	for _, field := range staleFields {
+		if err := client.Publish(channel, field); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func surrealDBBindingFieldBelongsToTenant(field string, bkTenantId string) bool {
+	if !cfg.EnableMultiTenantMode {
+		return true
+	}
+	return strings.HasSuffix(field, fmt.Sprintf("|%s", bkTenantId))
 }
 
 func surrealDBBindingRedisKey() string {

--- a/pkg/bk-monitor-worker/internal/metadata/service/surrealdb_binding.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/surrealdb_binding.go
@@ -1,0 +1,254 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	cfg "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/config"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/metadata/models"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/tenant"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/store/redis"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
+)
+
+const (
+	graphRelationBindingLabelKey    = "bkm_data_link_strategy"
+	graphRelationBindingLabelValue  = "graph_relation_time_series"
+	surrealDBBindingRedisCoreKey    = "surrealdb_binding"
+	surrealDBBindingRedisChannelKey = "surrealdb_binding:channel"
+)
+
+var errSurrealDBBindingSourceNotConfigured = errors.New("surrealdb binding resource api url is not configured")
+
+type SurrealDBBindingDetail struct {
+	Name        string `json:"name"`
+	BkBizID     string `json:"bk_biz_id"`
+	Database    string `json:"database"`
+	Namespace   string `json:"namespace"`
+	ClusterName string `json:"cluster_name"`
+	Phase       string `json:"phase"`
+}
+
+type SurrealDBBindingSource interface {
+	ListSurrealDBBindings(ctx context.Context, bkTenantId string) ([]SurrealDBBindingDetail, error)
+}
+
+type BKBaseSurrealDBBindingSource struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewBKBaseSurrealDBBindingSource() *BKBaseSurrealDBBindingSource {
+	return &BKBaseSurrealDBBindingSource{
+		baseURL: cfg.SurrealDBBindingResourceAPIURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (s *BKBaseSurrealDBBindingSource) ListSurrealDBBindings(ctx context.Context, bkTenantId string) ([]SurrealDBBindingDetail, error) {
+	baseURL := strings.TrimRight(s.baseURL, "/")
+	if baseURL == "" {
+		return nil, errSurrealDBBindingSourceNotConfigured
+	}
+	if !strings.HasSuffix(baseURL, "/surrealdbbindings") {
+		baseURL = fmt.Sprintf("%s/surrealdbbindings", baseURL)
+	}
+	query := url.Values{}
+	query.Set("label_selector", fmt.Sprintf("%s=%s", graphRelationBindingLabelKey, graphRelationBindingLabelValue))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/?%s", baseURL, query.Encode()), nil)
+	if err != nil {
+		return nil, err
+	}
+	adminUser, err := tenant.GetTenantAdminUser(bkTenantId)
+	if err != nil {
+		return nil, err
+	}
+
+	bkapiAuth, err := json.Marshal(map[string]string{
+		"bk_app_code":   cfg.BkApiAppCode,
+		"bk_app_secret": cfg.BkApiAppSecret,
+		"bk_username":   adminUser,
+	})
+	if err != nil {
+		return nil, err
+	}
+	bkbaseAuth, err := json.Marshal(map[string]string{
+		"bk_app_code":                  cfg.BkApiAppCode,
+		"bk_username":                  adminUser,
+		"bkdata_authentication_method": "user",
+		"bkdata_data_token":            "",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Bkapi-Authorization", string(bkapiAuth))
+	req.Header.Set("X-Bkbase-Authorization", string(bkbaseAuth))
+	if bkTenantId != "" {
+		req.Header.Set("X-Bk-Tenant-Id", bkTenantId)
+	}
+
+	client := s.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("list SurrealDBBinding failed: status=%s", resp.Status)
+	}
+
+	var listResp bkbaseSurrealDBBindingListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		return nil, err
+	}
+	if !listResp.Result {
+		return nil, fmt.Errorf("bkbase list SurrealDBBinding response error: code=%s, message=%s", listResp.Code, listResp.Message)
+	}
+
+	return selectSurrealDBBindingDetails(listResp.Data)
+}
+
+type bkbaseSurrealDBBindingListResponse struct {
+	Result  bool                     `json:"result"`
+	Code    string                   `json:"code"`
+	Message string                   `json:"message"`
+	Data    []bkbaseSurrealDBBinding `json:"data"`
+}
+
+type bkbaseSurrealDBBinding struct {
+	Metadata struct {
+		Name        string            `json:"name"`
+		Labels      map[string]string `json:"labels"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata"`
+	Spec struct {
+		Storage struct {
+			Name string `json:"name"`
+		} `json:"storage"`
+	} `json:"spec"`
+	Status struct {
+		Phase string `json:"phase"`
+	} `json:"status"`
+}
+
+func selectSurrealDBBindingDetails(items []bkbaseSurrealDBBinding) ([]SurrealDBBindingDetail, error) {
+	detailByBiz := make(map[string]SurrealDBBindingDetail)
+	for _, item := range items {
+		if item.Metadata.Labels[graphRelationBindingLabelKey] != graphRelationBindingLabelValue {
+			continue
+		}
+		if item.Status.Phase != "Ok" {
+			continue
+		}
+		bizID := item.Metadata.Labels["bk_biz_id"]
+		database := item.Metadata.Annotations["database"]
+		namespace := item.Metadata.Annotations["namespace"]
+		if bizID == "" || database == "" || namespace == "" {
+			continue
+		}
+		if _, ok := detailByBiz[bizID]; ok {
+			return nil, fmt.Errorf("multiple preferred SurrealDBBinding found for bk_biz_id=%s", bizID)
+		}
+
+		detailByBiz[bizID] = SurrealDBBindingDetail{
+			Name:        item.Metadata.Name,
+			BkBizID:     bizID,
+			Database:    database,
+			Namespace:   namespace,
+			ClusterName: item.Spec.Storage.Name,
+			Phase:       item.Status.Phase,
+		}
+	}
+
+	details := make([]SurrealDBBindingDetail, 0, len(detailByBiz))
+	for _, detail := range detailByBiz {
+		details = append(details, detail)
+	}
+
+	return details, nil
+}
+
+func (s *SpacePusher) PushSurrealDBBindings(ctx context.Context, bkTenantId string, isPublish bool) error {
+	source := NewBKBaseSurrealDBBindingSource()
+	details, err := source.ListSurrealDBBindings(ctx, bkTenantId)
+	if errors.Is(err, errSurrealDBBindingSourceNotConfigured) {
+		logger.Infof("PushSurrealDBBindings: skipped, %s", err.Error())
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return s.PushSurrealDBBindingDetails(bkTenantId, details, isPublish)
+}
+
+func (s *SpacePusher) PushSurrealDBBindingDetails(bkTenantId string, details []SurrealDBBindingDetail, isPublish bool) error {
+	if len(details) == 0 {
+		logger.Infof("PushSurrealDBBindingDetails: no SurrealDBBinding route to push, bk_tenant_id [%s]", bkTenantId)
+		return nil
+	}
+
+	client := redis.GetStorageRedisInstance()
+	key := surrealDBBindingRedisKey()
+	channel := surrealDBBindingRedisChannel()
+	for _, detail := range details {
+		if detail.BkBizID == "" || detail.Database == "" || detail.Namespace == "" {
+			return fmt.Errorf("invalid SurrealDBBinding route detail: %+v", detail)
+		}
+
+		field := composeTenantRedisKey(SpaceRouteKey(models.SpaceTypeBKCC, detail.BkBizID), bkTenantId)
+		value, err := jsonx.MarshalString(detail)
+		if err != nil {
+			return err
+		}
+
+		if !isPublish {
+			if err := client.HSet(key, field, value); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if _, err := client.HSetWithCompareAndPublish(key, field, value, channel, field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func surrealDBBindingRedisKey() string {
+	if cfg.SurrealDBBindingKey != "" {
+		return cfg.SurrealDBBindingKey
+	}
+	return fmt.Sprintf("bkmonitorv3:spaces:%s", surrealDBBindingRedisCoreKey)
+}
+
+func surrealDBBindingRedisChannel() string {
+	if cfg.SurrealDBBindingChannel != "" {
+		return cfg.SurrealDBBindingChannel
+	}
+	return fmt.Sprintf("bkmonitorv3:spaces:%s", surrealDBBindingRedisChannelKey)
+}

--- a/pkg/bk-monitor-worker/internal/metadata/task/space.go
+++ b/pkg/bk-monitor-worker/internal/metadata/task/space.go
@@ -280,6 +280,22 @@ func PushAndPublishSpaceRouterInfo(ctx context.Context, t *t.Task) error {
 		})
 	}
 
+	// 处理 surrealdb_binding 关联路由
+	for bkTenantId := range bkTenantIdSet {
+		wg.Add(1)
+		bkTenantId := bkTenantId
+		_ = p.Submit(func() {
+			defer wg.Done()
+			t1 := time.Now()
+			name := fmt.Sprintf("[task] PushAndPublishSpaceRouterInfo surrealdb_binding tenant[%s]", bkTenantId)
+			if pushErr := pusher.PushSurrealDBBindings(ctx, bkTenantId, true); pushErr != nil {
+				logger.Errorf("%s error %s", name, pushErr)
+				return
+			}
+			logger.Infof("%s success, cost: %s", name, time.Since(t1))
+		})
+	}
+
 	// 处理 result_table_detail 路由
 	for bkTenantId := range bkTenantIdSet {
 		wg.Add(1)


### PR DESCRIPTION
## 变更

- 在 BMW 空间路由任务中增加 SurrealDBBinding 路由同步，写入 `bkmonitorv3:spaces:surrealdb_binding`。
- 从 BKBase Resource API 读取 `bkm_data_link_strategy=graph_relation_time_series` 的 `SurrealDBBinding`，提取 `database`、`namespace`、binding 名称、集群名和 phase。