### PR TITLE
feat: transfer支持consul下发initial_offset配置

### DIFF
--- a/pkg/transfer/config/kafka.go
+++ b/pkg/transfer/config/kafka.go
@@ -34,6 +34,14 @@ func (c *KafkaMetaClusterInfo) SetPartition(val int) {
 	c.StorageConfigHelper.Set("partition", val)
 }
 
+// GetInitialOffset :
+func (c *KafkaMetaClusterInfo) GetInitialOffset() (int64, bool) {
+	if c.InitialOffset == nil {
+		return 0, false
+	}
+	return *c.InitialOffset, true
+}
+
 // GetTarget :
 func (c *KafkaMetaClusterInfo) GetTarget() string {
 	return c.GetTopic()

--- a/pkg/transfer/config/metadata.go
+++ b/pkg/transfer/config/metadata.go
@@ -39,6 +39,7 @@ type MetaClusterInfo struct {
 	BatchSize     int                    `mapstructure:"batch_size" json:"batch_size"`
 	FlushInterval string                 `mapstructure:"flush_interval" json:"flush_interval"`
 	ConsumeRate   int                    `mapstructure:"consume_rate" json:"consume_rate"` // unit:Bytes
+	InitialOffset *int64                 `mapstructure:"initial_offset" json:"initial_offset"`
 }
 
 // NewMetaClusterInfo :

--- a/pkg/transfer/config/metadata_test.go
+++ b/pkg/transfer/config/metadata_test.go
@@ -114,8 +114,9 @@ func (s *PipelineConfigSuite) TestStruct() {
     },
     "storage_config": {
       "topic": "bkmonitor_130",
-      "partition": 1	
+      "partition": 1
     },
+    "initial_offset": -2,
     "auth_info": {
       "username": "admin",
       "password": "admin"
@@ -140,6 +141,7 @@ func (s *PipelineConfigSuite) TestStruct() {
 		{9092.0, pipe.MQConfig.ClusterConfig["port"]},
 		{"bkmonitor_130", pipe.MQConfig.StorageConfig["topic"]},
 		{1.0, pipe.MQConfig.StorageConfig["partition"]},
+		{int64(-2), *pipe.MQConfig.InitialOffset},
 		{"admin", pipe.MQConfig.AuthInfo["username"]},
 		{"admin", pipe.MQConfig.AuthInfo["password"]},
 		{config.ResultTableSchemaTypeFree, pipe.ResultTableList[0].SchemaType},

--- a/pkg/transfer/kafka/frontend.go
+++ b/pkg/transfer/kafka/frontend.go
@@ -349,6 +349,9 @@ func (f *Frontend) init() error {
 		logging.Errorf("frontend %v make config error %v", f, err)
 		return err
 	}
+	if initialOffset, ok := kafkaConfig.GetInitialOffset(); ok {
+		c.Consumer.Offsets.Initial = initialOffset
+	}
 
 	auth := config.NewAuthInfo(config.MQConfigFromContext(f.ctx))
 	userName, err := auth.GetUserName()

--- a/pkg/transfer/kafka/frontend_test.go
+++ b/pkg/transfer/kafka/frontend_test.go
@@ -12,9 +12,12 @@ package kafka_test
 import (
 	"context"
 	"sync"
+	"testing"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/transfer/define"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/transfer/kafka"
@@ -31,12 +34,15 @@ type FrontendSuite struct {
 // SetupTest :
 func (s *FrontendSuite) SetupTest() {
 	s.ConfigSuite.SetupTest()
+	s.Config.Set(kafka.ConfKafkaFlowInterval, time.Second)
 
 	kafkaConfig := s.PipelineConfig.MQConfig.AsKafkaCluster()
 	kafkaConfig.SetTopic("test")
 	kafkaConfig.SetDomain("localhost")
 	kafkaConfig.SetPort(9092)
 	kafkaConfig.SetPartition(0)
+	s.PipelineConfig.MQConfig.AuthInfo["username"] = ""
+	s.PipelineConfig.MQConfig.AuthInfo["password"] = ""
 
 	s.newKafkaConsumerGroup = kafka.NewKafkaConsumerGroup
 	s.newKafkaConfig = kafka.NewKafkaConsumerConfig
@@ -128,4 +134,43 @@ func (s *FrontendSuite) TestPull() {
 	close(outCh)
 	s.NoError(f.Close())
 	wg.Wait()
+}
+
+func (s *FrontendSuite) TestInitialOffsetFromMQConfig() {
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	offset := int64(sarama.OffsetOldest)
+	s.PipelineConfig.MQConfig.InitialOffset = &offset
+	s.Config.Set(kafka.ConfKafkaConsumerOffsetInitial, sarama.OffsetNewest)
+
+	var captured *sarama.Config
+	kafka.NewKafkaConsumerConfig = func(_ define.Configuration) (*sarama.Config, error) {
+		cfg := sarama.NewConfig()
+		cfg.Consumer.Offsets.Initial = sarama.OffsetNewest
+		return cfg, nil
+	}
+
+	errCh := make(chan error)
+	close(errCh)
+	group := NewMockConsumerGroup(ctrl)
+	group.EXPECT().Errors().Return(errCh).AnyTimes()
+	group.EXPECT().Consume(gomock.Any(), gomock.Any(), gomock.Any()).Return(context.Canceled)
+	group.EXPECT().Close().Return(nil)
+	kafka.NewKafkaConsumerGroup = func(_ []string, _ string, cfg *sarama.Config) (sarama.ConsumerGroup, error) {
+		captured = cfg
+		return group, nil
+	}
+
+	f := kafka.NewFrontend(s.CTX, "test")
+	killCh := make(chan error, 1)
+	f.Pull(make(chan define.Payload), killCh)
+	s.NoError(f.Close())
+
+	s.NotNil(captured)
+	s.Equal(int64(sarama.OffsetOldest), captured.Consumer.Offsets.Initial)
+}
+
+func TestFrontendSuite(t *testing.T) {
+	suite.Run(t, new(FrontendSuite))
 }


### PR DESCRIPTION
## 变更说明

本次改动为 transfer 增加 `initial_offset` 特性支持，使 transfer 在初始化 Kafka consumer 时，能够读取并使用 consul 元数据中下发的 `initial_offset` 配置。

该改动与监控平台侧的实现保持一致，字段位置为：

- `mq_config.initial_offset`

## 改动内容

- 在 `MetaClusterInfo` 中新增 `InitialOffset` 字段
- 在 Kafka 元数据配置 helper 中新增 `GetInitialOffset()` 方法
- 在 Kafka frontend 初始化时，优先使用 `mq_config.initial_offset` 覆盖全局 `kafka.initial_offset`
- 同步更新相关测试样例中的配置结构

## 行为说明

- 当 consul 中存在 `mq_config.initial_offset` 时，transfer 会使用该值初始化 Kafka consumer offset
- 当未配置该字段时，仍保持现有逻辑，继续使用全局配置或默认值
- 默认行为不变，仍为从最新位置开始消费

## 设计说明

- 本次仅支持平台侧当前下发格式：`mq_config.initial_offset`
- 未增加其他字段位置的兼容逻辑
- 改动范围控制在 transfer 侧最小必要实现内，没有扩展到其他无关逻辑