### PR TITLE
fix: (unify-query)修复 query_string 字符类正则匹配范围异常放大 --story=135991257

### DIFF
--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -31,6 +31,15 @@ type RewriteResult struct {
 
 // Rewrite 将 Python/Doris 搜索语义下的基础正则，改写成 ES regexp 整值匹配语义。
 func Rewrite(pattern string) RewriteResult {
+	return rewrite(pattern, false)
+}
+
+// RewriteForQueryString 在 Rewrite 基础上兼容 query_string 字段正则的方括号短语写法。
+func RewriteForQueryString(pattern string) RewriteResult {
+	return rewrite(pattern, true)
+}
+
+func rewrite(pattern string, keepBracketPhrase bool) RewriteResult {
 	if inner, ok := extractNegativeLookahead(pattern); ok {
 		return RewriteResult{
 			Pattern:  rewritePositivePattern(inner, false),
@@ -38,7 +47,7 @@ func Rewrite(pattern string) RewriteResult {
 		}
 	}
 
-	return RewriteResult{Pattern: rewritePositivePattern(pattern, true)}
+	return RewriteResult{Pattern: rewritePositivePattern(pattern, keepBracketPhrase)}
 }
 
 // rewritePositivePattern 将正向 regexp 改写为 ES 整值匹配下的等价 pattern。
@@ -60,8 +69,13 @@ func rewriteSinglePattern(pattern string, keepBracketPhrase bool) string {
 	if isExplicitContains(pattern) {
 		return pattern
 	}
-	if keepBracketPhrase && isBracketPhrase(pattern) {
+	if keepBracketPhrase && isLikelyBracketPhrase(pattern) {
 		return pattern
+	}
+	if keepBracketPhrase {
+		if rewritten, ok := rewriteWrappedBracketPhrase(pattern); ok {
+			return rewritten
+		}
 	}
 
 	hasPrefix := hasUnescapedPrefixAnchor(pattern)
@@ -179,23 +193,105 @@ func isExplicitContains(pattern string) bool {
 	return hasUnescapedPrefixLiteral(pattern, ".*") && hasUnescapedSuffixLiteral(pattern, ".*")
 }
 
-// isBracketPhrase 判断表达式是否像误写成字符类的方括号短语，例如 [Page Error]。
-func isBracketPhrase(pattern string) bool {
+// rewriteWrappedBracketPhrase 处理外层透明分组里的方括号短语，例如 ([Page Error]|foo)。
+func rewriteWrappedBracketPhrase(pattern string) (string, bool) {
+	inner, ok := trimOuterParens(pattern)
+	if !ok {
+		return "", false
+	}
+	if isLikelyBracketPhrase(inner) {
+		return "(" + inner + ")", true
+	}
+
+	alternatives, ok := splitTopLevelAlternation(inner)
+	if !ok {
+		return "", false
+	}
+
+	hasBracketPhrase := false
+	rewritten := make([]string, 0, len(alternatives))
+	for _, alternative := range alternatives {
+		if isLikelyBracketPhrase(alternative) {
+			hasBracketPhrase = true
+		}
+		rewritten = append(rewritten, rewriteSinglePattern(alternative, true))
+	}
+	if !hasBracketPhrase {
+		return "", false
+	}
+	return "(" + strings.Join(rewritten, "|") + ")", true
+}
+
+// isLikelyBracketPhrase 判断表达式是否像误写成字符类的方括号短语，例如 [Page Error]。
+func isLikelyBracketPhrase(pattern string) bool {
 	body, ok := standaloneCharClassBody(pattern)
-	if !ok || body == "" || strings.HasPrefix(body, "^") {
+	trimmedBody := strings.TrimSpace(body)
+	if !ok || trimmedBody == "" || strings.HasPrefix(trimmedBody, "^") {
 		return false
 	}
 
-	hasSpace := false
+	hasUpper := false
 	for i := 0; i < len(body); i++ {
 		switch body[i] {
-		case '\\', '-', '|', '[', ']':
+		case '\\', '-', '|', '[', ']', '(', ')':
 			return false
-		case ' ', '\t':
-			hasSpace = true
+		default:
+			if body[i] >= 'A' && body[i] <= 'Z' {
+				hasUpper = true
+			}
 		}
 	}
-	return hasSpace
+
+	longTokens := 0
+	for _, token := range strings.Fields(body) {
+		if len(token) > 1 {
+			longTokens++
+		}
+	}
+	return hasUpper && longTokens >= 2
+}
+
+func trimOuterParens(pattern string) (string, bool) {
+	if len(pattern) < 2 || pattern[0] != '(' || pattern[len(pattern)-1] != ')' {
+		return "", false
+	}
+
+	escaped := false
+	bracketDepth := 0
+	parenDepth := 0
+	for i := 0; i < len(pattern); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch pattern[i] {
+		case '\\':
+			escaped = true
+		case '[':
+			if bracketDepth == 0 {
+				bracketDepth = 1
+			}
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '(':
+			if bracketDepth == 0 {
+				parenDepth++
+			}
+		case ')':
+			if bracketDepth == 0 {
+				parenDepth--
+				if parenDepth < 0 || (parenDepth == 0 && i != len(pattern)-1) {
+					return "", false
+				}
+			}
+		}
+	}
+	if parenDepth != 0 || bracketDepth != 0 {
+		return "", false
+	}
+	return pattern[1 : len(pattern)-1], true
 }
 
 func standaloneCharClassBody(pattern string) (string, bool) {

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -60,6 +60,9 @@ func rewriteSinglePattern(pattern string) string {
 	if isExplicitContains(pattern) {
 		return pattern
 	}
+	if isStandaloneCharClass(pattern) {
+		return pattern
+	}
 
 	hasPrefix := hasUnescapedPrefixAnchor(pattern)
 	hasSuffix := hasUnescapedSuffixAnchor(pattern)
@@ -174,6 +177,28 @@ func hasUnescapedSuffixAnchor(pattern string) bool {
 // isExplicitContains 判断表达式是否已经显式写成 .*foo.* 这类包含匹配。
 func isExplicitContains(pattern string) bool {
 	return hasUnescapedPrefixLiteral(pattern, ".*") && hasUnescapedSuffixLiteral(pattern, ".*")
+}
+
+// isStandaloneCharClass 判断表达式是否是整段裸字符类，例如 [abc] 或 [^abc]。
+func isStandaloneCharClass(pattern string) bool {
+	if !strings.HasPrefix(pattern, "[") {
+		return false
+	}
+
+	escaped := false
+	for i := 1; i < len(pattern); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch pattern[i] {
+		case '\\':
+			escaped = true
+		case ']':
+			return i == len(pattern)-1
+		}
+	}
+	return false
 }
 
 // addContainsPrefix 在缺少前置 .* 时补齐包含匹配前缀。

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -69,11 +69,8 @@ func rewriteSinglePattern(pattern string, keepBracketPhrase bool) string {
 	if isExplicitContains(pattern) {
 		return pattern
 	}
-	if keepBracketPhrase && isLikelyBracketPhrase(pattern) {
-		return pattern
-	}
 	if keepBracketPhrase {
-		if rewritten, ok := rewriteWrappedBracketPhrase(pattern); ok {
+		if rewritten, ok := rewriteBracketPhrasePattern(pattern); ok {
 			return rewritten
 		}
 	}
@@ -193,33 +190,38 @@ func isExplicitContains(pattern string) bool {
 	return hasUnescapedPrefixLiteral(pattern, ".*") && hasUnescapedSuffixLiteral(pattern, ".*")
 }
 
-// rewriteWrappedBracketPhrase 处理外层透明分组里的方括号短语，例如 ([Page Error]|foo)。
-func rewriteWrappedBracketPhrase(pattern string) (string, bool) {
+// rewriteBracketPhrasePattern 递归处理透明分组里的方括号短语，例如 (([Page Error])|foo)。
+func rewriteBracketPhrasePattern(pattern string) (string, bool) {
+	if isLikelyBracketPhrase(pattern) {
+		return pattern, true
+	}
+
+	if alternatives, ok := splitTopLevelAlternation(pattern); ok {
+		hasBracketPhrase := false
+		rewritten := make([]string, 0, len(alternatives))
+		for _, alternative := range alternatives {
+			if rewrittenAlternative, ok := rewriteBracketPhrasePattern(alternative); ok {
+				hasBracketPhrase = true
+				rewritten = append(rewritten, rewrittenAlternative)
+				continue
+			}
+			rewritten = append(rewritten, rewriteSinglePattern(alternative, true))
+		}
+		if !hasBracketPhrase {
+			return "", false
+		}
+		return strings.Join(rewritten, "|"), true
+	}
+
 	inner, ok := trimOuterParens(pattern)
 	if !ok {
 		return "", false
 	}
-	if isLikelyBracketPhrase(inner) {
-		return "(" + inner + ")", true
-	}
-
-	alternatives, ok := splitTopLevelAlternation(inner)
+	rewrittenInner, ok := rewriteBracketPhrasePattern(inner)
 	if !ok {
 		return "", false
 	}
-
-	hasBracketPhrase := false
-	rewritten := make([]string, 0, len(alternatives))
-	for _, alternative := range alternatives {
-		if isLikelyBracketPhrase(alternative) {
-			hasBracketPhrase = true
-		}
-		rewritten = append(rewritten, rewriteSinglePattern(alternative, true))
-	}
-	if !hasBracketPhrase {
-		return "", false
-	}
-	return "(" + strings.Join(rewritten, "|") + ")", true
+	return "(" + rewrittenInner + ")", true
 }
 
 // isLikelyBracketPhrase 判断表达式是否像误写成字符类的方括号短语，例如 [Page Error]。
@@ -230,15 +232,10 @@ func isLikelyBracketPhrase(pattern string) bool {
 		return false
 	}
 
-	hasUpper := false
 	for i := 0; i < len(body); i++ {
 		switch body[i] {
-		case '\\', '-', '|', '[', ']', '(', ')':
+		case '\\', '-', '|', '^', '[', ']', '(', ')':
 			return false
-		default:
-			if body[i] >= 'A' && body[i] <= 'Z' {
-				hasUpper = true
-			}
 		}
 	}
 
@@ -248,7 +245,7 @@ func isLikelyBracketPhrase(pattern string) bool {
 			longTokens++
 		}
 	}
-	return hasUpper && longTokens >= 2
+	return longTokens >= 2
 }
 
 func trimOuterParens(pattern string) (string, bool) {

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -33,34 +33,34 @@ type RewriteResult struct {
 func Rewrite(pattern string) RewriteResult {
 	if inner, ok := extractNegativeLookahead(pattern); ok {
 		return RewriteResult{
-			Pattern:  rewritePositivePattern(inner),
+			Pattern:  rewritePositivePattern(inner, false),
 			Negative: true,
 		}
 	}
 
-	return RewriteResult{Pattern: rewritePositivePattern(pattern)}
+	return RewriteResult{Pattern: rewritePositivePattern(pattern, true)}
 }
 
 // rewritePositivePattern 将正向 regexp 改写为 ES 整值匹配下的等价 pattern。
-func rewritePositivePattern(pattern string) string {
+func rewritePositivePattern(pattern string, keepBracketPhrase bool) string {
 	if alternatives, ok := splitTopLevelAlternation(pattern); ok {
 		rewritten := make([]string, 0, len(alternatives))
 		for _, alternative := range alternatives {
-			rewritten = append(rewritten, rewriteSinglePattern(alternative))
+			rewritten = append(rewritten, rewriteSinglePattern(alternative, keepBracketPhrase))
 		}
 		return "(" + strings.Join(rewritten, "|") + ")"
 	}
 
-	return rewriteSinglePattern(pattern)
+	return rewriteSinglePattern(pattern, keepBracketPhrase)
 }
 
 // rewriteSinglePattern 改写不含顶层 | 的单个正则分支。
 // 未显式锚定的分支会补齐 .* 以模拟历史包含匹配；^/$ 锚点会被转换成 ES 整值匹配下的前缀/后缀约束。
-func rewriteSinglePattern(pattern string) string {
+func rewriteSinglePattern(pattern string, keepBracketPhrase bool) string {
 	if isExplicitContains(pattern) {
 		return pattern
 	}
-	if isStandaloneCharClass(pattern) {
+	if keepBracketPhrase && isBracketPhrase(pattern) {
 		return pattern
 	}
 
@@ -179,10 +179,28 @@ func isExplicitContains(pattern string) bool {
 	return hasUnescapedPrefixLiteral(pattern, ".*") && hasUnescapedSuffixLiteral(pattern, ".*")
 }
 
-// isStandaloneCharClass 判断表达式是否是整段裸字符类，例如 [abc] 或 [^abc]。
-func isStandaloneCharClass(pattern string) bool {
-	if !strings.HasPrefix(pattern, "[") {
+// isBracketPhrase 判断表达式是否像误写成字符类的方括号短语，例如 [Page Error]。
+func isBracketPhrase(pattern string) bool {
+	body, ok := standaloneCharClassBody(pattern)
+	if !ok || body == "" || strings.HasPrefix(body, "^") {
 		return false
+	}
+
+	hasSpace := false
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '\\', '-', '|', '[', ']':
+			return false
+		case ' ', '\t':
+			hasSpace = true
+		}
+	}
+	return hasSpace
+}
+
+func standaloneCharClassBody(pattern string) (string, bool) {
+	if !strings.HasPrefix(pattern, "[") {
+		return "", false
 	}
 
 	escaped := false
@@ -195,10 +213,13 @@ func isStandaloneCharClass(pattern string) bool {
 		case '\\':
 			escaped = true
 		case ']':
-			return i == len(pattern)-1
+			if i != len(pattern)-1 {
+				return "", false
+			}
+			return pattern[1:i], true
 		}
 	}
-	return false
+	return "", false
 }
 
 // addContainsPrefix 在缺少前置 .* 时补齐包含匹配前缀。

--- a/pkg/unify-query/internal/esregexpcompat/rewrite.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite.go
@@ -241,11 +241,22 @@ func isLikelyBracketPhrase(pattern string) bool {
 
 	longTokens := 0
 	for _, token := range strings.Fields(body) {
-		if len(token) > 1 {
+		if runeCountGreaterThanOne(token) {
 			longTokens++
 		}
 	}
 	return longTokens >= 2
+}
+
+func runeCountGreaterThanOne(s string) bool {
+	count := 0
+	for range s {
+		count++
+		if count > 1 {
+			return true
+		}
+	}
+	return false
 }
 
 func trimOuterParens(pattern string) (string, bool) {

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -45,9 +45,9 @@ func TestRewrite(t *testing.T) {
 			pattern:     "(foo|bar)",
 			wantPattern: ".*(foo|bar).*",
 		},
-		"方括号短语不补齐包含匹配": {
+		"默认方括号短语仍补齐包含匹配": {
 			pattern:     "[Page Error]",
-			wantPattern: "[Page Error]",
+			wantPattern: ".*[Page Error].*",
 		},
 		"普通字符类仍补齐包含匹配": {
 			pattern:     "[0-9]",
@@ -85,9 +85,9 @@ func TestRewrite(t *testing.T) {
 			pattern:     "[Ee]rror",
 			wantPattern: ".*[Ee]rror.*",
 		},
-		"顶层或表达式中的整段字符类分支不补齐包含匹配": {
+		"默认顶层或表达式中的方括号短语分支仍补齐包含匹配": {
 			pattern:     "foo|[Page Error]",
-			wantPattern: "(.*foo.*|[Page Error])",
+			wantPattern: "(.*foo.*|.*[Page Error].*)",
 		},
 		"转义字符类按普通包含处理": {
 			pattern:     `\[Page Error\]`,
@@ -164,6 +164,80 @@ func TestRewrite(t *testing.T) {
 			}
 			if got.Negative != tt.wantNegative {
 				t.Fatalf("Rewrite(%q).Negative = %v, want %v", tt.pattern, got.Negative, tt.wantNegative)
+			}
+		})
+	}
+}
+
+func TestRewriteForQueryString(t *testing.T) {
+	tests := map[string]struct {
+		pattern      string
+		wantPattern  string
+		wantNegative bool
+	}{
+		"方括号短语不补齐包含匹配": {
+			pattern:     "[Page Error]",
+			wantPattern: "[Page Error]",
+		},
+		"空白字符类仍补齐包含匹配": {
+			pattern:     "[ ]",
+			wantPattern: ".*[ ].*",
+		},
+		"单字符加空格字符类仍补齐包含匹配": {
+			pattern:     "[a b]",
+			wantPattern: ".*[a b].*",
+		},
+		"数字加空格字符类仍补齐包含匹配": {
+			pattern:     "[0 9]",
+			wantPattern: ".*[0 9].*",
+		},
+		"空格和下划线字符类仍补齐包含匹配": {
+			pattern:     "[ _]",
+			wantPattern: ".*[ _].*",
+		},
+		"普通字符类仍补齐包含匹配": {
+			pattern:     "[0-9]",
+			wantPattern: ".*[0-9].*",
+		},
+		"十六进制转义字符类仍补齐包含匹配": {
+			pattern:     `[\x61]`,
+			wantPattern: `.*[\x61].*`,
+		},
+		"外层透明分组方括号短语不补齐包含匹配": {
+			pattern:     "([Page Error])",
+			wantPattern: "([Page Error])",
+		},
+		"外层透明分组内的方括号短语分支不补齐包含匹配": {
+			pattern:     "([Page Error]|foo)",
+			wantPattern: "([Page Error]|.*foo.*)",
+		},
+		"外层透明分组内无方括号短语时保持原包含匹配": {
+			pattern:     "(foo|bar)",
+			wantPattern: ".*(foo|bar).*",
+		},
+		"外层透明分组内合法字符类时保持原包含匹配": {
+			pattern:     "([ _]|foo)",
+			wantPattern: ".*([ _]|foo).*",
+		},
+		"顶层或表达式中的方括号短语分支不补齐包含匹配": {
+			pattern:     "foo|[Page Error]",
+			wantPattern: "(.*foo.*|[Page Error])",
+		},
+		"不包含语义固定前缀内的方括号短语保持包含匹配": {
+			pattern:      "^(?!.*[Page Error]).*",
+			wantPattern:  ".*[Page Error].*",
+			wantNegative: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := RewriteForQueryString(tt.pattern)
+			if got.Pattern != tt.wantPattern {
+				t.Fatalf("RewriteForQueryString(%q).Pattern = %q, want %q", tt.pattern, got.Pattern, tt.wantPattern)
+			}
+			if got.Negative != tt.wantNegative {
+				t.Fatalf("RewriteForQueryString(%q).Negative = %v, want %v", tt.pattern, got.Negative, tt.wantNegative)
 			}
 		})
 	}

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -45,9 +45,29 @@ func TestRewrite(t *testing.T) {
 			pattern:     "(foo|bar)",
 			wantPattern: ".*(foo|bar).*",
 		},
+		"整段字符类不补齐包含匹配": {
+			pattern:     "[Page Error]",
+			wantPattern: "[Page Error]",
+		},
+		"整段排除字符类不补齐包含匹配": {
+			pattern:     "[^abc]",
+			wantPattern: "[^abc]",
+		},
 		"字符类内竖线不视为顶层或表达式": {
 			pattern:     "[a|b]",
-			wantPattern: ".*[a|b].*",
+			wantPattern: "[a|b]",
+		},
+		"非整段字符类仍补齐包含匹配": {
+			pattern:     "[Ee]rror",
+			wantPattern: ".*[Ee]rror.*",
+		},
+		"顶层或表达式中的整段字符类分支不补齐包含匹配": {
+			pattern:     "foo|[Page Error]",
+			wantPattern: "(.*foo.*|[Page Error])",
+		},
+		"转义字符类按普通包含处理": {
+			pattern:     `\[Page Error\]`,
+			wantPattern: `.*\[Page Error\].*`,
 		},
 		"前缀锚点改写为整值前缀匹配": {
 			pattern:     "^foo",

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -179,6 +179,10 @@ func TestRewriteForQueryString(t *testing.T) {
 			pattern:     "[Page Error]",
 			wantPattern: "[Page Error]",
 		},
+		"小写方括号短语不补齐包含匹配": {
+			pattern:     "[page error]",
+			wantPattern: "[page error]",
+		},
 		"空白字符类仍补齐包含匹配": {
 			pattern:     "[ ]",
 			wantPattern: ".*[ ].*",
@@ -207,9 +211,17 @@ func TestRewriteForQueryString(t *testing.T) {
 			pattern:     "([Page Error])",
 			wantPattern: "([Page Error])",
 		},
+		"双层透明分组方括号短语不补齐包含匹配": {
+			pattern:     "(([Page Error]))",
+			wantPattern: "(([Page Error]))",
+		},
 		"外层透明分组内的方括号短语分支不补齐包含匹配": {
 			pattern:     "([Page Error]|foo)",
 			wantPattern: "([Page Error]|.*foo.*)",
+		},
+		"双层透明分组内的方括号短语分支不补齐包含匹配": {
+			pattern:     "(([Page Error])|foo)",
+			wantPattern: "(([Page Error])|.*foo.*)",
 		},
 		"外层透明分组内无方括号短语时保持原包含匹配": {
 			pattern:     "(foo|bar)",

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -45,17 +45,41 @@ func TestRewrite(t *testing.T) {
 			pattern:     "(foo|bar)",
 			wantPattern: ".*(foo|bar).*",
 		},
-		"整段字符类不补齐包含匹配": {
+		"方括号短语不补齐包含匹配": {
 			pattern:     "[Page Error]",
 			wantPattern: "[Page Error]",
 		},
-		"整段排除字符类不补齐包含匹配": {
+		"普通字符类仍补齐包含匹配": {
+			pattern:     "[0-9]",
+			wantPattern: ".*[0-9].*",
+		},
+		"整段排除字符类仍补齐包含匹配": {
 			pattern:     "[^abc]",
-			wantPattern: "[^abc]",
+			wantPattern: ".*[^abc].*",
+		},
+		"空字符类仍补齐包含匹配": {
+			pattern:     "[]",
+			wantPattern: ".*[].*",
+		},
+		"空排除字符类仍补齐包含匹配": {
+			pattern:     "[^]",
+			wantPattern: ".*[^].*",
+		},
+		"带量词字符类仍补齐包含匹配": {
+			pattern:     "[abc]+",
+			wantPattern: ".*[abc]+.*",
+		},
+		"带转义右中括号字符类仍补齐包含匹配": {
+			pattern:     `[a\]b]`,
+			wantPattern: `.*[a\]b].*`,
+		},
+		"带十六进制转义字符类仍补齐包含匹配": {
+			pattern:     `[\x61]`,
+			wantPattern: `.*[\x61].*`,
 		},
 		"字符类内竖线不视为顶层或表达式": {
 			pattern:     "[a|b]",
-			wantPattern: "[a|b]",
+			wantPattern: ".*[a|b].*",
 		},
 		"非整段字符类仍补齐包含匹配": {
 			pattern:     "[Ee]rror",
@@ -110,6 +134,16 @@ func TestRewrite(t *testing.T) {
 		"不包含语义固定前缀内的顶层或表达式按分支补齐包含匹配": {
 			pattern:      "^(?!.*foo|.*bar).*",
 			wantPattern:  "(.*foo.*|.*bar.*)",
+			wantNegative: true,
+		},
+		"不包含语义固定前缀内的字符类保持包含匹配": {
+			pattern:      "^(?!.*[abc]).*",
+			wantPattern:  ".*[abc].*",
+			wantNegative: true,
+		},
+		"不包含语义固定前缀内的方括号短语保持包含匹配": {
+			pattern:      "^(?!.*[Page Error]).*",
+			wantPattern:  ".*[Page Error].*",
 			wantNegative: true,
 		},
 		"转义前缀锚点按普通包含处理": {

--- a/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
+++ b/pkg/unify-query/internal/esregexpcompat/rewrite_test.go
@@ -199,6 +199,14 @@ func TestRewriteForQueryString(t *testing.T) {
 			pattern:     "[ _]",
 			wantPattern: ".*[ _].*",
 		},
+		"中文单字符加空格字符类仍补齐包含匹配": {
+			pattern:     "[中 文]",
+			wantPattern: ".*[中 文].*",
+		},
+		"中文方括号短语不补齐包含匹配": {
+			pattern:     "[页面 错误]",
+			wantPattern: "[页面 错误]",
+		},
 		"普通字符类仍补齐包含匹配": {
 			pattern:     "[0-9]",
 			wantPattern: ".*[0-9].*",

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -839,10 +839,15 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"regexp":{"msg":{"value":".*TypeError.*"}}}`,
 			sql: "`msg` REGEXP 'TypeError'",
 		},
-		"字段整段字符类正则不补齐包含匹配": {
+		"字段方括号短语正则不补齐包含匹配": {
 			q:   `msg:/[Page Error]/`,
 			es:  `{"regexp":{"msg":{"value":"[Page Error]"}}}`,
 			sql: "`msg` REGEXP '[Page Error]'",
+		},
+		"字段普通字符类正则仍补齐包含匹配": {
+			q:   `msg:/[0-9]/`,
+			es:  `{"regexp":{"msg":{"value":".*[0-9].*"}}}`,
+			sql: "`msg` REGEXP '[0-9]'",
 		},
 		"字段正则顶层或表达式按分支补齐包含匹配": {
 			q:   `msg:/foo|bar/`,
@@ -863,6 +868,11 @@ func TestLuceneParser(t *testing.T) {
 			q:   `msg:/^(?!.*idip).*/`,
 			es:  `{"bool":{"must":{"exists":{"field":"msg"}},"must_not":{"regexp":{"msg":{"value":".*idip.*"}}}}}`,
 			sql: "`msg` REGEXP '^(?!.*idip).*'",
+		},
+		"字段正则不包含前缀内的字符类保持包含匹配": {
+			q:   `msg:/^(?!.*[abc]).*/`,
+			es:  `{"bool":{"must":{"exists":{"field":"msg"}},"must_not":{"regexp":{"msg":{"value":".*[abc].*"}}}}}`,
+			sql: "`msg` REGEXP '^(?!.*[abc]).*'",
 		},
 		"fuzzy_and_field": {
 			q:   `log: test~`,

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -849,10 +849,25 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"regexp":{"msg":{"value":".*[0-9].*"}}}`,
 			sql: "`msg` REGEXP '[0-9]'",
 		},
+		"字段空格下划线字符类正则仍补齐包含匹配": {
+			q:   `msg:/[ _]/`,
+			es:  `{"regexp":{"msg":{"value":".*[ _].*"}}}`,
+			sql: "`msg` REGEXP '[ _]'",
+		},
 		"字段正则顶层或表达式按分支补齐包含匹配": {
 			q:   `msg:/foo|bar/`,
 			es:  `{"regexp":{"msg":{"value":"(.*foo.*|.*bar.*)"}}}`,
 			sql: "`msg` REGEXP 'foo|bar'",
+		},
+		"字段正则外层分组方括号短语不补齐包含匹配": {
+			q:   `msg:/([Page Error])/`,
+			es:  `{"regexp":{"msg":{"value":"([Page Error])"}}}`,
+			sql: "`msg` REGEXP '([Page Error])'",
+		},
+		"字段正则外层分组内的方括号短语分支不补齐包含匹配": {
+			q:   `msg:/([Page Error]|foo)/`,
+			es:  `{"regexp":{"msg":{"value":"([Page Error]|.*foo.*)"}}}`,
+			sql: "`msg` REGEXP '([Page Error]|foo)'",
 		},
 		"字段正则顶层或表达式保留分支锚点语义": {
 			q:   `msg:/^foo|bar/`,

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -839,6 +839,11 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"regexp":{"msg":{"value":".*TypeError.*"}}}`,
 			sql: "`msg` REGEXP 'TypeError'",
 		},
+		"字段整段字符类正则不补齐包含匹配": {
+			q:   `msg:/[Page Error]/`,
+			es:  `{"regexp":{"msg":{"value":"[Page Error]"}}}`,
+			sql: "`msg` REGEXP '[Page Error]'",
+		},
 		"字段正则顶层或表达式按分支补齐包含匹配": {
 			q:   `msg:/foo|bar/`,
 			es:  `{"regexp":{"msg":{"value":"(.*foo.*|.*bar.*)"}}}`,

--- a/pkg/unify-query/internal/lucene_parser/parser_test.go
+++ b/pkg/unify-query/internal/lucene_parser/parser_test.go
@@ -308,6 +308,18 @@ func TestDorisSQLExpr_ParserQueryString(t *testing.T) {
 			dsl:   `{"regexp":{"case_insensitive_log":{"value":".*ssr_request_error.*"}}}`,
 		},
 		{
+			name:  "大小写不敏感字段的大写方括号短语 lower 后不补齐包含匹配",
+			input: `case_insensitive_log:/[Page Error]/`,
+			sql:   "`case_insensitive_log` REGEXP '[Page Error]'",
+			dsl:   `{"regexp":{"case_insensitive_log":{"value":"[page error]"}}}`,
+		},
+		{
+			name:  "大小写不敏感字段的小写方括号短语不补齐包含匹配",
+			input: `case_insensitive_log:/[page error]/`,
+			sql:   "`case_insensitive_log` REGEXP '[page error]'",
+			dsl:   `{"regexp":{"case_insensitive_log":{"value":"[page error]"}}}`,
+		},
+		{
 			name:  "旧版大小写不敏感字段的正则会 lower pattern",
 			input: `legacy_case_insensitive_log:/SSR_REQUEST_ERROR/`,
 			sql:   "`legacy_case_insensitive_log` REGEXP 'SSR_REQUEST_ERROR'",
@@ -864,10 +876,20 @@ func TestLuceneParser(t *testing.T) {
 			es:  `{"regexp":{"msg":{"value":"([Page Error])"}}}`,
 			sql: "`msg` REGEXP '([Page Error])'",
 		},
+		"字段正则双层分组方括号短语不补齐包含匹配": {
+			q:   `msg:/(([Page Error]))/`,
+			es:  `{"regexp":{"msg":{"value":"(([Page Error]))"}}}`,
+			sql: "`msg` REGEXP '(([Page Error]))'",
+		},
 		"字段正则外层分组内的方括号短语分支不补齐包含匹配": {
 			q:   `msg:/([Page Error]|foo)/`,
 			es:  `{"regexp":{"msg":{"value":"([Page Error]|.*foo.*)"}}}`,
 			sql: "`msg` REGEXP '([Page Error]|foo)'",
+		},
+		"字段正则双层分组内的方括号短语分支不补齐包含匹配": {
+			q:   `msg:/(([Page Error])|foo)/`,
+			es:  `{"regexp":{"msg":{"value":"(([Page Error])|.*foo.*)"}}}`,
+			sql: "`msg` REGEXP '(([Page Error])|foo)'",
 		},
 		"字段正则顶层或表达式保留分支锚点语义": {
 			q:   `msg:/^foo|bar/`,

--- a/pkg/unify-query/internal/lucene_parser/visitor.go
+++ b/pkg/unify-query/internal/lucene_parser/visitor.go
@@ -641,7 +641,7 @@ func (n *ConditionNode) DSL() (allMust []elastic.Query, allShould []elastic.Quer
 			result = wildcardQueryForField(field, value, fieldOption, cv.Boost)
 		}
 	case *RegexpNode:
-		rewrite := esregexpcompat.Rewrite(value)
+		rewrite := esregexpcompat.RewriteForQueryString(value)
 		value = rewrite.Pattern
 		// ES regexp 是 term-level 查询，不会像 match/match_phrase 一样走 analyzer；
 		// 因此 text + lowercase/analyzed 字段需要在 UQ 侧按字段大小写语义归一化 pattern。

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -260,7 +260,7 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"regexp":{"keyword":{"value":".*TypeError.*"}}}}`,
 		},
-		"结构化整段字符类正则不补齐包含匹配": {
+		"结构化方括号短语正则不补齐包含匹配": {
 			conditions: metadata.AllConditions{
 				{
 					{
@@ -271,6 +271,18 @@ func TestFormatFactory_Query(t *testing.T) {
 				},
 			},
 			expected: `{"query":{"regexp":{"keyword":{"value":"[Page Error]"}}}}`,
+		},
+		"结构化普通字符类正则仍补齐包含匹配": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"[0-9]"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"regexp":{"keyword":{"value":".*[0-9].*"}}}}`,
 		},
 		"结构化正则顶层或表达式按分支补齐包含匹配": {
 			conditions: metadata.AllConditions{
@@ -319,6 +331,18 @@ func TestFormatFactory_Query(t *testing.T) {
 				},
 			},
 			expected: `{"query":{"bool":{"must":{"exists":{"field":"keyword"}},"must_not":{"regexp":{"keyword":{"value":".*idip.*"}}}}}}`,
+		},
+		"结构化正则不包含前缀内的字符类保持包含匹配": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"^(?!.*[abc]).*"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"bool":{"must":{"exists":{"field":"keyword"}},"must_not":{"regexp":{"keyword":{"value":".*[abc].*"}}}}}}`,
 		},
 		"结构化正则不包含前缀形式只作用于当前 value": {
 			conditions: metadata.AllConditions{

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -260,7 +260,7 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"regexp":{"keyword":{"value":".*TypeError.*"}}}}`,
 		},
-		"结构化方括号短语正则不补齐包含匹配": {
+		"结构化方括号短语正则仍补齐包含匹配": {
 			conditions: metadata.AllConditions{
 				{
 					{
@@ -270,7 +270,7 @@ func TestFormatFactory_Query(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"query":{"regexp":{"keyword":{"value":"[Page Error]"}}}}`,
+			expected: `{"query":{"regexp":{"keyword":{"value":".*[Page Error].*"}}}}`,
 		},
 		"结构化普通字符类正则仍补齐包含匹配": {
 			conditions: metadata.AllConditions{

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -260,6 +260,18 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"regexp":{"keyword":{"value":".*TypeError.*"}}}}`,
 		},
+		"结构化整段字符类正则不补齐包含匹配": {
+			conditions: metadata.AllConditions{
+				{
+					{
+						DimensionName: "keyword",
+						Value:         []string{"[Page Error]"},
+						Operator:      structured.ConditionRegEqual,
+					},
+				},
+			},
+			expected: `{"query":{"regexp":{"keyword":{"value":"[Page Error]"}}}}`,
+		},
 		"结构化正则顶层或表达式按分支补齐包含匹配": {
 			conditions: metadata.AllConditions{
 				{


### PR DESCRIPTION
## 背景

当 `query_string` 中包含字段正则 `msg:/[Page Error]/` 时，`[Page Error]` 在正则语义下是字符类，不是字面量字符串。UQ 的 ES regexp 兼容逻辑会将未锚定正则补齐为 contains 匹配，叠加字段大小写归一化后，该表达式被改写为 `.*[page error].*`，导致匹配范围明显放大。

现网完整请求验证：

- 原生 ES query_string：1398
- UQ 当前补宽后：5653
- 对 `[Page Error]` 这类疑似方括号短语不补 `.*` 后：1398

## 修复

- 新增 `esregexpcompat.RewriteForQueryString`，仅用于 Lucene `query_string` 字段正则路径。
- 对 `[Page Error]`、`[page error]`、`([Page Error])`、`(([Page Error])|foo)` 这类疑似误写成字符类的方括号短语不再自动补齐 `.*`，避免 `.*[page error].*` 带来的匹配范围放大。
- 结构化 `req/nreq` 继续使用默认 `esregexpcompat.Rewrite`，保持 Doris / Go regexp 的未锚定 contains 兼容语义。
- 保留真实正则字符类的历史 contains 兼容行为，如 `[0-9]`、`[^abc]`、`[abc]+`、`[\x61]`、`[ _]`、`[中 文]` 仍会补齐 `.*`。
- 负向正则 `^(?!.*xxx).*` 内部继续保持 contains 改写，避免破坏“不包含”语义。
- 保留普通正则、转义字符类、非整段字符类、顶层 OR 等现有兼容行为。

## 测试

```bash
cd pkg/unify-query && go test ./internal/esregexpcompat ./internal/lucene_parser ./tsdb/elasticsearch