### PR TITLE
refactor(operator): 删除零引用死常量 container_with_datasource_relation --story=135992891

### DIFF
--- a/pkg/operator/operator/objectsref/relation.go
+++ b/pkg/operator/operator/objectsref/relation.go
@@ -40,7 +40,6 @@ const (
 	relationDomainService        = "domain_with_service_relation"
 	relationIngressService       = "ingress_with_service_relation"
 
-	relationContainerWithDataSource   = "container_with_datasource_relation"
 	relationDataSourceWithPod         = "datasource_with_pod_relation"
 	relationDataSourceWithNode        = "datasource_with_node_relation"
 	relationBkLogConfigWithDataSource = "bklogconfig_with_datasource_relation"


### PR DESCRIPTION
## 背景
`objectsref/relation.go` 中常量 `relationContainerWithDataSource = "container_with_datasource_relation"` 声明后全仓零引用，无任何上报路径，静态关系定义中也不存在 container↔datasource 关系。

## 改动
删除该死常量声明（1 行）。datasource 关联在 pod 级（`datasource_with_pod_relation`）已足够，不做 container 级 datasource 关系。

## 验证
- 全仓复核：标识符与字面量各仅 1 处（=声明本身），零使用。
- `gofmt` 校验通过，const 块对齐不受影响。

详见 TAPD #1010158081135992891