### PR TITLE
feat: (unify-query)优化 UQ Lucene regexp 查询大小写不一致问题 --story=135766779

### DIFF
--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -301,6 +301,36 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 			sql:   "(`case_sensitive_log` LIKE '%ERROR%' OR `case_sensitive_log` LIKE '%Traceback%')",
 			dsl:   `{"bool":{"should":[{"wildcard":{"case_sensitive_log":{"value":"*ERROR*"}}},{"wildcard":{"case_sensitive_log":{"value":"*Traceback*"}}}]}}`,
 		},
+		{
+			name:  "大小写不敏感 analyzed 字段的正则会 lower pattern",
+			input: `case_insensitive_log:/SSR_REQUEST_ERROR/`,
+			sql:   "`case_insensitive_log` REGEXP 'SSR_REQUEST_ERROR'",
+			dsl:   `{"regexp":{"case_insensitive_log":{"value":".*ssr_request_error.*"}}}`,
+		},
+		{
+			name:  "旧版大小写不敏感字段的正则会 lower pattern",
+			input: `legacy_case_insensitive_log:/SSR_REQUEST_ERROR/`,
+			sql:   "`legacy_case_insensitive_log` REGEXP 'SSR_REQUEST_ERROR'",
+			dsl:   `{"regexp":{"legacy_case_insensitive_log":{"value":".*ssr_request_error.*"}}}`,
+		},
+		{
+			name:  "大小写敏感 analyzed 字段的正则保持原始大小写",
+			input: `case_sensitive_log:/SSR_REQUEST_ERROR/`,
+			sql:   "`case_sensitive_log` REGEXP 'SSR_REQUEST_ERROR'",
+			dsl:   `{"regexp":{"case_sensitive_log":{"value":".*SSR_REQUEST_ERROR.*"}}}`,
+		},
+		{
+			name:  "混合大小写语义字段的正则同时保留原始和 lower pattern",
+			input: `mixed_log:/SSR_REQUEST_ERROR/`,
+			sql:   "`mixed_log` REGEXP 'SSR_REQUEST_ERROR'",
+			dsl:   `{"bool":{"should":[{"regexp":{"mixed_log":{"value":".*SSR_REQUEST_ERROR.*"}}},{"regexp":{"mixed_log":{"value":".*ssr_request_error.*"}}}]}}`,
+		},
+		{
+			name:  "大小写不敏感字段的不包含正则 lower 后保持反向语义",
+			input: `case_insensitive_log:/^(?!.*ERROR).*/`,
+			sql:   "`case_insensitive_log` REGEXP '^(?!.*ERROR).*'",
+			dsl:   `{"bool":{"must":{"exists":{"field":"case_insensitive_log"}},"must_not":{"regexp":{"case_insensitive_log":{"value":".*error.*"}}}}}`,
+		},
 	}
 
 	mock.Init()

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -643,10 +643,9 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 	case *RegexpNode:
 		rewrite := esregexpcompat.Rewrite(value)
 		value = rewrite.Pattern
-		cq := elastic.NewRegexpQuery(field, value)
-		if cv.Boost != "" {
-			cq.Boost(cast.ToFloat64(cv.Boost))
-		}
+		// ES regexp 是 term-level 查询，不会像 match/match_phrase 一样走 analyzer；
+		// 因此 text + lowercase/analyzed 字段需要在 UQ 侧按字段大小写语义归一化 pattern。
+		cq := regexpQueryForField(field, value, fieldOption, cv.Boost)
 		if rewrite.Negative {
 			// 正向不包含前缀形式必须要求字段存在；单独 must_not regexp 会误匹配缺失字段。
 			result = negativeLookaheadQuery(field, cq)
@@ -710,7 +709,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 }
 
 func wildcardQueryForField(field, value string, fieldOption metadata.FieldOption, boost string) elastic.Query {
-	if !wildcardShouldIgnoreCase(fieldOption) {
+	if !termPatternShouldIgnoreCase(fieldOption) {
 		return boostedWildcardQuery(field, value, false, boost)
 	}
 
@@ -732,13 +731,44 @@ func wildcardQueryForField(field, value string, fieldOption metadata.FieldOption
 	return boostedWildcardQuery(field, lowerValue, fieldOption.WildcardCaseInsensitive, boost)
 }
 
-func wildcardShouldIgnoreCase(fieldOption metadata.FieldOption) bool {
+func regexpQueryForField(field, value string, fieldOption metadata.FieldOption, boost string) elastic.Query {
+	if !termPatternShouldIgnoreCase(fieldOption) {
+		return boostedRegexpQuery(field, value, boost)
+	}
+
+	// regexp 没有复用 ES wildcard.case_insensitive 参数，避免不同 ES 版本兼容风险；
+	// 对大小写不敏感字段直接匹配 lowercase 后的索引 term。
+	lowerValue := strings.ToLower(value)
+	if fieldOption.IsMixedCaseSensitivity {
+		// 同名字段跨索引大小写语义不一致时，同时查询原始 pattern 和 lower pattern。
+		if lowerValue == value {
+			return boostedRegexpQuery(field, value, boost)
+		}
+		return elastic.NewBoolQuery().Should(
+			boostedRegexpQuery(field, value, boost),
+			boostedRegexpQuery(field, lowerValue, boost),
+		)
+	}
+
+	return boostedRegexpQuery(field, lowerValue, boost)
+}
+
+func termPatternShouldIgnoreCase(fieldOption metadata.FieldOption) bool {
 	if !fieldOption.Existed() || fieldOption.IsCaseSensitive {
 		return false
 	}
 
+	// 只有明确存在 lowercase 语义的字段才归一化 pattern；
 	// 默认 keyword 不 analyzed 且没有 normalizer，历史 FieldOption 零值不能触发 lower。
 	return fieldOption.IsAnalyzed || fieldOption.IsCaseInsensitive
+}
+
+func boostedRegexpQuery(field, value string, boost string) *elastic.RegexpQuery {
+	cq := elastic.NewRegexpQuery(field, value)
+	if boost != "" {
+		cq.Boost(cast.ToFloat64(boost))
+	}
+	return cq
 }
 
 func boostedWildcardQuery(field, value string, caseInsensitive bool, boost string) *elastic.WildcardQuery {


### PR DESCRIPTION
## 背景

UQ 将 Lucene `msg:/SSR_REQUEST_ERROR/` 转换为 ES `regexp` 查询时，会直接保留原始大写 pattern：

```json
{"regexp":{"msg":{"value":".*SSR_REQUEST_ERROR.*"}}}
```

线上 msg 字段是 text + analyzed + is_case_sensitive=false，索引侧 term 会按大小写不敏感语义归一化。ES regexp 属于 term-level 查询，不会像 match/match_phrase 一样走 analyzer，因此大写 pattern 无法匹配 lowercase 后的索引 term，导致 UQ 查询返回 0。
## 修改
- 为 Lucene RegexpNode 增加字段级 regexp 查询构造逻辑。
- 将原 wildcard 大小写判断逻辑泛化为 termPatternShouldIgnoreCase，供 wildcard 和 regexp 共用。
- 对大小写不敏感字段，将 regexp pattern 转为 lowercase 后生成 ES 查询。
- 对混合大小写语义字段，同时生成原始 pattern 和 lowercase pattern 的 bool.should 查询。
- 保持 negative-lookahead regexp 的现有兼容逻辑，只调整内部 regexp query 的大小写处理。