### PR TITLE
fix: 补齐 system_base 主机目标云区域维度 --story=135843866

### DIFF
--- a/pkg/bkmonitorbeat/tasks/dmesg/event.go
+++ b/pkg/bkmonitorbeat/tasks/dmesg/event.go
@@ -10,13 +10,12 @@
 package dmesg
 
 import (
-	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tasks"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/output/gse"
 )
 
@@ -48,15 +47,7 @@ func (e *Event) AsMapStr() common.MapStr {
 			"event": common.MapStr{
 				"content": exception.Message,
 			},
-			"dimension": common.MapStr{
-				"bk_cloud_id":  strconv.Itoa(int(info.Cloudid)),
-				"bk_target_ip": info.IP,
-				"bk_agent_id":  info.BKAgentID,
-				"bk_host_id":   strconv.Itoa(int(info.HostID)),
-				"bk_biz_id":    strconv.Itoa(int(info.BKBizID)),
-				"node_id":      fmt.Sprintf("%d:%s", info.Cloudid, info.IP),
-				"hostname":     info.Hostname,
-			},
+			"dimension": tasks.HostDimension(info),
 			"timestamp": exception.Time.UnixMilli(),
 		})
 	}

--- a/pkg/bkmonitorbeat/tasks/host_dimension.go
+++ b/pkg/bkmonitorbeat/tasks/host_dimension.go
@@ -1,0 +1,31 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package tasks
+
+import (
+	"fmt"
+	"strconv"
+
+	gsetype "github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/gse"
+)
+
+func HostDimension(info gsetype.AgentInfo) map[string]string {
+	cloudID := strconv.Itoa(int(info.Cloudid))
+	return map[string]string{
+		"bk_cloud_id":        cloudID,
+		"bk_target_cloud_id": cloudID,
+		"bk_target_ip":       info.IP,
+		"bk_agent_id":        info.BKAgentID,
+		"bk_host_id":         strconv.Itoa(int(info.HostID)),
+		"bk_biz_id":          strconv.Itoa(int(info.BKBizID)),
+		"node_id":            fmt.Sprintf("%d:%s", info.Cloudid, info.IP),
+		"hostname":           info.Hostname,
+	}
+}

--- a/pkg/bkmonitorbeat/tasks/host_dimension_test.go
+++ b/pkg/bkmonitorbeat/tasks/host_dimension_test.go
@@ -1,0 +1,43 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package tasks
+
+import (
+	"testing"
+
+	gsetype "github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/gse"
+)
+
+func TestHostDimension(t *testing.T) {
+	dimensions := HostDimension(gsetype.AgentInfo{
+		BKBizID:   2,
+		Cloudid:   3,
+		IP:        "127.0.0.1",
+		BKAgentID: "agent-id",
+		HostID:    4,
+		Hostname:  "host-name",
+	})
+
+	expected := map[string]string{
+		"bk_cloud_id":        "3",
+		"bk_target_cloud_id": "3",
+		"bk_target_ip":       "127.0.0.1",
+		"bk_agent_id":        "agent-id",
+		"bk_host_id":         "4",
+		"bk_biz_id":          "2",
+		"node_id":            "3:127.0.0.1",
+		"hostname":           "host-name",
+	}
+	for key, value := range expected {
+		if dimensions[key] != value {
+			t.Fatalf("%s = %q, want %q", key, dimensions[key], value)
+		}
+	}
+}

--- a/pkg/bkmonitorbeat/tasks/selfstats/gather.go
+++ b/pkg/bkmonitorbeat/tasks/selfstats/gather.go
@@ -11,7 +11,6 @@ package selfstats
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"time"
@@ -53,15 +52,7 @@ func (g *Gather) Run(ctx context.Context, e chan<- define.Event) {
 	}
 
 	info, _ := gse.GetAgentInfo()
-	lbs := map[string]string{
-		"bk_cloud_id":  strconv.Itoa(int(info.Cloudid)),
-		"bk_target_ip": info.IP,
-		"bk_agent_id":  info.BKAgentID,
-		"bk_host_id":   strconv.Itoa(int(info.HostID)),
-		"bk_biz_id":    strconv.Itoa(int(info.BKBizID)),
-		"node_id":      fmt.Sprintf("%d:%s", info.Cloudid, info.IP),
-		"hostname":     info.Hostname,
-	}
+	lbs := tasks.HostDimension(info)
 
 	var data []common.MapStr
 	for i := 0; i < len(metrics); i++ {

--- a/pkg/bkmonitorbeat/tasks/timesync/gather.go
+++ b/pkg/bkmonitorbeat/tasks/timesync/gather.go
@@ -11,9 +11,7 @@ package timesync
 
 import (
 	"context"
-	"fmt"
 	"math"
-	"strconv"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -107,15 +105,7 @@ func stats2Metrics(env string, stat *Stat) *Metrics {
 	dims := map[string]string{}
 	if env == "host" {
 		info, _ := gse.GetAgentInfo()
-		dims = map[string]string{
-			"bk_cloud_id":  strconv.Itoa(int(info.Cloudid)),
-			"bk_target_ip": info.IP,
-			"bk_agent_id":  info.BKAgentID,
-			"bk_host_id":   strconv.Itoa(int(info.HostID)),
-			"bk_biz_id":    strconv.Itoa(int(info.BKBizID)),
-			"node_id":      fmt.Sprintf("%d:%s", info.Cloudid, info.IP),
-			"hostname":     info.Hostname,
-		}
+		dims = tasks.HostDimension(info)
 	}
 	return &Metrics{
 		Metrics:   metrics,


### PR DESCRIPTION
## 变更说明
- 为 bkmonitorbeat system_base 主机维度新增统一构造函数，保留 bk_cloud_id 的同时补齐标准 bk_target_cloud_id
- 覆盖 timesync、selfstats、dmesg 三类绕过 CMDB level 补维度的 systembase 数据
- 新增 HostDimension 单测，避免后续维度字段再次漂移

## 验证
- git diff --check
- cd pkg/bkmonitorbeat && go test ./tasks ./tasks/selfstats ./tasks/dmesg
- cd pkg/bkmonitorbeat && GOOS=linux go test -c ./tasks/timesync
- cd pkg/bkmonitorbeat && GOOS=windows go test -c ./tasks/timesync

说明：macOS 原生执行 go test ./tasks/timesync 仍受既有 golang.org/x/sys/windows/registry build constraints 限制，采用 linux/windows 编译检查覆盖。