### PR TITLE
fix(operator): DataID 后到时自动恢复采集发现任务 --bug=136030942 --story=136030942

### DIFF
--- a/pkg/operator/operator/dataid_reconcile.go
+++ b/pkg/operator/operator/dataid_reconcile.go
@@ -1,0 +1,110 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package operator
+
+import (
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/operator/operator/discover"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
+)
+
+type monitorResourceLister interface {
+	ListAll(selector labels.Selector, appendFn cache.AppendFunc) error
+}
+
+type monitorDiscoverBuilder func(obj any) []discover.Discover
+
+func (c *Operator) recoverMonitorDiscovers(
+	lister monitorResourceLister,
+	builder monitorDiscoverBuilder,
+) error {
+	c.monitorReconcileMut.Lock()
+	defer c.monitorReconcileMut.Unlock()
+
+	return lister.ListAll(labels.Everything(), func(obj any) {
+		for _, dis := range builder(obj) {
+			added, err := c.addDiscoverIfAbsent(dis)
+			if err != nil {
+				logger.Errorf("recover discover %v failed: %s", dis, err)
+				continue
+			}
+			if added {
+				logger.Infof("recover discover %v", dis)
+			}
+		}
+	})
+}
+
+func (c *Operator) serviceMonitorDiscoversFromObject(obj any) []discover.Discover {
+	serviceMonitor, ok := obj.(*promv1.ServiceMonitor)
+	if !ok {
+		logger.Errorf("expected ServiceMonitor type, got %T", obj)
+		return nil
+	}
+	if ifRejectServiceMonitor(serviceMonitor) {
+		return nil
+	}
+	return c.createServiceMonitorDiscovers(serviceMonitor)
+}
+
+func (c *Operator) recoverServiceMonitorDiscovers() error {
+	if c.serviceMonitorInformer == nil {
+		return nil
+	}
+	return c.recoverMonitorDiscovers(c.serviceMonitorInformer, c.serviceMonitorDiscoversFromObject)
+}
+
+func (c *Operator) podMonitorDiscoversFromObject(obj any) []discover.Discover {
+	podMonitor, ok := obj.(*promv1.PodMonitor)
+	if !ok {
+		logger.Errorf("expected PodMonitor type, got %T", obj)
+		return nil
+	}
+	if ifRejectPodMonitor(podMonitor) {
+		return nil
+	}
+	return c.createPodMonitorDiscovers(podMonitor)
+}
+
+func (c *Operator) recoverPodMonitorDiscovers() error {
+	if c.podMonitorInformer == nil {
+		return nil
+	}
+	return c.recoverMonitorDiscovers(c.podMonitorInformer, c.podMonitorDiscoversFromObject)
+}
+
+func (c *Operator) recoverPromScrapeConfigDiscovers() {
+	c.promSdReconcileMut.Lock()
+	defer c.promSdReconcileMut.Unlock()
+
+	for _, dis := range c.createPromScrapeConfigDiscovers(c.snapshotPromScrapeConfigs()) {
+		added, err := c.addDiscoverIfAbsent(dis)
+		if err != nil {
+			logger.Errorf("recover prom scrapeConfig discover %v failed: %s", dis, err)
+			continue
+		}
+		if added {
+			logger.Infof("recover prom scrapeConfig discover %v", dis)
+		}
+	}
+}
+
+func (c *Operator) recoverDataIDDependentDiscovers() {
+	if err := c.recoverServiceMonitorDiscovers(); err != nil {
+		logger.Errorf("recover serviceMonitor discovers failed: %s", err)
+	}
+	if err := c.recoverPodMonitorDiscovers(); err != nil {
+		logger.Errorf("recover podMonitor discovers failed: %s", err)
+	}
+	c.recoverPromScrapeConfigDiscovers()
+}

--- a/pkg/operator/operator/dataid_reconcile_test.go
+++ b/pkg/operator/operator/dataid_reconcile_test.go
@@ -1,0 +1,471 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/prometheus/config"
+	promdiscovery "github.com/prometheus/prometheus/discovery"
+	promk8ssd "github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	bkv1beta1 "github.com/TencentBlueKing/bkmonitor-datalink/pkg/operator/apis/monitoring/v1beta1"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/operator/common/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/operator/configs"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/operator/operator/dataidwatcher"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/operator/operator/discover"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/operator/operator/objectsref"
+)
+
+type fakeMonitorResourceLister struct {
+	objects []any
+	listed  chan struct{}
+	release chan struct{}
+}
+
+func (l *fakeMonitorResourceLister) ListAll(_ labels.Selector, appendFn cache.AppendFunc) error {
+	for _, obj := range l.objects {
+		if l.listed != nil {
+			close(l.listed)
+			<-l.release
+		}
+		appendFn(obj)
+	}
+	return nil
+}
+
+type fakeDiscover struct {
+	name        string
+	dataID      *bkv1beta1.DataID
+	startErr    error
+	startCount  int
+	stopCount   int
+	reloadCount int
+}
+
+type fakeDataIDWatcher struct {
+	metricDataID *bkv1beta1.DataID
+	metricErr    error
+}
+
+var _ dataidwatcher.Watcher = (*fakeDataIDWatcher)(nil)
+
+func (w *fakeDataIDWatcher) Start() error { return nil }
+
+func (w *fakeDataIDWatcher) Stop() {}
+
+func (w *fakeDataIDWatcher) DataIDs() []*bkv1beta1.DataID {
+	if w.metricDataID == nil {
+		return nil
+	}
+	return []*bkv1beta1.DataID{w.metricDataID}
+}
+
+func (w *fakeDataIDWatcher) MatchMetricDataID(
+	_ define.MonitorMeta,
+	_ bool,
+) (*bkv1beta1.DataID, error) {
+	return w.metricDataID, w.metricErr
+}
+
+func (w *fakeDataIDWatcher) MatchEventDataID(
+	_ define.MonitorMeta,
+	_ bool,
+) (*bkv1beta1.DataID, error) {
+	return nil, errors.New("event dataid not configured")
+}
+
+func (w *fakeDataIDWatcher) GetClusterInfo() (*define.ClusterInfo, error) {
+	return nil, errors.New("cluster info not configured")
+}
+
+func (d *fakeDiscover) Name() string { return d.name }
+
+func (d *fakeDiscover) UK() string { return d.name }
+
+func (d *fakeDiscover) Type() string { return monitorKindServiceMonitor }
+
+func (d *fakeDiscover) IsSystem() bool { return true }
+
+func (d *fakeDiscover) Start() error {
+	d.startCount++
+	return d.startErr
+}
+
+func (d *fakeDiscover) Stop() { d.stopCount++ }
+
+func (d *fakeDiscover) Reload() error {
+	d.reloadCount++
+	return nil
+}
+
+func (d *fakeDiscover) MonitorMeta() define.MonitorMeta { return define.MonitorMeta{} }
+
+func (d *fakeDiscover) DataID() *bkv1beta1.DataID { return d.dataID }
+
+func (d *fakeDiscover) SetDataID(dataID *bkv1beta1.DataID) { d.dataID = dataID }
+
+func (d *fakeDiscover) DaemonSetChildConfigs() []*discover.ChildConfig { return nil }
+
+func (d *fakeDiscover) StatefulSetChildConfigs() []*discover.ChildConfig { return nil }
+
+func TestAddDiscoverIfAbsent(t *testing.T) {
+	t.Run("starts and registers a missing discover", func(t *testing.T) {
+		op := &Operator{discovers: make(map[string]discover.Discover)}
+		candidate := &fakeDiscover{name: "ServiceMonitor:default/example:0"}
+
+		added, err := op.addDiscoverIfAbsent(candidate)
+
+		require.NoError(t, err)
+		assert.True(t, added)
+		assert.Equal(t, 1, candidate.startCount)
+		assert.Same(t, candidate, op.discovers[candidate.Name()])
+	})
+
+	t.Run("keeps an existing discover running", func(t *testing.T) {
+		existing := &fakeDiscover{name: "ServiceMonitor:default/example:0"}
+		candidate := &fakeDiscover{name: existing.Name()}
+		op := &Operator{discovers: map[string]discover.Discover{existing.Name(): existing}}
+
+		added, err := op.addDiscoverIfAbsent(candidate)
+
+		require.NoError(t, err)
+		assert.False(t, added)
+		assert.Zero(t, candidate.startCount)
+		assert.Zero(t, candidate.stopCount)
+		assert.Zero(t, existing.startCount)
+		assert.Zero(t, existing.stopCount)
+		assert.Same(t, existing, op.discovers[existing.Name()])
+	})
+
+	t.Run("does not register a discover that fails to start", func(t *testing.T) {
+		op := &Operator{discovers: make(map[string]discover.Discover)}
+		candidate := &fakeDiscover{
+			name:     "ServiceMonitor:default/example:0",
+			startErr: errors.New("start failed"),
+		}
+
+		added, err := op.addDiscoverIfAbsent(candidate)
+
+		assert.EqualError(t, err, "start failed")
+		assert.False(t, added)
+		assert.Equal(t, 1, candidate.startCount)
+		assert.Empty(t, op.discovers)
+	})
+}
+
+func assertMonitorDiscoverRecovery(
+	t *testing.T,
+	resource any,
+	expectedType any,
+) {
+	t.Helper()
+
+	op := &Operator{discovers: make(map[string]discover.Discover)}
+	lister := &fakeMonitorResourceLister{objects: []any{resource}}
+	candidate := &fakeDiscover{name: "monitor:default/example:0"}
+	dataIDAvailable := false
+	create := func(obj any) []discover.Discover {
+		assert.IsType(t, expectedType, obj)
+		if !dataIDAvailable {
+			return nil
+		}
+		return []discover.Discover{candidate}
+	}
+
+	require.NoError(t, op.recoverMonitorDiscovers(lister, create))
+	assert.Empty(t, op.discovers)
+
+	dataIDAvailable = true
+	require.NoError(t, op.recoverMonitorDiscovers(lister, create))
+	assert.Equal(t, 1, candidate.startCount)
+	assert.Same(t, candidate, op.discovers[candidate.Name()])
+
+	require.NoError(t, op.recoverMonitorDiscovers(lister, create))
+	assert.Equal(t, 1, candidate.startCount)
+}
+
+func TestRecoverServiceMonitorDiscovers(t *testing.T) {
+	assertMonitorDiscoverRecovery(
+		t,
+		&promv1.ServiceMonitor{},
+		&promv1.ServiceMonitor{},
+	)
+}
+
+func TestRecoverPodMonitorDiscovers(t *testing.T) {
+	assertMonitorDiscoverRecovery(
+		t,
+		&promv1.PodMonitor{},
+		&promv1.PodMonitor{},
+	)
+}
+
+func TestMonitorDeleteCannotBeOverwrittenByStaleRecovery(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource any
+		builder  monitorDiscoverBuilder
+		remove   func(*Operator, any)
+	}{
+		{
+			name: "ServiceMonitor",
+			resource: &promv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+				Spec:       promv1.ServiceMonitorSpec{Endpoints: []promv1.Endpoint{{}}},
+			},
+			builder: func(any) []discover.Discover {
+				return []discover.Discover{&fakeDiscover{name: define.MonitorMeta{
+					Kind: monitorKindServiceMonitor, Namespace: "default", Name: "example",
+				}.ID()}}
+			},
+			remove: func(op *Operator, obj any) { op.handleServiceMonitorDelete(obj) },
+		},
+		{
+			name: "PodMonitor",
+			resource: &promv1.PodMonitor{
+				ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+				Spec: promv1.PodMonitorSpec{
+					PodMetricsEndpoints: []promv1.PodMetricsEndpoint{{}},
+				},
+			},
+			builder: func(any) []discover.Discover {
+				return []discover.Discover{&fakeDiscover{name: define.MonitorMeta{
+					Kind: monitorKindPodMonitor, Namespace: "default", Name: "example",
+				}.ID()}}
+			},
+			remove: func(op *Operator, obj any) { op.handlePodMonitorDelete(obj) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listed := make(chan struct{})
+			release := make(chan struct{})
+			lister := &fakeMonitorResourceLister{
+				objects: []any{tt.resource},
+				listed:  listed,
+				release: release,
+			}
+			op := &Operator{discovers: make(map[string]discover.Discover)}
+
+			recovered := make(chan error, 1)
+			go func() {
+				recovered <- op.recoverMonitorDiscovers(lister, tt.builder)
+			}()
+			<-listed
+
+			deleted := make(chan struct{})
+			go func() {
+				tt.remove(op, tt.resource)
+				close(deleted)
+			}()
+
+			select {
+			case <-deleted:
+			case <-time.After(100 * time.Millisecond):
+			}
+			close(release)
+			require.NoError(t, <-recovered)
+			<-deleted
+
+			assert.Empty(t, op.discovers)
+		})
+	}
+}
+
+func newDataIDRecoveryTestOperator(
+	watcher dataidwatcher.Watcher,
+) *Operator {
+	return &Operator{
+		ctx:               context.Background(),
+		client:            k8sfake.NewSimpleClientset(),
+		dw:                watcher,
+		objectsController: &objectsref.ObjectsController{},
+	}
+}
+
+func TestServiceMonitorDiscoversFromObjectRetriesAfterDataIDArrives(t *testing.T) {
+	watcher := &fakeDataIDWatcher{metricErr: errors.New("system dataid not found")}
+	op := newDataIDRecoveryTestOperator(watcher)
+	serviceMonitor := &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+		},
+		Spec: promv1.ServiceMonitorSpec{
+			Endpoints: []promv1.Endpoint{{}},
+		},
+	}
+
+	assert.Empty(t, op.serviceMonitorDiscoversFromObject(serviceMonitor))
+
+	watcher.metricDataID = newTestMetricDataID()
+	watcher.metricErr = nil
+	discovers := op.serviceMonitorDiscoversFromObject(serviceMonitor)
+	require.Len(t, discovers, 1)
+	assert.Equal(t, watcher.metricDataID, discovers[0].DataID())
+}
+
+func TestPodMonitorDiscoversFromObjectRetriesAfterDataIDArrives(t *testing.T) {
+	watcher := &fakeDataIDWatcher{metricErr: errors.New("system dataid not found")}
+	op := newDataIDRecoveryTestOperator(watcher)
+	podMonitor := &promv1.PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+		},
+		Spec: promv1.PodMonitorSpec{
+			PodMetricsEndpoints: []promv1.PodMetricsEndpoint{{}},
+		},
+	}
+
+	assert.Empty(t, op.podMonitorDiscoversFromObject(podMonitor))
+
+	watcher.metricDataID = newTestMetricDataID()
+	watcher.metricErr = nil
+	discovers := op.podMonitorDiscoversFromObject(podMonitor)
+	require.Len(t, discovers, 1)
+	assert.Equal(t, watcher.metricDataID, discovers[0].DataID())
+}
+
+func newTestMetricDataID() *bkv1beta1.DataID {
+	return &bkv1beta1.DataID{
+		ObjectMeta: metav1.ObjectMeta{Name: "custommetricdataid"},
+		Spec: bkv1beta1.DataIDSpec{
+			DataID: 1001,
+			Labels: map[string]string{
+				"bcs_cluster_id": "test-cluster",
+				"bk_biz_id":      "2",
+			},
+		},
+	}
+}
+
+func TestCreatePromScrapeConfigDiscoversRetriesAfterDataIDArrives(t *testing.T) {
+	previousKinds := configs.G().PromSDKinds
+	configs.G().PromSDKinds = configs.PromSDKinds{monitorKindKubernetesSd}
+	t.Cleanup(func() {
+		configs.G().PromSDKinds = previousKinds
+	})
+
+	dataID := newTestMetricDataID()
+	watcher := &fakeDataIDWatcher{
+		metricDataID: dataID,
+		metricErr:    errors.New("common dataid not found"),
+	}
+	op := &Operator{
+		ctx:               context.Background(),
+		client:            k8sfake.NewSimpleClientset(),
+		dw:                watcher,
+		objectsController: &objectsref.ObjectsController{},
+	}
+	scrapeConfigs := []resourceScrapConfig{
+		{
+			Namespace: "default",
+			Resource:  "secret/prometheus.yaml",
+			Config: config.ScrapeConfig{
+				JobName: "example",
+				ServiceDiscoveryConfigs: promdiscovery.Configs{
+					&promk8ssd.SDConfig{Role: promk8ssd.RolePod},
+				},
+			},
+		},
+	}
+
+	assert.Empty(t, op.createPromScrapeConfigDiscovers(scrapeConfigs))
+
+	watcher.metricErr = nil
+	discovers := op.createPromScrapeConfigDiscovers(scrapeConfigs)
+	require.Len(t, discovers, 1)
+	assert.Equal(t, dataID, discovers[0].DataID())
+}
+
+func TestReloadAllDiscoversKeepsExistingBehavior(t *testing.T) {
+	oldDataID := &bkv1beta1.DataID{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8smetricdataid"},
+		Spec:       bkv1beta1.DataIDSpec{DataID: 1001},
+	}
+	newDataID := oldDataID.DeepCopy()
+	newDataID.Spec.DataID = 1002
+
+	watcher := &fakeDataIDWatcher{metricDataID: newDataID}
+	existing := &fakeDiscover{name: "ServiceMonitor:default/example:0", dataID: oldDataID}
+	op := &Operator{
+		dw:        watcher,
+		discovers: map[string]discover.Discover{existing.Name(): existing},
+	}
+
+	op.reloadAllDiscovers()
+
+	assert.Same(t, newDataID, existing.dataID)
+	assert.Equal(t, 1, existing.reloadCount)
+	assert.Zero(t, existing.stopCount)
+}
+
+func TestSnapshotPromScrapeConfigs(t *testing.T) {
+	expected := resourceScrapConfig{
+		Namespace: "default",
+		Resource:  "secret/prometheus.yaml",
+		Config:    config.ScrapeConfig{JobName: "example"},
+	}
+	op := &Operator{
+		prevResourceScrapeConfigs: map[string]resourceScrapConfig{
+			"secret/prometheus.yaml/example": expected,
+		},
+	}
+
+	snapshot := op.snapshotPromScrapeConfigs()
+	delete(op.prevResourceScrapeConfigs, "secret/prometheus.yaml/example")
+
+	assert.Equal(t, []resourceScrapConfig{expected}, snapshot)
+}
+
+func TestPromSdReloadWaitsForRecoveryReconcile(t *testing.T) {
+	existing := resourceScrapConfig{
+		Resource: "secret/prometheus.yaml",
+		Config:   config.ScrapeConfig{JobName: "example"},
+	}
+	op := &Operator{
+		discovers: make(map[string]discover.Discover),
+		prevResourceScrapeConfigs: map[string]resourceScrapConfig{
+			"secret/prometheus.yaml/example": existing,
+		},
+	}
+
+	// 模拟恢复流程已进入临界区且持有旧快照。
+	op.promSdReconcileMut.Lock()
+	reloaded := make(chan struct{})
+	go func() {
+		op.reconcilePromScrapeConfigs(nil)
+		close(reloaded)
+	}()
+
+	select {
+	case <-reloaded:
+		t.Fatal("PromSD reload must wait for the recovery reconcile")
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.Contains(t, op.prevResourceScrapeConfigs, "secret/prometheus.yaml/example")
+
+	op.promSdReconcileMut.Unlock()
+	<-reloaded
+	assert.Empty(t, op.prevResourceScrapeConfigs)
+}

--- a/pkg/operator/operator/discover/shareddiscovery/shared_discovery.go
+++ b/pkg/operator/operator/discover/shareddiscovery/shared_discovery.go
@@ -152,24 +152,27 @@ func Register(uk string, createFunc func() (*SharedDiscovery, error)) error {
 	sharedDiscoveryLock.Lock()
 	defer sharedDiscoveryLock.Unlock()
 
-	sharedDiscoveryRefs[uk]++
-	if _, ok := sharedDiscoveryMap[uk]; !ok {
-		sd, err := createFunc()
-		if err != nil {
-			logger.Errorf("failed to create shared discovery (%s): %v", uk, err)
-			return err
-		}
-		gWg.Add(2)
-		go func() {
-			defer gWg.Done()
-			sd.watch()
-		}()
-		go func() {
-			defer gWg.Done()
-			sd.start()
-		}()
-		sharedDiscoveryMap[uk] = sd
+	if _, ok := sharedDiscoveryMap[uk]; ok {
+		sharedDiscoveryRefs[uk]++
+		return nil
 	}
+
+	sd, err := createFunc()
+	if err != nil {
+		logger.Errorf("failed to create shared discovery (%s): %v", uk, err)
+		return err
+	}
+	gWg.Add(2)
+	go func() {
+		defer gWg.Done()
+		sd.watch()
+	}()
+	go func() {
+		defer gWg.Done()
+		sd.start()
+	}()
+	sharedDiscoveryMap[uk] = sd
+	sharedDiscoveryRefs[uk]++
 
 	return nil
 }

--- a/pkg/operator/operator/discover/shareddiscovery/shared_discovery_test.go
+++ b/pkg/operator/operator/discover/shareddiscovery/shared_discovery_test.go
@@ -1,0 +1,44 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package shareddiscovery
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterDoesNotRetainReferenceWhenCreateFails(t *testing.T) {
+	const uk = "failed-discovery"
+
+	sharedDiscoveryLock.Lock()
+	oldRefs := sharedDiscoveryRefs
+	oldMap := sharedDiscoveryMap
+	sharedDiscoveryRefs = make(map[string]int)
+	sharedDiscoveryMap = make(map[string]*SharedDiscovery)
+	sharedDiscoveryLock.Unlock()
+	t.Cleanup(func() {
+		sharedDiscoveryLock.Lock()
+		sharedDiscoveryRefs = oldRefs
+		sharedDiscoveryMap = oldMap
+		sharedDiscoveryLock.Unlock()
+	})
+
+	err := Register(uk, func() (*SharedDiscovery, error) {
+		return nil, errors.New("create failed")
+	})
+
+	assert.EqualError(t, err, "create failed")
+	sharedDiscoveryLock.Lock()
+	defer sharedDiscoveryLock.Unlock()
+	assert.NotContains(t, sharedDiscoveryRefs, uk)
+	assert.NotContains(t, sharedDiscoveryMap, uk)
+}

--- a/pkg/operator/operator/operator.go
+++ b/pkg/operator/operator/operator.go
@@ -81,9 +81,10 @@ type Operator struct {
 	statefulSetSecretMap    map[string]struct{}
 	statefulSetSecretMut    sync.Mutex
 
-	dw           dataidwatcher.Watcher
-	discoversMut sync.RWMutex
-	discovers    map[string]discover.Discover
+	dw                  dataidwatcher.Watcher
+	discoversMut        sync.RWMutex
+	discovers           map[string]discover.Discover
+	monitorReconcileMut sync.Mutex
 
 	objectsController *objectsref.ObjectsController
 
@@ -91,8 +92,10 @@ type Operator struct {
 	statefulSetTaskCache map[int]map[string]struct{}
 	eventTaskCache       string
 
-	promSdConfigsBytes        map[SecretKey][]byte           // 无并发读写
-	prevResourceScrapeConfigs map[string]resourceScrapConfig // 无并发读写
+	promSdConfigsMut          sync.Mutex
+	promSdReconcileMut        sync.Mutex
+	promSdConfigsBytes        map[SecretKey][]byte
+	prevResourceScrapeConfigs map[string]resourceScrapConfig
 }
 
 func New(ctx context.Context, buildInfo BuildInfo) (*Operator, error) {
@@ -496,6 +499,21 @@ func (c *Operator) addOrUpdateDiscover(discover discover.Discover) error {
 	return nil
 }
 
+// addDiscoverIfAbsent 仅在 discover 尚未注册时启动并添加。
+func (c *Operator) addDiscoverIfAbsent(discover discover.Discover) (bool, error) {
+	c.discoversMut.Lock()
+	defer c.discoversMut.Unlock()
+
+	if _, ok := c.discovers[discover.Name()]; ok {
+		return false, nil
+	}
+	if err := discover.Start(); err != nil {
+		return false, err
+	}
+	c.discovers[discover.Name()] = discover
+	return true, nil
+}
+
 // deleteDiscoverByName 删除 discover
 func (c *Operator) deleteDiscoverByName(name string) {
 	c.discoversMut.Lock()
@@ -569,6 +587,7 @@ func (c *Operator) handleDataIDNotify() {
 			start := time.Now()
 			count++
 			c.reloadAllDiscovers()
+			c.recoverDataIDDependentDiscovers()
 			logger.Infof("reload discovers, count=%d, take: %v", count, time.Since(start))
 		}
 	}

--- a/pkg/operator/operator/podmonitor.go
+++ b/pkg/operator/operator/podmonitor.go
@@ -30,6 +30,9 @@ func podMonitorID(obj *promv1.PodMonitor) string {
 }
 
 func (c *Operator) handlePodMonitorAdd(obj any) {
+	c.monitorReconcileMut.Lock()
+	defer c.monitorReconcileMut.Unlock()
+
 	podMonitor, ok := obj.(*promv1.PodMonitor)
 	if !ok {
 		logger.Errorf("expected PodMonitor type, got %T", obj)
@@ -51,6 +54,9 @@ func (c *Operator) handlePodMonitorAdd(obj any) {
 }
 
 func (c *Operator) handlePodMonitorUpdate(oldObj any, newObj any) {
+	c.monitorReconcileMut.Lock()
+	defer c.monitorReconcileMut.Unlock()
+
 	old, ok := oldObj.(*promv1.PodMonitor)
 	if !ok {
 		logger.Errorf("expected PodMonitor type, got %T", oldObj)
@@ -87,6 +93,9 @@ func (c *Operator) handlePodMonitorUpdate(oldObj any, newObj any) {
 }
 
 func (c *Operator) handlePodMonitorDelete(obj any) {
+	c.monitorReconcileMut.Lock()
+	defer c.monitorReconcileMut.Unlock()
+
 	podMonitor, ok := obj.(*promv1.PodMonitor)
 	if !ok {
 		logger.Errorf("expected PodMonitor type, got %T", obj)

--- a/pkg/operator/operator/promsd.go
+++ b/pkg/operator/operator/promsd.go
@@ -70,6 +70,9 @@ func (c *Operator) getPromResourceScrapeConfigs() ([]resourceScrapConfig, bool) 
 		}
 	}
 
+	c.promSdConfigsMut.Lock()
+	defer c.promSdConfigsMut.Unlock()
+
 	eq := reflect.DeepEqual(c.promSdConfigsBytes, newRound) // 对比是否需要更新操作
 	c.promSdConfigsBytes = newRound
 	return rscs, !eq // changed
@@ -343,6 +346,12 @@ func (c *Operator) reloadPromScrapeConfigDiscovers() {
 	if !ok {
 		return
 	}
+	c.reconcilePromScrapeConfigs(resourceScrapeConfigs)
+}
+
+func (c *Operator) reconcilePromScrapeConfigs(resourceScrapeConfigs []resourceScrapConfig) {
+	c.promSdReconcileMut.Lock()
+	defer c.promSdReconcileMut.Unlock()
 
 	newRound := make(map[string]resourceScrapConfig)
 	for _, sc := range resourceScrapeConfigs {
@@ -357,6 +366,8 @@ func (c *Operator) reloadPromScrapeConfigDiscovers() {
 
 	var addOrUpdateScrapeConfigs []resourceScrapConfig
 	var removeScrapeConfigs []resourceScrapConfig
+
+	c.promSdConfigsMut.Lock()
 	for _, sc := range resourceScrapeConfigs {
 		uid := fmt.Sprintf("%s/%s", sc.Resource, sc.Config.JobName)
 		v, ok := c.prevResourceScrapeConfigs[uid]
@@ -378,6 +389,8 @@ func (c *Operator) reloadPromScrapeConfigDiscovers() {
 			logger.Infof("promsd remove (%s) scrapeConfig", uid)
 		}
 	}
+	c.prevResourceScrapeConfigs = newRound
+	c.promSdConfigsMut.Unlock()
 
 	// 模拟 monitor 资源监听变化
 	if len(addOrUpdateScrapeConfigs) > 0 {
@@ -386,10 +399,22 @@ func (c *Operator) reloadPromScrapeConfigDiscovers() {
 	if len(removeScrapeConfigs) > 0 {
 		c.handlePromScrapeConfigDiscovers(removeScrapeConfigs, opRemove)
 	}
-	c.prevResourceScrapeConfigs = newRound
 }
 
-func (c *Operator) handlePromScrapeConfigDiscovers(resourceScrapeConfigs []resourceScrapConfig, op string) {
+func (c *Operator) snapshotPromScrapeConfigs() []resourceScrapConfig {
+	c.promSdConfigsMut.Lock()
+	defer c.promSdConfigsMut.Unlock()
+
+	configs := make([]resourceScrapConfig, 0, len(c.prevResourceScrapeConfigs))
+	for _, scrapeConfig := range c.prevResourceScrapeConfigs {
+		configs = append(configs, scrapeConfig)
+	}
+	return configs
+}
+
+func (c *Operator) createPromScrapeConfigDiscovers(
+	resourceScrapeConfigs []resourceScrapConfig,
+) []discover.Discover {
 	var discovers []discover.Discover
 	kinds := configs.G().PromSDKinds
 	for i := 0; i < len(resourceScrapeConfigs); i++ {
@@ -442,7 +467,11 @@ func (c *Operator) handlePromScrapeConfigDiscovers(resourceScrapeConfigs []resou
 			}
 		}
 	}
+	return discovers
+}
 
+func (c *Operator) handlePromScrapeConfigDiscovers(resourceScrapeConfigs []resourceScrapConfig, op string) {
+	discovers := c.createPromScrapeConfigDiscovers(resourceScrapeConfigs)
 	switch op {
 	case opAddOrUpdate:
 		for _, dis := range discovers {

--- a/pkg/operator/operator/servicemonitor.go
+++ b/pkg/operator/operator/servicemonitor.go
@@ -29,6 +29,9 @@ func serviceMonitorID(obj *promv1.ServiceMonitor) string {
 }
 
 func (c *Operator) handleServiceMonitorAdd(obj any) {
+	c.monitorReconcileMut.Lock()
+	defer c.monitorReconcileMut.Unlock()
+
 	serviceMonitor, ok := obj.(*promv1.ServiceMonitor)
 	if !ok {
 		logger.Errorf("expected ServiceMonitor type, got %T", obj)
@@ -50,6 +53,9 @@ func (c *Operator) handleServiceMonitorAdd(obj any) {
 }
 
 func (c *Operator) handleServiceMonitorUpdate(oldObj any, newObj any) {
+	c.monitorReconcileMut.Lock()
+	defer c.monitorReconcileMut.Unlock()
+
 	old, ok := oldObj.(*promv1.ServiceMonitor)
 	if !ok {
 		logger.Errorf("expected ServiceMonitor type, got %T", oldObj)
@@ -86,6 +92,9 @@ func (c *Operator) handleServiceMonitorUpdate(oldObj any, newObj any) {
 }
 
 func (c *Operator) handleServiceMonitorDelete(obj any) {
+	c.monitorReconcileMut.Lock()
+	defer c.monitorReconcileMut.Unlock()
+
 	serviceMonitor, ok := obj.(*promv1.ServiceMonitor)
 	if !ok {
 		logger.Errorf("expected ServiceMonitor type, got %T", obj)


### PR DESCRIPTION
## Summary

- reconcile missing ServiceMonitor and PodMonitor discovers after DataID changes
- retry PromSD discover creation when its DataID becomes available
- keep existing discovers running and preserve the current DataID reload path
- protect PromSD caches from concurrent reload and recovery access

## Root cause

When a monitor resource was first handled before its matching DataID existed, no discover was registered. Later DataID notifications only reloaded registered discovers, so the missing resource was never retried until the monitor changed or the operator restarted.

## Verification

- `make test`
- `go test -race ./operator -count=1 -ldflags '-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore'`
- `go vet ./...`
- `git diff --check upstream/master...HEAD`
