### PR TITLE
feat: 优化 processbeat 进程扫描 CPU 开销 --story=135807950

### DIFF
--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf.go
@@ -29,14 +29,23 @@ type PortConfigStore struct {
 
 var ErrSkipCollect = errors.New("skip collect")
 
+type procMetaReader interface {
+	readMeta(pid int32) (define.ProcStat, error)
+}
+
 type procPerfMgr struct {
 	mut      sync.Mutex
 	totalMem uint64
 	ioCache  map[int32]define.IOStat
 	cpuCache map[int32]define.CPUStat
+	reader   procMetaReader
 }
 
 func (p *procPerfMgr) GetOneMetaData(pid int32) (define.ProcStat, error) {
+	return p.getOneMetaData(pid)
+}
+
+func (p *procPerfMgr) getOneMetaDataByGopsutil(pid int32) (define.ProcStat, error) {
 	var stat define.ProcStat
 	proc, err := shiroups.NewProcess(pid)
 	if err != nil {
@@ -51,7 +60,7 @@ func (p *procPerfMgr) GetOneMetaData(pid int32) (define.ProcStat, error) {
 	if len(status) > 0 {
 		s = status[0]
 	}
-	stat.Status = p.getProcState(s)
+	stat.Status = procStateName(s)
 
 	stat.Username, _ = proc.Username()
 	stat.Name, _ = proc.Name()
@@ -81,6 +90,10 @@ func (p *procPerfMgr) MergeMetaDataPerfStat(meta, perf define.ProcStat) define.P
 }
 
 func (p *procPerfMgr) getProcState(s string) string {
+	return procStateName(s)
+}
+
+func procStateName(s string) string {
 	switch s {
 	case "S", "sleep", "sleeping":
 		return "sleeping"

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package process
+
+import (
+	"os"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+)
+
+func (p *procPerfMgr) getOneMetaData(pid int32) (define.ProcStat, error) {
+	return p.procFSReader().readMeta(pid)
+}
+
+func (p *procPerfMgr) procFSReader() *procFSReader {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	if p.reader == nil {
+		p.reader = newProcFSReader(hostProcRoot())
+	}
+	return p.reader.(*procFSReader)
+}
+
+func hostProcRoot() string {
+	if root := os.Getenv("HOST_PROC"); root != "" {
+		return root
+	}
+	return "/proc"
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux_test.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestProcPerfMgrUsesHostProcRoot(t *testing.T) {
+	procRoot := filepath.Join(t.TempDir(), "hostproc")
+	writeProcBootTime(t, procRoot, 1700000000)
+	writeLinuxProc(t, procRoot, 424242, "host-worker", "S", 1, 12345, "host-worker\x00--config\x00x", 1000)
+	t.Setenv("HOST_PROC", procRoot)
+
+	stat, err := (&procPerfMgr{}).GetOneMetaData(424242)
+	if err != nil {
+		t.Fatalf("GetOneMetaData error: %v", err)
+	}
+	if stat.Name != "host-worker" || stat.Pid != 424242 || stat.PPid != 1 {
+		t.Fatalf("unexpected stat from HOST_PROC: %+v", stat)
+	}
+	if stat.Cmd != "host-worker --config x" {
+		t.Fatalf("cmd = %q, want host-worker --config x", stat.Cmd)
+	}
+}
+
+func writeProcBootTime(t *testing.T, procRoot string, boot uint64) {
+	t.Helper()
+
+	if err := os.MkdirAll(procRoot, 0o755); err != nil {
+		t.Fatalf("mkdir proc root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(procRoot, "stat"), []byte("btime "+strconv.FormatUint(boot, 10)+"\n"), 0o644); err != nil {
+		t.Fatalf("write proc stat: %v", err)
+	}
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux_test.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux_test.go
@@ -16,6 +16,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
 )
 
 func TestProcPerfMgrUsesHostProcRoot(t *testing.T) {
@@ -33,6 +36,30 @@ func TestProcPerfMgrUsesHostProcRoot(t *testing.T) {
 	}
 	if stat.Cmd != "host-worker --config x" {
 		t.Fatalf("cmd = %q, want host-worker --config x", stat.Cmd)
+	}
+}
+
+func TestProcPerfMgrMetaDataDoesNotTouchPerfCaches(t *testing.T) {
+	procRoot := filepath.Join(t.TempDir(), "hostproc")
+	writeProcBootTime(t, procRoot, 1700000000)
+	writeLinuxProc(t, procRoot, 424243, "host-worker", "S", 1, 12345, "host-worker\x00", 1000)
+	t.Setenv("HOST_PROC", procRoot)
+
+	cpuStat := define.CPUStat{Ts: time.Unix(100, 0), Total: 1234}
+	ioStat := define.IOStat{Ts: time.Unix(100, 0), ReadBytes: 10, WriteBytes: 20}
+	mgr := &procPerfMgr{
+		cpuCache: map[int32]define.CPUStat{424243: cpuStat},
+		ioCache:  map[int32]define.IOStat{424243: ioStat},
+	}
+
+	if _, err := mgr.GetOneMetaData(424243); err != nil {
+		t.Fatalf("GetOneMetaData error: %v", err)
+	}
+	if got := mgr.cpuCache[424243]; got != cpuStat {
+		t.Fatalf("cpu cache changed after metadata read: got %+v, want %+v", got, cpuStat)
+	}
+	if got := mgr.ioCache[424243]; got != ioStat {
+		t.Fatalf("io cache changed after metadata read: got %+v, want %+v", got, ioStat)
 	}
 }
 

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_notlinux.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_notlinux.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package process
+
+import "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+
+func (p *procPerfMgr) getOneMetaData(pid int32) (define.ProcStat, error) {
+	return p.getOneMetaDataByGopsutil(pid)
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
@@ -1,6 +1,12 @@
 package process
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 func TestGetProcState(t *testing.T) {
 	mgr := &procPerfMgr{}
@@ -30,4 +36,138 @@ func TestGetProcState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcFSReaderReadsStableMetaWithSingleBootTimeLookup(t *testing.T) {
+	root := t.TempDir()
+	writeLinuxProc(t, root, 101, "worker 1", "S", 1, 12345, "worker\x00--config\x00x", 1000)
+	writeLinuxProc(t, root, 102, "worker 2", "R", 101, 22345, "worker2\x00", 1000)
+
+	bootReads := 0
+	usernameLookups := 0
+	reader := newProcFSReader(root)
+	reader.bootTime = func() (uint64, error) {
+		bootReads++
+		return 1700000000, nil
+	}
+	reader.lookupUsername = func(uid string) (string, error) {
+		usernameLookups++
+		return "user-" + uid, nil
+	}
+	reader.readLink = func(name string) (string, error) {
+		return "/link/" + filepath.Base(name), nil
+	}
+
+	first, err := reader.readMeta(101)
+	if err != nil {
+		t.Fatalf("readMeta(101) error: %v", err)
+	}
+	second, err := reader.readMeta(102)
+	if err != nil {
+		t.Fatalf("readMeta(102) error: %v", err)
+	}
+
+	if bootReads != 1 {
+		t.Fatalf("boot time reads = %d, want 1", bootReads)
+	}
+	if usernameLookups != 1 {
+		t.Fatalf("username lookups = %d, want 1", usernameLookups)
+	}
+	if first.Pid != 101 || first.PPid != 1 || first.Name != "worker 1" || first.Status != "sleeping" {
+		t.Fatalf("unexpected first meta: %+v", first)
+	}
+	if first.Created != 1700000123450 {
+		t.Fatalf("first created = %d, want 1700000123450", first.Created)
+	}
+	if first.Username != "user-1000" {
+		t.Fatalf("first username = %q, want user-1000", first.Username)
+	}
+	if first.Cmd != "worker --config x" {
+		t.Fatalf("first cmd = %q, want worker --config x", first.Cmd)
+	}
+	if len(first.CmdSlice) != 3 || first.CmdSlice[1] != "--config" {
+		t.Fatalf("first cmd slice = %#v, want parsed argv", first.CmdSlice)
+	}
+	if second.PPid != 101 || second.Status != "running" || second.Created != 1700000223450 {
+		t.Fatalf("unexpected second meta: %+v", second)
+	}
+}
+
+func TestProcFSReaderTreatsRootAsProcFSRoot(t *testing.T) {
+	procRoot := filepath.Join(t.TempDir(), "hostproc")
+	writeLinuxProc(t, procRoot, 104, "host-worker", "S", 1, 42345, "host-worker\x00", 1000)
+
+	reader := newProcFSReader(procRoot)
+	reader.bootTime = func() (uint64, error) {
+		return 1700000000, nil
+	}
+	reader.lookupUsername = func(uid string) (string, error) {
+		return "user-" + uid, nil
+	}
+
+	stat, err := reader.readMeta(104)
+	if err != nil {
+		t.Fatalf("readMeta(104) error: %v", err)
+	}
+	if stat.Name != "host-worker" || stat.Pid != 104 {
+		t.Fatalf("unexpected stat from proc root: %+v", stat)
+	}
+}
+
+func TestProcFSReaderCompletesTruncatedProcessName(t *testing.T) {
+	root := t.TempDir()
+	writeLinuxProc(t, root, 103, "very-long-proce", "S", 1, 32345, "/usr/bin/very-long-process-name\x00--flag", 1000)
+
+	reader := newProcFSReader(root)
+	reader.bootTime = func() (uint64, error) {
+		return 1700000000, nil
+	}
+	reader.lookupUsername = func(uid string) (string, error) {
+		return "user-" + uid, nil
+	}
+
+	stat, err := reader.readMeta(103)
+	if err != nil {
+		t.Fatalf("readMeta(103) error: %v", err)
+	}
+	if stat.Name != "very-long-process-name" {
+		t.Fatalf("name = %q, want completed long process name", stat.Name)
+	}
+}
+
+func writeLinuxProc(t *testing.T, root string, pid int, name, state string, ppid int, startTicks uint64, cmdline string, uid int) {
+	t.Helper()
+
+	dir := filepath.Join(root, strconv.Itoa(pid))
+	writeLinuxProcInDir(t, dir, pid, name, state, ppid, startTicks, cmdline, uid)
+}
+
+func writeLinuxProcInDir(t *testing.T, dir string, pid int, name, state string, ppid int, startTicks uint64, cmdline string, uid int) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir proc dir: %v", err)
+	}
+	stat := linuxStatLine(pid, name, state, ppid, startTicks)
+	if err := os.WriteFile(filepath.Join(dir, "stat"), []byte(stat), 0o644); err != nil {
+		t.Fatalf("write stat: %v", err)
+	}
+	uidText := strconv.Itoa(uid)
+	status := "Name:\t" + name + "\nState:\t" + state + "\nUid:\t" + uidText + "\t" + uidText + "\t" + uidText + "\t" + uidText + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "status"), []byte(status), 0o644); err != nil {
+		t.Fatalf("write status: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cmdline"), []byte(cmdline), 0o644); err != nil {
+		t.Fatalf("write cmdline: %v", err)
+	}
+}
+
+func linuxStatLine(pid int, name, state string, ppid int, startTicks uint64) string {
+	fields := []string{
+		strconv.Itoa(pid), "(" + name + ")", state, strconv.Itoa(ppid),
+		"0", "0", "0", "0", "0", "0", "0", "0",
+		"0", "0", "0", "0", "0", "0", "1", "0",
+		"0", strconv.FormatUint(startTicks, 10), "0", "0",
+	}
+	return strings.Join(fields, " ")
 }

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetProcState(t *testing.T) {
@@ -132,6 +133,37 @@ func TestProcFSReaderCompletesTruncatedProcessName(t *testing.T) {
 	}
 	if stat.Name != "very-long-process-name" {
 		t.Fatalf("name = %q, want completed long process name", stat.Name)
+	}
+}
+
+func TestProcFSReaderExpiresUsernameCache(t *testing.T) {
+	now := time.Unix(100, 0)
+	lookups := 0
+	reader := newProcFSReader(t.TempDir())
+	reader.now = func() time.Time {
+		return now
+	}
+	reader.lookupUsername = func(uid string) (string, error) {
+		lookups++
+		return "user-" + strconv.Itoa(lookups), nil
+	}
+
+	if got := reader.username("1000"); got != "user-1" {
+		t.Fatalf("first username = %q, want user-1", got)
+	}
+	if got := reader.username("1000"); got != "user-1" {
+		t.Fatalf("cached username = %q, want user-1", got)
+	}
+	if lookups != 1 {
+		t.Fatalf("lookups before ttl = %d, want 1", lookups)
+	}
+
+	now = now.Add(uidNameCacheTTL + time.Second)
+	if got := reader.username("1000"); got != "user-2" {
+		t.Fatalf("expired username = %q, want user-2", got)
+	}
+	if lookups != 2 {
+		t.Fatalf("lookups after ttl = %d, want 2", lookups)
 	}
 }
 

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_clock_linux.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_clock_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package process
+
+import (
+	"sync"
+
+	"github.com/tklauser/go-sysconf"
+)
+
+var (
+	clockTicksOnce sync.Once
+	clockTicks     uint64 = 100
+)
+
+func cachedClockTicks() uint64 {
+	clockTicksOnce.Do(func() {
+		if ticks, err := sysconf.Sysconf(sysconf.SC_CLK_TCK); err == nil && ticks > 0 {
+			clockTicks = uint64(ticks)
+		}
+	})
+	return clockTicks
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_clock_notlinux.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_clock_notlinux.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package process
+
+func cachedClockTicks() uint64 {
+	return 100
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_reader.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_reader.go
@@ -1,0 +1,248 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package process
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/user"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+)
+
+// procFSReader avoids gopsutil's repeated /proc/<pid>/stat and boot time reads during full host scans.
+type procFSReader struct {
+	root string
+
+	bootTime func() (uint64, error)
+	readFile func(string) ([]byte, error)
+	readLink func(string) (string, error)
+
+	lookupUsername func(string) (string, error)
+
+	mut        sync.Mutex
+	boot       uint64
+	bootLoaded bool
+	uidNames   map[string]string
+}
+
+func newProcFSReader(root string) *procFSReader {
+	if root == "" {
+		root = "/proc"
+	}
+	r := &procFSReader{
+		root:           root,
+		readFile:       os.ReadFile,
+		readLink:       os.Readlink,
+		lookupUsername: lookupUsername,
+		uidNames:       map[string]string{},
+	}
+	r.bootTime = r.readBootTime
+	return r
+}
+
+func (r *procFSReader) readMeta(pid int32) (define.ProcStat, error) {
+	var stat define.ProcStat
+	procDir := r.procDir(pid)
+	statBytes, err := r.readFile(filepath.Join(procDir, "stat"))
+	if err != nil {
+		return stat, err
+	}
+	parsed, err := parseProcStat(statBytes)
+	if err != nil {
+		return stat, err
+	}
+
+	boot, err := r.cachedBootTime()
+	if err != nil {
+		return stat, err
+	}
+	statusName, uid := r.statusIdentity(procDir)
+	cmd, cmdSlice := r.cmdline(procDir)
+	name := parsed.name
+	if statusName != "" {
+		name = statusName
+	}
+
+	stat.Pid = pid
+	stat.PPid = parsed.ppid
+	stat.Name = completeProcName(name, cmdSlice)
+	stat.Status = procStateName(parsed.state)
+	stat.Created = int64(boot*1000 + parsed.startTimeTicks*1000/cachedClockTicks())
+	stat.Username = r.username(uid)
+	stat.Cmd, stat.CmdSlice = cmd, cmdSlice
+	stat.Exe, _ = r.readLink(filepath.Join(procDir, "exe"))
+	stat.Cwd, _ = r.readLink(filepath.Join(procDir, "cwd"))
+	return stat, nil
+}
+
+func (r *procFSReader) procDir(pid int32) string {
+	return filepath.Join(r.root, strconv.Itoa(int(pid)))
+}
+
+func (r *procFSReader) cachedBootTime() (uint64, error) {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+
+	if r.bootLoaded {
+		return r.boot, nil
+	}
+	boot, err := r.bootTime()
+	if err != nil {
+		return 0, err
+	}
+	r.boot = boot
+	r.bootLoaded = true
+	return boot, nil
+}
+
+func (r *procFSReader) readBootTime() (uint64, error) {
+	statBytes, err := r.readFile(filepath.Join(r.root, "stat"))
+	if err != nil {
+		return 0, err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(statBytes))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "btime ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return 0, fmt.Errorf("wrong btime format")
+		}
+		return strconv.ParseUint(fields[1], 10, 64)
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return 0, fmt.Errorf("could not find btime")
+}
+
+func (r *procFSReader) username(uid string) string {
+	if uid == "" {
+		return ""
+	}
+
+	r.mut.Lock()
+	if name, ok := r.uidNames[uid]; ok {
+		r.mut.Unlock()
+		return name
+	}
+	r.mut.Unlock()
+
+	name, err := r.lookupUsername(uid)
+	if err != nil || name == "" {
+		name = uid
+	}
+
+	r.mut.Lock()
+	r.uidNames[uid] = name
+	r.mut.Unlock()
+	return name
+}
+
+func (r *procFSReader) statusIdentity(procDir string) (name, uid string) {
+	statusBytes, err := r.readFile(filepath.Join(procDir, "status"))
+	if err != nil {
+		return "", ""
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(statusBytes))
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "Name:"):
+			name = strings.TrimSpace(strings.TrimPrefix(line, "Name:"))
+		case strings.HasPrefix(line, "Uid:"):
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				uid = fields[1]
+			}
+		}
+		if name == "" || uid == "" {
+			continue
+		}
+		return name, uid
+	}
+	return name, uid
+}
+
+func (r *procFSReader) cmdline(procDir string) (string, []string) {
+	cmdBytes, err := r.readFile(filepath.Join(procDir, "cmdline"))
+	if err != nil || len(cmdBytes) == 0 {
+		return "", nil
+	}
+	cmdBytes = bytes.TrimRight(cmdBytes, "\x00")
+	if len(cmdBytes) == 0 {
+		return "", nil
+	}
+	parts := strings.Split(string(cmdBytes), "\x00")
+	return strings.Join(parts, " "), parts
+}
+
+func completeProcName(name string, cmdSlice []string) string {
+	if len(name) < 15 || len(cmdSlice) == 0 {
+		return name
+	}
+	extendedName := path.Base(cmdSlice[0])
+	if strings.HasPrefix(extendedName, name) {
+		return extendedName
+	}
+	return name
+}
+
+type procStatFields struct {
+	name           string
+	state          string
+	ppid           int32
+	startTimeTicks uint64
+}
+
+func parseProcStat(stat []byte) (procStatFields, error) {
+	var ret procStatFields
+	line := strings.TrimSpace(string(stat))
+	left := strings.IndexByte(line, '(')
+	right := strings.LastIndexByte(line, ')')
+	if left < 0 || right <= left {
+		return ret, fmt.Errorf("invalid proc stat line")
+	}
+	ret.name = line[left+1 : right]
+	fields := strings.Fields(line[right+1:])
+	if len(fields) < 20 {
+		return ret, fmt.Errorf("insufficient proc stat fields")
+	}
+	ret.state = fields[0]
+	ppid, err := strconv.ParseInt(fields[1], 10, 32)
+	if err != nil {
+		return ret, err
+	}
+	ret.ppid = int32(ppid)
+	startTime, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return ret, err
+	}
+	ret.startTimeTicks = startTime
+	return ret, nil
+}
+
+func lookupUsername(uid string) (string, error) {
+	u, err := user.LookupId(uid)
+	if err != nil {
+		return "", err
+	}
+	return u.Username, nil
+}

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_reader.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_reader.go
@@ -20,9 +20,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
 )
+
+const uidNameCacheTTL = 10 * time.Minute
 
 // procFSReader avoids gopsutil's repeated /proc/<pid>/stat and boot time reads during full host scans.
 type procFSReader struct {
@@ -33,11 +36,17 @@ type procFSReader struct {
 	readLink func(string) (string, error)
 
 	lookupUsername func(string) (string, error)
+	now            func() time.Time
 
 	mut        sync.Mutex
 	boot       uint64
 	bootLoaded bool
-	uidNames   map[string]string
+	uidNames   map[string]uidNameCacheEntry
+}
+
+type uidNameCacheEntry struct {
+	name     string
+	expireAt time.Time
 }
 
 func newProcFSReader(root string) *procFSReader {
@@ -49,7 +58,8 @@ func newProcFSReader(root string) *procFSReader {
 		readFile:       os.ReadFile,
 		readLink:       os.Readlink,
 		lookupUsername: lookupUsername,
-		uidNames:       map[string]string{},
+		now:            time.Now,
+		uidNames:       map[string]uidNameCacheEntry{},
 	}
 	r.bootTime = r.readBootTime
 	return r
@@ -138,10 +148,11 @@ func (r *procFSReader) username(uid string) string {
 		return ""
 	}
 
+	now := r.now()
 	r.mut.Lock()
-	if name, ok := r.uidNames[uid]; ok {
+	if entry, ok := r.uidNames[uid]; ok && now.Before(entry.expireAt) {
 		r.mut.Unlock()
-		return name
+		return entry.name
 	}
 	r.mut.Unlock()
 
@@ -151,7 +162,10 @@ func (r *procFSReader) username(uid string) string {
 	}
 
 	r.mut.Lock()
-	r.uidNames[uid] = name
+	r.uidNames[uid] = uidNameCacheEntry{
+		name:     name,
+		expireAt: now.Add(uidNameCacheTTL),
+	}
 	r.mut.Unlock()
 	return name
 }


### PR DESCRIPTION
close #1010158081135807950

## Summary
- add a Linux procfs metadata reader for processbeat full-process scans
- cache boot time and uid-to-username resolution per bkmonitorbeat process
- keep non-Linux platforms on the existing gopsutil metadata path

## Collection-layer Analysis
Processbeat builds a full process metadata snapshot before matching process configs. On Linux, the previous path called multiple gopsutil methods per PID to collect pid, ppid, name, status, username, cmdline, exe, cwd, and created time.

Those gopsutil calls repeatedly refresh procfs-backed data, including `/proc/<pid>/stat`, `/proc/<pid>/status`, `/proc/<pid>/cmdline`, and `/proc/stat` boot time. On hosts with many processes, this turns one logical metadata scan into many procfs reads per PID.

This change keeps the same output fields but reads Linux procfs directly for metadata:
- `/proc/<pid>/stat` provides pid name, state, ppid, and start time ticks
- `/proc/<pid>/status` provides the status name fallback and uid
- `/proc/<pid>/cmdline` is read once and reused for both cmdline string and argv slice
- `/proc/stat` boot time is cached for the processbeat collector instance
- uid-to-username lookup is cached for the processbeat collector instance

The implementation also preserves gopsutil compatibility behavior:
- if Linux `comm`/status name is truncated, `cmdline[0]` basename is used when it clearly extends the truncated name
- Linux procfs root follows `HOST_PROC`, defaulting to `/proc`, so PID enumeration and metadata reads stay on the same procfs mount

## Deployment-layer Analysis
Multiple bkmonitorbeat instances can run on the same host for different environments or tenants. These processes do not share in-process caches, so a deployment with multiple instances still performs one scan per instance and per task schedule.

This PR intentionally does not introduce cross-process shared state. Cross-instance sharing would add lifecycle, isolation, and correctness risks between environments. Instead, it reduces the cost of each instance's own scan. For deployments that run multiple agents on the same machine, this makes repeated scans cheaper while preserving per-environment isolation.

## Compatibility
- Linux uses direct procfs parsing for metadata and preserves long process-name completion behavior from gopsutil.
- Linux honors `HOST_PROC`, matching gopsutil's procfs root selection for containerized host procfs mounts.
- Non-Linux builds continue to use the existing gopsutil path.
- Existing process metadata fields remain unchanged: pid, ppid, name, status, username, cmdline, exe, cwd, and created time.
- Disappearing processes remain skipped when their procfs files cannot be read, matching the existing best-effort scan behavior.

## Validation
- `go test ./tasks/processbeat/process -run 'TestProcFSReaderExpiresUsernameCache|TestProcPerfMgrMetaDataDoesNotTouchPerfCaches|TestProcPerfMgrUsesHostProcRoot|TestProcFSReaderTreatsRootAsProcFSRoot|TestProcFSReaderReadsStableMetaWithSingleBootTimeLookup|TestProcFSReaderCompletesTruncatedProcessName' -count=1`
- `go test ./tasks/processbeat/... ./tasks/procstatus/... ./tasks/proccustom/...`
- `GOOS=linux GOARCH=amd64 go test -c ./tasks/processbeat/process -o /tmp/processbeat-process-linux-gtm.test`
- `GOOS=windows GOARCH=amd64 go test -c ./tasks/processbeat/process -o /tmp/processbeat-process-windows-gtm.test`

## Canary Validation
One controlled Linux canary was run with the existing plugin restart command, using the same bkmonitorbeat working directory and config before/after. Sampling window was 60 seconds before + 60 seconds after, at 5-second intervals. The sampled process count was stable around 1183 before/after.

| Metric | Baseline | Fixed |
| --- | ---: | ---: |
| CPU avg | 14.15% | 0.53% |
| CPU max | 106.40% | 2.20% |
| RSS avg | 42,776 KiB | 45,332 KiB |
| Threads avg | 33.6 | 35.1 |

Observed average CPU drop: 96.25%.

The canary confirms the optimized Linux metadata scan removes the single-core-level CPU spikes seen on the baseline process under the same process-count range, without obvious RSS or thread-count regression in this short validation window.

## Review Notes
This PR supersedes the earlier non-GTM PR #1385. The code change is the same scope, migrated onto a GTM-created issue branch.
