### PR TITLE
fix(unify-query): 按类型过滤Doris联合选择所有字段 --bug=160579978

### DIFF
--- a/pkg/unify-query/internal/doris_parser/visitor.go
+++ b/pkg/unify-query/internal/doris_parser/visitor.go
@@ -12,6 +12,7 @@ package doris_parser
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	antlr "github.com/antlr4-go/antlr/v4"
@@ -121,6 +122,11 @@ type UnionProjectionField struct {
 type unionProjectionField struct {
 	field        string
 	validateName string
+}
+
+type selectAllUnionField struct {
+	projection unionProjectionField
+	fieldType  string
 }
 
 // collectColumnNamesFromSQL 从已经渲染完成的 SQL 片段里提取物理列名。
@@ -500,6 +506,26 @@ func (v *Statement) unionSelectList() string {
 
 	if selectSQL == Star || hasTopLevelWildcard(selectSQL) {
 		if len(v.Tables) > 1 && v.RejectSelectAllUnion {
+			fields, err := ExpandSelectAllUnionFields(v.Tables, v.TableFieldsMap)
+			if err != nil {
+				v.errNode = append(v.errNode, err.Error())
+				return Star
+			}
+			if len(fields) > 0 {
+				aliases := v.collectSelectAliases()
+				for alias := range collectAliasesFromSQL(selectSQL) {
+					addAlias(aliases, alias)
+				}
+				projectionFields := collectUnionProjectionFields(selectSQL, nil)
+				projectionFields = append(projectionFields, collectUnionProjectionFields(v.ItemString(GroupItem), aliases)...)
+				projectionFields = append(projectionFields, collectUnionProjectionFields(v.ItemString(OrderItem), aliases)...)
+				if err := validateUnionProjectionFields(v.Tables, projectionFields, v.TableFieldsMap); err != nil {
+					v.errNode = append(v.errNode, err.Error())
+					return Star
+				}
+				fields = appendMissingUnionFieldNames(fields, projectionFields)
+				return strings.Join(fields, ", ")
+			}
 			v.errNode = append(v.errNode, "doris multi-table union does not support SELECT *; use explicit fields")
 		}
 		return Star
@@ -507,9 +533,9 @@ func (v *Statement) unionSelectList() string {
 
 	// 多张 Doris 表合并时不能无条件 SELECT *：
 	// 历史表和当前表可能存在字段漂移，Doris 要求 UNION ALL 两侧列数一致。
-	// 因此外层 SQL 只依赖部分字段时，内层子查询只投影这些字段。
-	// 顶层 SELECT * 仍会被识别出来并在多表场景返回明确错误；COUNT(*) 不是顶层
-	// wildcard，不会被展开。若没有任何真实字段依赖，内层 UNION 使用常量投影即可保留行数语义。
+	// 因此外层 SQL 只依赖部分字段时，内层子查询只投影这些字段；顶层 SELECT *
+	// 在有表结构时会先转换成公共字段投影。COUNT(*) 不是顶层 wildcard，不会被展开。
+	// 若没有任何真实字段依赖，内层 UNION 使用常量投影即可保留行数语义。
 	aliases := v.collectSelectAliases()
 	for alias := range collectAliasesFromSQL(selectSQL) {
 		addAlias(aliases, alias)
@@ -561,6 +587,151 @@ func ValidateUnionProjectionFieldNames(tables []string, fields []UnionProjection
 		})
 	}
 	return validateUnionProjectionFields(tables, projectionFields, tableFieldsMap)
+}
+
+// ExpandSelectAllUnionFields converts SELECT * for Doris multi-table UNION into
+// a deterministic explicit projection over fields shared by every table.
+func ExpandSelectAllUnionFields(tables []string, tableFieldsMap TableFieldsMap) ([]string, error) {
+	fields, err := collectSelectAllUnionProjectionFields(tables, tableFieldsMap)
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	if err := validateUnionProjectionFields(tables, fields, tableFieldsMap); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(fields))
+	for _, field := range fields {
+		names = append(names, field.field)
+	}
+	return names, nil
+}
+
+func collectSelectAllUnionProjectionFields(tables []string, tableFieldsMap TableFieldsMap) ([]unionProjectionField, error) {
+	if len(tables) == 0 || len(tableFieldsMap) == 0 {
+		return nil, nil
+	}
+
+	common := make(map[string]selectAllUnionField)
+	for idx, table := range tables {
+		fieldsMap, ok := tableFieldsMap[table]
+		if !ok {
+			return nil, fmt.Errorf("doris multi-table union missing schema for table %s", table)
+		}
+		if idx == 0 {
+			for name, option := range fieldsMap {
+				name = strings.TrimSpace(name)
+				if name == "" || !option.Existed() || isUnsupportedUnionFieldType(option.FieldType) {
+					continue
+				}
+				key := strings.ToLower(name)
+				if _, ok := common[key]; ok {
+					continue
+				}
+				common[key] = selectAllUnionField{
+					projection: unionProjectionField{
+						field:        selectAllUnionProjectionField(name, option.FieldType),
+						validateName: name,
+					},
+					fieldType: option.FieldType,
+				}
+			}
+			continue
+		}
+
+		for key, field := range common {
+			option := fieldsMap.Field(field.projection.validateName)
+			if !option.Existed() ||
+				isUnsupportedUnionFieldType(option.FieldType) ||
+				!compatibleUnionFieldTypes(field.fieldType, option.FieldType) {
+				delete(common, key)
+			}
+		}
+	}
+
+	if len(common) == 0 {
+		return nil, fmt.Errorf("doris multi-table union SELECT * has no common fields")
+	}
+
+	keys := make([]string, 0, len(common))
+	for key := range common {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	fields := make([]unionProjectionField, 0, len(keys))
+	for _, key := range keys {
+		fields = append(fields, common[key].projection)
+	}
+	return fields, nil
+}
+
+func selectAllUnionProjectionField(field string, fieldType string) string {
+	field = unquoteUnionField(strings.TrimSpace(field))
+	if !strings.Contains(field, ".") {
+		return quoteUnionField(field)
+	}
+	return fmt.Sprintf("CAST(%s AS %s) AS `%s`", dorisObjectFieldExpression(field), dorisCastType(fieldType), field)
+}
+
+func dorisObjectFieldExpression(field string) string {
+	parts := strings.Split(field, ".")
+	if len(parts) == 0 {
+		return field
+	}
+
+	mapFieldSet := map[string]struct{}{
+		"resource":   {},
+		"attributes": {},
+	}
+
+	var builder strings.Builder
+	sep := ""
+	for idx, part := range parts {
+		switch idx {
+		case 0:
+			sep = "['"
+		case len(parts) - 1:
+			sep = "']"
+		}
+
+		builder.WriteString(part)
+		builder.WriteString(sep)
+		if _, ok := mapFieldSet[part]; ok {
+			sep = "."
+		} else if sep != "." {
+			sep = "']['"
+		}
+	}
+	return builder.String()
+}
+
+func dorisCastType(fieldType string) string {
+	fieldType = strings.ToUpper(strings.TrimSpace(fieldType))
+	if strings.HasPrefix(fieldType, "ARRAY<") && strings.HasSuffix(fieldType, ">") {
+		return strings.TrimSuffix(strings.TrimPrefix(fieldType, "ARRAY<"), ">") + " ARRAY"
+	}
+	if fieldType == "" {
+		return "STRING"
+	}
+	return fieldType
+}
+
+func appendMissingUnionFieldNames(fields []string, extraFields []unionProjectionField) []string {
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		seen[field] = struct{}{}
+	}
+	for _, field := range extraFields {
+		if _, ok := seen[field.field]; ok {
+			continue
+		}
+		seen[field.field] = struct{}{}
+		fields = append(fields, field.field)
+	}
+	return fields
 }
 
 func validateUnionProjectionFields(tables []string, fields []unionProjectionField, tableFieldsMap TableFieldsMap) error {
@@ -633,6 +804,11 @@ func unionFieldOption(fieldsMap metadata.FieldsMap, field string, validateName s
 
 func unquoteUnionField(field string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(field, "`"), "`")
+}
+
+func quoteUnionField(field string) string {
+	field = unquoteUnionField(strings.TrimSpace(field))
+	return fmt.Sprintf("`%s`", field)
 }
 
 func isUnsupportedUnionFieldType(fieldType string) bool {

--- a/pkg/unify-query/internal/doris_parser/visitor.go
+++ b/pkg/unify-query/internal/doris_parser/visitor.go
@@ -27,6 +27,7 @@ import (
 const (
 	Star                 = "*"
 	unionDummyProjection = "1"
+	maxDorisDecimalWidth = 38
 )
 
 const (
@@ -752,9 +753,9 @@ func dorisCastType(fieldType string) string {
 }
 
 func rejectSelectAllExtraProjectionFields(fields []string, extraFields []unionProjectionField) error {
-	seen := make(map[string]struct{}, len(fields))
+	seen := make(map[string]struct{}, len(fields)*2)
 	for _, field := range fields {
-		seen[field] = struct{}{}
+		addSelectAllProjectionOutputName(seen, field)
 	}
 	for _, field := range extraFields {
 		if _, ok := seen[field.field]; !ok {
@@ -762,6 +763,19 @@ func rejectSelectAllExtraProjectionFields(fields []string, extraFields []unionPr
 		}
 	}
 	return nil
+}
+
+func addSelectAllProjectionOutputName(seen map[string]struct{}, field string) {
+	seen[field] = struct{}{}
+	upperField := strings.ToUpper(field)
+	idx := strings.LastIndex(upperField, " AS `")
+	if idx < 0 {
+		return
+	}
+	alias := field[idx+len(" AS "):]
+	if strings.HasPrefix(alias, "`") && strings.HasSuffix(alias, "`") {
+		seen[alias] = struct{}{}
+	}
 }
 
 func validateUnionProjectionFields(tables []string, fields []unionProjectionField, tableFieldsMap TableFieldsMap) error {
@@ -860,32 +874,36 @@ func safeUnionFieldType(left, right string) (string, bool) {
 	if normalized != normalizeUnionFieldType(right) {
 		return "", false
 	}
-	return safeNormalizedUnionFieldType(normalized, left, right), true
+	return safeNormalizedUnionFieldType(normalized, left, right)
 }
 
-func safeNormalizedUnionFieldType(normalized, left, right string) string {
+func safeNormalizedUnionFieldType(normalized, left, right string) (string, bool) {
 	if strings.HasPrefix(normalized, "array:") {
-		return safeNormalizedUnionFieldType(strings.TrimPrefix(normalized, "array:"), left, right) + " ARRAY"
+		fieldType, ok := safeNormalizedUnionFieldType(strings.TrimPrefix(normalized, "array:"), left, right)
+		if !ok {
+			return "", false
+		}
+		return fieldType + " ARRAY", true
 	}
 
 	switch normalized {
 	case "string":
-		return "TEXT"
+		return "TEXT", true
 	case "integer":
 		if baseUnionFieldType(left) == "largeint" || baseUnionFieldType(right) == "largeint" {
-			return "LARGEINT"
+			return "LARGEINT", true
 		}
-		return "BIGINT"
+		return "BIGINT", true
 	case "decimal":
 		return safeDecimalUnionFieldType(left, right)
 	case "number":
-		return "DOUBLE"
+		return "DOUBLE", true
 	case "boolean":
-		return "BOOLEAN"
+		return "BOOLEAN", true
 	case "time":
-		return "DATETIME"
+		return "DATETIME", true
 	default:
-		return dorisCastType(left)
+		return dorisCastType(left), true
 	}
 }
 
@@ -910,11 +928,11 @@ type decimalUnionFieldSpec struct {
 	hasParams bool
 }
 
-func safeDecimalUnionFieldType(left, right string) string {
+func safeDecimalUnionFieldType(left, right string) (string, bool) {
 	leftSpec, leftOK := decimalUnionFieldSpecFromType(left)
 	rightSpec, rightOK := decimalUnionFieldSpecFromType(right)
 	if !leftOK || !rightOK {
-		return dorisCastType(left)
+		return dorisCastType(left), true
 	}
 	if leftSpec.hasParams && rightSpec.hasParams {
 		kind := "DECIMAL"
@@ -923,15 +941,19 @@ func safeDecimalUnionFieldType(left, right string) string {
 		}
 		scale := max(leftSpec.scale, rightSpec.scale)
 		integerDigits := max(leftSpec.precision-leftSpec.scale, rightSpec.precision-rightSpec.scale)
-		return fmt.Sprintf("%s(%d,%d)", kind, integerDigits+scale, scale)
+		precision := integerDigits + scale
+		if precision > maxDorisDecimalWidth {
+			return "", false
+		}
+		return fmt.Sprintf("%s(%d,%d)", kind, precision, scale), true
 	}
 	if strings.EqualFold(strings.TrimSpace(left), strings.TrimSpace(right)) {
-		return dorisCastType(left)
+		return dorisCastType(left), true
 	}
 	if leftSpec.kind == "decimalv3" || rightSpec.kind == "decimalv3" {
-		return "DECIMALV3"
+		return "DECIMALV3", true
 	}
-	return "DECIMAL"
+	return "DECIMAL", true
 }
 
 func decimalUnionFieldSpecFromType(fieldType string) (decimalUnionFieldSpec, bool) {

--- a/pkg/unify-query/internal/doris_parser/visitor.go
+++ b/pkg/unify-query/internal/doris_parser/visitor.go
@@ -415,6 +415,14 @@ func hasTopLevelWildcard(s string) bool {
 		return true
 	}
 
+	return scanTopLevelWildcard(s, isWildcardToken)
+}
+
+func hasTopLevelQualifiedWildcard(s string) bool {
+	return scanTopLevelWildcard(s, isQualifiedWildcardToken)
+}
+
+func scanTopLevelWildcard(s string, match func(string, int) bool) bool {
 	depth := 0
 	for idx := 0; idx < len(s); idx++ {
 		switch s[idx] {
@@ -439,7 +447,7 @@ func hasTopLevelWildcard(s string) bool {
 				return true
 			}
 		case '*':
-			if depth == 0 && isWildcardToken(s, idx) {
+			if depth == 0 && match(s, idx) {
 				return true
 			}
 		}
@@ -498,11 +506,26 @@ func isDistinctStarExpression(s string) bool {
 func isWildcardToken(s string, idx int) bool {
 	prev := previousNonSpaceByte(s, idx)
 	next := nextNonSpaceByte(s, idx+1)
-	return (prev == 0 || prev == ',' || prev == '.') && (next == 0 || next == ',')
+	return (prev == 0 || prev == ',') && (next == 0 || next == ',')
+}
+
+func isQualifiedWildcardToken(s string, idx int) bool {
+	prev := previousNonSpaceByte(s, idx)
+	next := nextNonSpaceByte(s, idx+1)
+	return prev == '.' && (next == 0 || next == ',')
 }
 
 func (v *Statement) unionSelectList() string {
 	selectSQL := v.ItemString(SelectItem)
+
+	if hasTopLevelQualifiedWildcard(selectSQL) {
+		// 多表 UNION 会把 FROM 改写成 combined_data 子查询，原始表别名不再存在。
+		// 因此只有 plain * 可以按公共字段展开，t.* 这类 qualified wildcard 继续要求显式字段。
+		if len(v.Tables) > 1 && v.RejectSelectAllUnion {
+			v.errNode = append(v.errNode, "doris multi-table union does not support SELECT *; use explicit fields")
+		}
+		return Star
+	}
 
 	if selectSQL == Star || hasTopLevelWildcard(selectSQL) {
 		if len(v.Tables) > 1 && v.RejectSelectAllUnion {

--- a/pkg/unify-query/internal/doris_parser/visitor.go
+++ b/pkg/unify-query/internal/doris_parser/visitor.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	antlr "github.com/antlr4-go/antlr/v4"
@@ -546,7 +547,10 @@ func (v *Statement) unionSelectList() string {
 					v.errNode = append(v.errNode, err.Error())
 					return Star
 				}
-				fields = appendMissingUnionFieldNames(fields, projectionFields)
+				if err := rejectSelectAllExtraProjectionFields(fields, projectionFields); err != nil {
+					v.errNode = append(v.errNode, err.Error())
+					return Star
+				}
 				return strings.Join(fields, ", ")
 			}
 			v.errNode = append(v.errNode, "doris multi-table union does not support SELECT *; use explicit fields")
@@ -747,19 +751,17 @@ func dorisCastType(fieldType string) string {
 	return fieldType
 }
 
-func appendMissingUnionFieldNames(fields []string, extraFields []unionProjectionField) []string {
+func rejectSelectAllExtraProjectionFields(fields []string, extraFields []unionProjectionField) error {
 	seen := make(map[string]struct{}, len(fields))
 	for _, field := range fields {
 		seen[field] = struct{}{}
 	}
 	for _, field := range extraFields {
-		if _, ok := seen[field.field]; ok {
-			continue
+		if _, ok := seen[field.field]; !ok {
+			return fmt.Errorf("doris multi-table union SELECT * cannot be combined with field dependency %s; use explicit fields", field.field)
 		}
-		seen[field.field] = struct{}{}
-		fields = append(fields, field.field)
 	}
-	return fields
+	return nil
 }
 
 func validateUnionProjectionFields(tables []string, fields []unionProjectionField, tableFieldsMap TableFieldsMap) error {
@@ -874,6 +876,8 @@ func safeNormalizedUnionFieldType(normalized, left, right string) string {
 			return "LARGEINT"
 		}
 		return "BIGINT"
+	case "decimal":
+		return safeDecimalUnionFieldType(left, right)
 	case "number":
 		return "DOUBLE"
 	case "boolean":
@@ -899,6 +903,79 @@ func baseUnionFieldType(fieldType string) string {
 	return strings.TrimSpace(t)
 }
 
+type decimalUnionFieldSpec struct {
+	kind      string
+	precision int
+	scale     int
+	hasParams bool
+}
+
+func safeDecimalUnionFieldType(left, right string) string {
+	leftSpec, leftOK := decimalUnionFieldSpecFromType(left)
+	rightSpec, rightOK := decimalUnionFieldSpecFromType(right)
+	if !leftOK || !rightOK {
+		return dorisCastType(left)
+	}
+	if leftSpec.hasParams && rightSpec.hasParams {
+		kind := "DECIMAL"
+		if leftSpec.kind == "decimalv3" || rightSpec.kind == "decimalv3" {
+			kind = "DECIMALV3"
+		}
+		scale := max(leftSpec.scale, rightSpec.scale)
+		integerDigits := max(leftSpec.precision-leftSpec.scale, rightSpec.precision-rightSpec.scale)
+		return fmt.Sprintf("%s(%d,%d)", kind, integerDigits+scale, scale)
+	}
+	if strings.EqualFold(strings.TrimSpace(left), strings.TrimSpace(right)) {
+		return dorisCastType(left)
+	}
+	if leftSpec.kind == "decimalv3" || rightSpec.kind == "decimalv3" {
+		return "DECIMALV3"
+	}
+	return "DECIMAL"
+}
+
+func decimalUnionFieldSpecFromType(fieldType string) (decimalUnionFieldSpec, bool) {
+	t := strings.ToLower(strings.TrimSpace(fieldType))
+	if strings.HasPrefix(t, "array<") && strings.HasSuffix(t, ">") {
+		return decimalUnionFieldSpecFromType(t[len("array<") : len(t)-1])
+	}
+	if strings.HasSuffix(t, " array") {
+		return decimalUnionFieldSpecFromType(strings.TrimSuffix(t, " array"))
+	}
+
+	base := t
+	params := ""
+	if idx := strings.IndexByte(t, '('); idx >= 0 {
+		base = strings.TrimSpace(t[:idx])
+		params = strings.TrimSuffix(t[idx+1:], ")")
+	}
+	if base != "decimal" && base != "decimalv2" && base != "decimalv3" {
+		return decimalUnionFieldSpec{}, false
+	}
+
+	spec := decimalUnionFieldSpec{kind: base}
+	if params == "" {
+		return spec, true
+	}
+
+	parts := strings.Split(params, ",")
+	precision, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return spec, true
+	}
+	scale := 0
+	if len(parts) > 1 {
+		scale, err = strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return spec, true
+		}
+	}
+	spec.precision = precision
+	spec.scale = scale
+	spec.hasParams = true
+	return spec, true
+}
+
 func normalizeUnionFieldType(fieldType string) string {
 	t := strings.ToLower(strings.TrimSpace(fieldType))
 	if strings.HasPrefix(t, "array<") && strings.HasSuffix(t, ">") {
@@ -916,7 +993,9 @@ func normalizeUnionFieldType(fieldType string) string {
 		return "string"
 	case "tinyint", "smallint", "int", "integer", "bigint", "largeint":
 		return "integer"
-	case "float", "double", "decimal", "decimalv3":
+	case "decimal", "decimalv2", "decimalv3":
+		return "decimal"
+	case "float", "double":
 		return "number"
 	case "bool", "boolean":
 		return "boolean"

--- a/pkg/unify-query/internal/doris_parser/visitor.go
+++ b/pkg/unify-query/internal/doris_parser/visitor.go
@@ -377,11 +377,11 @@ func isIdentifierPartOfNumericLiteral(s string, start int) bool {
 func isSQLKeyword(name string) bool {
 	switch strings.ToUpper(name) {
 	case "AND", "ARRAY", "AS", "ASC", "BETWEEN", "BIGINT", "BOOL", "BOOLEAN", "BY", "CASE", "CAST",
-		"DATE", "DATETIME", "DECIMAL", "DESC", "DISTINCT", "DOUBLE", "ELSE", "END", "FALSE", "FLOAT",
-		"FROM", "GROUP", "IN", "INT", "INTEGER", "IS", "LIKE", "LIMIT", "MATCH_ALL", "MATCH_ANY",
+		"DATE", "DATETIME", "DAY", "DECIMAL", "DESC", "DISTINCT", "DOUBLE", "ELSE", "END", "FALSE", "FLOAT",
+		"FROM", "GROUP", "HOUR", "IN", "INT", "INTEGER", "IS", "LIKE", "LIMIT", "MATCH_ALL", "MATCH_ANY",
 		"MATCH_PHRASE", "MATCH_PHRASE_EDGE", "MATCH_PHRASE_PREFIX", "MATCH_REGEXP",
-		"NOT", "NULL", "OR", "ORDER", "REGEXP", "SELECT", "STRING", "TEXT", "THEN", "TIME", "TIMESTAMP",
-		"TRUE", "VARCHAR", "WHEN", "WHERE":
+		"MINUTE", "MONTH", "NOT", "NULL", "OR", "ORDER", "QUARTER", "REGEXP", "SECOND", "SELECT",
+		"STRING", "TEXT", "THEN", "TIME", "TIMESTAMP", "TRUE", "VARCHAR", "WEEK", "WHEN", "WHERE", "YEAR":
 		return true
 	default:
 		return false
@@ -825,6 +825,12 @@ func validateUnionProjectionFields(tables []string, fields []unionProjectionFiel
 			continue
 		}
 		seen[key] = struct{}{}
+		if ok, err := validateRootObjectUnionField(tables, field.field, name, tableFieldsMap); ok || err != nil {
+			if err != nil {
+				return err
+			}
+			continue
+		}
 		var base metadata.FieldOption
 		var baseTable string
 		for _, table := range tables {
@@ -854,6 +860,99 @@ func validateUnionProjectionFields(tables []string, fields []unionProjectionFiel
 	return nil
 }
 
+// validateRootObjectUnionField 校验直接投影对象 root 的场景。
+//
+// 例如 SELECT dimensions 时，schema 往往只有 dimensions.xxx leaf，没有
+// dimensions root 字段。这里按完整 leaf 集合比较，避免随机选中某个 leaf 后
+// 把两张完全相同的对象 schema 误判为类型不兼容。
+func validateRootObjectUnionField(tables []string, field string, validateName string, tableFieldsMap TableFieldsMap) (bool, error) {
+	rootName := unquoteUnionField(field)
+	if validateName != rootName {
+		return false, nil
+	}
+
+	var baseTable string
+	var baseFields map[string]rootObjectUnionField
+	for _, table := range tables {
+		fieldsMap, ok := tableFieldsMap[table]
+		if !ok {
+			return false, fmt.Errorf("doris multi-table union missing schema for table %s", table)
+		}
+		if fieldsMap.Field(rootName).Existed() {
+			return false, nil
+		}
+		fields := rootObjectUnionFields(fieldsMap, rootName)
+		if len(fields) == 0 {
+			if baseFields == nil {
+				return false, nil
+			}
+			return true, fmt.Errorf("doris multi-table union field %s is missing from table %s", field, table)
+		}
+		if baseFields == nil {
+			baseFields = fields
+			baseTable = table
+			continue
+		}
+		if err := validateRootObjectUnionFields(baseTable, baseFields, table, fields); err != nil {
+			return true, err
+		}
+	}
+	return baseFields != nil, nil
+}
+
+type rootObjectUnionField struct {
+	name   string
+	option metadata.FieldOption
+}
+
+func rootObjectUnionFields(fieldsMap metadata.FieldsMap, rootName string) map[string]rootObjectUnionField {
+	prefix := rootName + "."
+	fields := make(map[string]rootObjectUnionField)
+	for fieldName, option := range fieldsMap {
+		if !option.Existed() || len(fieldName) <= len(prefix) || !strings.EqualFold(fieldName[:len(prefix)], prefix) {
+			continue
+		}
+		fields[strings.ToLower(fieldName)] = rootObjectUnionField{name: fieldName, option: option}
+	}
+	return fields
+}
+
+func validateRootObjectUnionFields(
+	baseTable string,
+	baseFields map[string]rootObjectUnionField,
+	table string,
+	fields map[string]rootObjectUnionField,
+) error {
+	for key, baseField := range baseFields {
+		fieldOption, ok := fields[key]
+		if !ok {
+			return fmt.Errorf("doris multi-table union field %s is missing from table %s", quoteUnionField(baseField.name), table)
+		}
+		if isUnsupportedUnionFieldType(fieldOption.option.FieldType) {
+			return fmt.Errorf("doris multi-table union field %s in table %s has unsupported type %s", quoteUnionField(fieldOption.name), table, fieldOption.option.FieldType)
+		}
+		if !compatibleUnionFieldTypes(baseField.option.FieldType, fieldOption.option.FieldType) {
+			return fmt.Errorf(
+				"doris multi-table union field %s type mismatch: table %s has %s, table %s has %s",
+				quoteUnionField(fieldOption.name), baseTable, baseField.option.FieldType, table, fieldOption.option.FieldType,
+			)
+		}
+	}
+	for key, fieldOption := range fields {
+		if _, ok := baseFields[key]; ok {
+			continue
+		}
+		return fmt.Errorf("doris multi-table union field %s is missing from table %s", quoteUnionField(fieldOption.name), baseTable)
+	}
+	return nil
+}
+
+// unionFieldOption 解析 UNION 投影字段对应的 schema。
+//
+// 对象字段表达式渲染后会使用 root 列，例如 dimensions['pipelineName'] 会投影为
+// `dimensions`，而 schema 里通常只有 dimensions.pipelineName 这样的 leaf 字段。
+// validateName 用于传递已知 leaf；直接投影 root 对象时，会先按完整 leaf 集合校验，
+// 再进入这里的兜底逻辑。
 func unionFieldOption(fieldsMap metadata.FieldsMap, field string, validateName string) (metadata.FieldOption, bool) {
 	fieldOption := fieldsMap.Field(validateName)
 	if fieldOption.Existed() {
@@ -869,8 +968,18 @@ func unionFieldOption(fieldsMap metadata.FieldsMap, field string, validateName s
 		return metadata.FieldOption{}, false
 	}
 
+	// 兼容只传 root 对象名的旧调用方：选择固定顺序的 leaf，避免依赖 Go map
+	// 的随机遍历顺序导致同一份 schema 偶发类型误判。
 	prefix := rootName + "."
-	for fieldName, option := range fieldsMap {
+	fieldNames := make([]string, 0, len(fieldsMap))
+	for fieldName := range fieldsMap {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Slice(fieldNames, func(i, j int) bool {
+		return strings.ToLower(fieldNames[i]) < strings.ToLower(fieldNames[j])
+	})
+	for _, fieldName := range fieldNames {
+		option := fieldsMap[fieldName]
 		if strings.HasPrefix(fieldName, prefix) && option.Existed() {
 			return option, true
 		}
@@ -1053,7 +1162,7 @@ func normalizeUnionFieldType(fieldType string) string {
 		return "number"
 	case "bool", "boolean":
 		return "boolean"
-	case "date", "datetime", "timestamp":
+	case "date", "datev1", "datev2", "datetime", "datetimev1", "datetimev2", "timestamp":
 		return "time"
 	default:
 		return t

--- a/pkg/unify-query/internal/doris_parser/visitor.go
+++ b/pkg/unify-query/internal/doris_parser/visitor.go
@@ -758,15 +758,19 @@ func rejectSelectAllExtraProjectionFields(fields []string, extraFields []unionPr
 		addSelectAllProjectionOutputName(seen, field)
 	}
 	for _, field := range extraFields {
-		if _, ok := seen[field.field]; !ok {
-			return fmt.Errorf("doris multi-table union SELECT * cannot be combined with field dependency %s; use explicit fields", field.field)
+		if selectAllProjectionOutputNameExists(seen, field.field) {
+			continue
 		}
+		return fmt.Errorf("doris multi-table union SELECT * cannot be combined with field dependency %s; use explicit fields", field.field)
 	}
 	return nil
 }
 
 func addSelectAllProjectionOutputName(seen map[string]struct{}, field string) {
 	seen[field] = struct{}{}
+	if key := normalizedSelectAllProjectionName(field); key != "" {
+		seen[key] = struct{}{}
+	}
 	upperField := strings.ToUpper(field)
 	idx := strings.LastIndex(upperField, " AS `")
 	if idx < 0 {
@@ -775,7 +779,35 @@ func addSelectAllProjectionOutputName(seen map[string]struct{}, field string) {
 	alias := field[idx+len(" AS "):]
 	if strings.HasPrefix(alias, "`") && strings.HasSuffix(alias, "`") {
 		seen[alias] = struct{}{}
+		if key := normalizedSelectAllProjectionName(alias); key != "" {
+			seen[key] = struct{}{}
+		}
 	}
+}
+
+func selectAllProjectionOutputNameExists(seen map[string]struct{}, field string) bool {
+	if _, ok := seen[field]; ok {
+		return true
+	}
+	if key := normalizedSelectAllProjectionName(field); key != "" {
+		_, ok := seen[key]
+		return ok
+	}
+	return false
+}
+
+func normalizedSelectAllProjectionName(field string) string {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return ""
+	}
+	if strings.HasPrefix(field, "`") && strings.HasSuffix(field, "`") {
+		field = unquoteUnionField(field)
+	}
+	if strings.ContainsAny(field, " ()") {
+		return ""
+	}
+	return strings.ToLower(field)
 }
 
 func validateUnionProjectionFields(tables []string, fields []unionProjectionField, tableFieldsMap TableFieldsMap) error {

--- a/pkg/unify-query/internal/doris_parser/visitor.go
+++ b/pkg/unify-query/internal/doris_parser/visitor.go
@@ -415,14 +415,14 @@ func hasTopLevelWildcard(s string) bool {
 		return true
 	}
 
-	return scanTopLevelWildcard(s, isWildcardToken)
+	return scanTopLevelWildcard(s, isWildcardToken, true)
 }
 
 func hasTopLevelQualifiedWildcard(s string) bool {
-	return scanTopLevelWildcard(s, isQualifiedWildcardToken)
+	return scanTopLevelWildcard(s, isQualifiedWildcardToken, false)
 }
 
-func scanTopLevelWildcard(s string, match func(string, int) bool) bool {
+func scanTopLevelWildcard(s string, match func(string, int) bool, matchDistinct bool) bool {
 	depth := 0
 	for idx := 0; idx < len(s); idx++ {
 		switch s[idx] {
@@ -443,7 +443,7 @@ func scanTopLevelWildcard(s string, match func(string, int) bool) bool {
 				depth--
 			}
 		default:
-			if depth == 0 && isDistinctStarAt(s, idx) {
+			if matchDistinct && depth == 0 && isDistinctStarAt(s, idx) {
 				return true
 			}
 		case '*':
@@ -666,11 +666,16 @@ func collectSelectAllUnionProjectionFields(tables []string, tableFieldsMap Table
 
 		for key, field := range common {
 			option := fieldsMap.Field(field.projection.validateName)
+			safeType, compatible := safeUnionFieldType(field.fieldType, option.FieldType)
 			if !option.Existed() ||
 				isUnsupportedUnionFieldType(option.FieldType) ||
-				!compatibleUnionFieldTypes(field.fieldType, option.FieldType) {
+				!compatible {
 				delete(common, key)
+				continue
 			}
+			field.fieldType = safeType
+			field.projection.field = selectAllUnionProjectionField(field.projection.validateName, safeType)
+			common[key] = field
 		}
 	}
 
@@ -844,7 +849,54 @@ func isUnsupportedUnionFieldType(fieldType string) bool {
 }
 
 func compatibleUnionFieldTypes(left, right string) bool {
-	return normalizeUnionFieldType(left) == normalizeUnionFieldType(right)
+	_, ok := safeUnionFieldType(left, right)
+	return ok
+}
+
+func safeUnionFieldType(left, right string) (string, bool) {
+	normalized := normalizeUnionFieldType(left)
+	if normalized != normalizeUnionFieldType(right) {
+		return "", false
+	}
+	return safeNormalizedUnionFieldType(normalized, left, right), true
+}
+
+func safeNormalizedUnionFieldType(normalized, left, right string) string {
+	if strings.HasPrefix(normalized, "array:") {
+		return safeNormalizedUnionFieldType(strings.TrimPrefix(normalized, "array:"), left, right) + " ARRAY"
+	}
+
+	switch normalized {
+	case "string":
+		return "TEXT"
+	case "integer":
+		if baseUnionFieldType(left) == "largeint" || baseUnionFieldType(right) == "largeint" {
+			return "LARGEINT"
+		}
+		return "BIGINT"
+	case "number":
+		return "DOUBLE"
+	case "boolean":
+		return "BOOLEAN"
+	case "time":
+		return "DATETIME"
+	default:
+		return dorisCastType(left)
+	}
+}
+
+func baseUnionFieldType(fieldType string) string {
+	t := strings.ToLower(strings.TrimSpace(fieldType))
+	if strings.HasPrefix(t, "array<") && strings.HasSuffix(t, ">") {
+		return baseUnionFieldType(t[len("array<") : len(t)-1])
+	}
+	if strings.HasSuffix(t, " array") {
+		return baseUnionFieldType(strings.TrimSuffix(t, " array"))
+	}
+	if idx := strings.IndexByte(t, '('); idx >= 0 {
+		t = t[:idx]
+	}
+	return strings.TrimSpace(t)
 }
 
 func normalizeUnionFieldType(fieldType string) string {

--- a/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
+++ b/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
@@ -69,6 +69,11 @@ func TestCollectColumnNamesFromSQLForUnion(t *testing.T) {
 			sql:      "`log` MATCH_ANY 'x', `message` MATCH_PHRASE_EDGE 'y', `path` MATCH_PHRASE_PREFIX 'z', `trace_id` MATCH_REGEXP '.*'",
 			expected: []string{"`log`", "`message`", "`path`", "`trace_id`"},
 		},
+		{
+			name:     "TIMESTAMPDIFF 时间单位不当作字段",
+			sql:      "TIMESTAMPDIFF(DAY, start_time, end_time) AS duration_days",
+			expected: []string{"`start_time`", "`end_time`"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -431,6 +436,96 @@ func TestStatementUnionSelectListValidatesRequestedObjectLeaf(t *testing.T) {
 	}
 
 	assert.Equal(t, "`dimensions`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
+}
+
+func TestStatementUnionSelectListValidatesRootObjectLeavesDeterministically(t *testing.T) {
+	stmt := &Statement{
+		Tables: []string{"`db_his`.doris", "`db_current`.doris"},
+		TableFieldsMap: TableFieldsMap{
+			"`db_his`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"dimensions.retry_count":  {FieldType: "int"},
+			},
+			"`db_current`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"dimensions.retry_count":  {FieldType: "int"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "dimensions"},
+		},
+	}
+
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, "`dimensions`", stmt.unionSelectList())
+		assert.NoError(t, stmt.Error())
+	}
+}
+
+func TestStatementUnionSelectListRejectsRootObjectLeafMismatch(t *testing.T) {
+	stmt := &Statement{
+		Tables: []string{"`db_his`.doris", "`db_current`.doris"},
+		TableFieldsMap: TableFieldsMap{
+			"`db_his`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"dimensions.retry_count":  {FieldType: "int"},
+			},
+			"`db_current`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"dimensions.retry_count":  {FieldType: "double"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "dimensions"},
+		},
+	}
+
+	assert.Equal(t, "`dimensions`", stmt.unionSelectList())
+	assert.ErrorContains(t, stmt.Error(), "field `dimensions.retry_count` type mismatch")
+}
+
+func TestStatementUnionSelectListAllowsDorisV2TimeTypes(t *testing.T) {
+	stmt := &Statement{
+		Tables: []string{"`db_his`.doris", "`db_current`.doris"},
+		TableFieldsMap: TableFieldsMap{
+			"`db_his`.doris": {
+				"event_date": {FieldType: "DATE"},
+				"event_time": {FieldType: "DATETIME"},
+			},
+			"`db_current`.doris": {
+				"event_date": {FieldType: "DATEV2"},
+				"event_time": {FieldType: "DATETIMEV2"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "event_date, event_time"},
+		},
+	}
+
+	assert.Equal(t, "`event_date`, `event_time`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
+}
+
+func TestStatementUnionSelectListAllowsTimestampdiffTimeUnit(t *testing.T) {
+	stmt := &Statement{
+		Tables: []string{"`db_his`.doris", "`db_current`.doris"},
+		TableFieldsMap: TableFieldsMap{
+			"`db_his`.doris": {
+				"start_time": {FieldType: "DATETIME"},
+				"end_time":   {FieldType: "DATETIME"},
+			},
+			"`db_current`.doris": {
+				"start_time": {FieldType: "DATETIMEV2"},
+				"end_time":   {FieldType: "DATETIMEV2"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "TIMESTAMPDIFF(DAY, start_time, end_time) AS duration_days"},
+		},
+	}
+
+	assert.Equal(t, "`start_time`, `end_time`", stmt.unionSelectList())
 	assert.NoError(t, stmt.Error())
 }
 

--- a/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
+++ b/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
@@ -212,17 +212,35 @@ func TestStatementUnionSelectListFallbacks(t *testing.T) {
 	}
 }
 
-func TestStatementUnionSelectListRejectsMultiTableWildcard(t *testing.T) {
+func TestStatementUnionSelectListExpandsMultiTableWildcard(t *testing.T) {
 	stmt := &Statement{
 		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
 		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"dimensions.retry_count":  {FieldType: "int"},
+				"path":                    {FieldType: "text"},
+				"value":                   {FieldType: "bigint"},
+				"status":                  {FieldType: "text"},
+				"extra":                   {FieldType: "bigint"},
+			},
+			"`db_a`.doris": {
+				"dimensions.pipelineName": {FieldType: "varchar(128)"},
+				"dimensions.retry_count":  {FieldType: "double"},
+				"dimensions.only_current": {FieldType: "varchar(128)"},
+				"path":                    {FieldType: "varchar(128)"},
+				"value":                   {FieldType: "int"},
+				"status":                  {FieldType: "bigint"},
+			},
+		},
 		nodeMap: map[string]Node{
-			SelectItem: &unionSelectTestNode{value: "*"},
+			SelectItem: &unionSelectTestNode{value: "*, `value` AS `_value_`"},
 		},
 	}
 
-	assert.Equal(t, Star, stmt.unionSelectList())
-	assert.ErrorContains(t, stmt.Error(), "SELECT *")
+	assert.Equal(t, "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, `path`, `value`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
 }
 
 func TestStatementUnionSelectListValidatesTableSchema(t *testing.T) {

--- a/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
+++ b/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
@@ -243,6 +243,46 @@ func TestStatementUnionSelectListExpandsMultiTableWildcard(t *testing.T) {
 	assert.NoError(t, stmt.Error())
 }
 
+func TestStatementUnionSelectListExpandsDistinctStar(t *testing.T) {
+	stmt := &Statement{
+		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
+		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {"path": {FieldType: "text"}},
+			"`db_a`.doris": {"path": {FieldType: "varchar(128)"}},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "DISTINCT(*)"},
+		},
+	}
+
+	assert.Equal(t, "`path`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
+}
+
+func TestStatementUnionSelectListUsesSafeCommonCastType(t *testing.T) {
+	stmt := &Statement{
+		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
+		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {
+				"dimensions.pipelineName": {FieldType: "varchar(128)"},
+				"dimensions.retry_count":  {FieldType: "int"},
+			},
+			"`db_a`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"dimensions.retry_count":  {FieldType: "bigint"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "*"},
+		},
+	}
+
+	assert.Equal(t, "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, CAST(dimensions['retry_count'] AS BIGINT) AS `dimensions.retry_count`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
+}
+
 func TestStatementUnionSelectListRejectsQualifiedMultiTableWildcard(t *testing.T) {
 	stmt := &Statement{
 		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},

--- a/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
+++ b/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
@@ -304,6 +304,52 @@ func TestStatementUnionSelectListPreservesDecimalCastType(t *testing.T) {
 	assert.NoError(t, stmt.Error())
 }
 
+func TestStatementUnionSelectListSkipsUnsafeDecimalCastType(t *testing.T) {
+	stmt := &Statement{
+		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
+		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {
+				"dimensions.amount": {FieldType: "decimal(38,18)"},
+				"path":              {FieldType: "text"},
+			},
+			"`db_a`.doris": {
+				"dimensions.amount": {FieldType: "decimal(38,0)"},
+				"path":              {FieldType: "varchar(128)"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "*"},
+		},
+	}
+
+	assert.Equal(t, "`path`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
+}
+
+func TestStatementUnionSelectListAllowsExpandedObjectLeafDependency(t *testing.T) {
+	stmt := &Statement{
+		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
+		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"path":                    {FieldType: "text"},
+			},
+			"`db_a`.doris": {
+				"dimensions.pipelineName": {FieldType: "varchar(128)"},
+				"path":                    {FieldType: "varchar(128)"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "*, `dimensions.pipelineName`"},
+		},
+	}
+
+	assert.Equal(t, "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, `path`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
+}
+
 func TestStatementUnionSelectListRejectsSelectAllWithObjectDependency(t *testing.T) {
 	stmt := &Statement{
 		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},

--- a/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
+++ b/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
@@ -283,6 +283,50 @@ func TestStatementUnionSelectListUsesSafeCommonCastType(t *testing.T) {
 	assert.NoError(t, stmt.Error())
 }
 
+func TestStatementUnionSelectListPreservesDecimalCastType(t *testing.T) {
+	stmt := &Statement{
+		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
+		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {
+				"dimensions.amount": {FieldType: "decimal(20,4)"},
+			},
+			"`db_a`.doris": {
+				"dimensions.amount": {FieldType: "decimal(30,8)"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "*"},
+		},
+	}
+
+	assert.Equal(t, "CAST(dimensions['amount'] AS DECIMAL(30,8)) AS `dimensions.amount`", stmt.unionSelectList())
+	assert.NoError(t, stmt.Error())
+}
+
+func TestStatementUnionSelectListRejectsSelectAllWithObjectDependency(t *testing.T) {
+	stmt := &Statement{
+		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
+		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {
+				"dimensions.pipelineName": {FieldType: "text"},
+				"path":                    {FieldType: "text"},
+			},
+			"`db_a`.doris": {
+				"dimensions.pipelineName": {FieldType: "varchar(128)"},
+				"path":                    {FieldType: "varchar(128)"},
+			},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "*, dimensions['pipelineName'] AS pipeline_name"},
+		},
+	}
+
+	assert.Equal(t, Star, stmt.unionSelectList())
+	assert.ErrorContains(t, stmt.Error(), "cannot be combined with field dependency `dimensions`")
+}
+
 func TestStatementUnionSelectListRejectsQualifiedMultiTableWildcard(t *testing.T) {
 	stmt := &Statement{
 		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},

--- a/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
+++ b/pkg/unify-query/internal/doris_parser/visitor_union_fields_test.go
@@ -243,6 +243,23 @@ func TestStatementUnionSelectListExpandsMultiTableWildcard(t *testing.T) {
 	assert.NoError(t, stmt.Error())
 }
 
+func TestStatementUnionSelectListRejectsQualifiedMultiTableWildcard(t *testing.T) {
+	stmt := &Statement{
+		Tables:               []string{"`db_b`.doris", "`db_a`.doris"},
+		RejectSelectAllUnion: true,
+		TableFieldsMap: TableFieldsMap{
+			"`db_b`.doris": {"path": {FieldType: "text"}},
+			"`db_a`.doris": {"path": {FieldType: "text"}},
+		},
+		nodeMap: map[string]Node{
+			SelectItem: &unionSelectTestNode{value: "t.*"},
+		},
+	}
+
+	assert.Equal(t, Star, stmt.unionSelectList())
+	assert.ErrorContains(t, stmt.Error(), "SELECT *")
+}
+
 func TestStatementUnionSelectListValidatesTableSchema(t *testing.T) {
 	stmt := &Statement{
 		Tables: []string{"`db_his`.doris", "`db_current`.doris"},

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -479,7 +479,7 @@ func (f *QueryFactory) parserSQL() (sql string, err error) {
 //
 // 普通聚合路径不经过 Doris SQL visitor，也需要在多 DB 合并时避免 SELECT *。
 // 这里从已渲染表达式中收集外层真正依赖的源字段，让内层 UNION 子查询只投影这些列。
-// 顶层 wildcard 仍保留为 *，让调用方拒绝多表 schema 漂移场景的 raw 明细查询。
+// 顶层 wildcard 会在 Doris 多表场景中按表结构转换成公共字段显式投影。
 // COUNT(*) 位于函数参数内，不会被当成 wildcard 展开；如果没有任何真实字段依赖，
 // UNION 分支只需投影常量，外层 COUNT 仍按行数聚合。
 type unionProjection struct {
@@ -510,7 +510,17 @@ func (f *QueryFactory) unionSelectList(selectFields, groupFields, orderFields []
 	switch {
 	case projection.selectAll:
 		if f.expr.Type() == sql_expr.Doris && len(f.tableFieldsMap) > 0 {
-			return "", fmt.Errorf("doris multi-table union does not support SELECT *; use explicit fields or aggregate dependencies")
+			fields, err := doris_parser.ExpandSelectAllUnionFields(tables, f.tableFieldsMap)
+			if err != nil {
+				return "", err
+			}
+			if err := doris_parser.ValidateUnionProjectionFieldNames(tables, toDorisUnionProjectionFields(projection.fields), f.tableFieldsMap); err != nil {
+				return "", err
+			}
+			fields = appendMissingUnionProjectionFields(fields, unionProjectionFieldNames(projection.fields))
+			if len(fields) > 0 {
+				return strings.Join(fields, ", "), nil
+			}
 		}
 		return selectAll, nil
 	case projection.dummy:
@@ -523,11 +533,13 @@ func (f *QueryFactory) unionSelectList(selectFields, groupFields, orderFields []
 }
 
 func collectUnionProjection(selectFields, groupFields, orderFields []string) unionProjection {
+	selectAll := false
 	allParts := [][]string{selectFields, groupFields, orderFields}
 	for _, parts := range allParts {
 		for _, part := range parts {
 			if hasTopLevelUnionWildcard(part) {
-				return unionProjection{selectAll: true}
+				selectAll = true
+				break
 			}
 		}
 	}
@@ -563,6 +575,9 @@ func collectUnionProjection(selectFields, groupFields, orderFields []string) uni
 		fields = append(fields, field)
 	}
 
+	if selectAll {
+		return unionProjection{selectAll: true, fields: fields}
+	}
 	if len(fields) == 0 {
 		return unionProjection{dummy: true}
 	}
@@ -584,6 +599,21 @@ func unionProjectionFieldNames(fields []unionProjectionField) []string {
 		names = append(names, field.field)
 	}
 	return names
+}
+
+func appendMissingUnionProjectionFields(fields []string, extraFields []string) []string {
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		seen[field] = struct{}{}
+	}
+	for _, field := range extraFields {
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		fields = append(fields, field)
+	}
+	return fields
 }
 
 func toDorisUnionProjectionFields(fields []unionProjectionField) []doris_parser.UnionProjectionField {

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -610,9 +610,9 @@ func unionProjectionFieldNames(fields []unionProjectionField) []string {
 }
 
 func firstMissingUnionProjectionField(fields []string, extraFields []string) string {
-	seen := make(map[string]struct{}, len(fields))
+	seen := make(map[string]struct{}, len(fields)*2)
 	for _, field := range fields {
-		seen[field] = struct{}{}
+		addUnionProjectionOutputName(seen, field)
 	}
 	for _, field := range extraFields {
 		if _, ok := seen[field]; !ok {
@@ -620,6 +620,19 @@ func firstMissingUnionProjectionField(fields []string, extraFields []string) str
 		}
 	}
 	return ""
+}
+
+func addUnionProjectionOutputName(seen map[string]struct{}, field string) {
+	seen[field] = struct{}{}
+	upperField := strings.ToUpper(field)
+	idx := strings.LastIndex(upperField, " AS `")
+	if idx < 0 {
+		return
+	}
+	alias := field[idx+len(" AS "):]
+	if strings.HasPrefix(alias, "`") && strings.HasSuffix(alias, "`") {
+		seen[alias] = struct{}{}
+	}
 }
 
 func toDorisUnionProjectionFields(fields []unionProjectionField) []doris_parser.UnionProjectionField {

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -483,9 +483,10 @@ func (f *QueryFactory) parserSQL() (sql string, err error) {
 // COUNT(*) 位于函数参数内，不会被当成 wildcard 展开；如果没有任何真实字段依赖，
 // UNION 分支只需投影常量，外层 COUNT 仍按行数聚合。
 type unionProjection struct {
-	selectAll bool
-	dummy     bool
-	fields    []unionProjectionField
+	selectAll          bool
+	qualifiedSelectAll bool
+	dummy              bool
+	fields             []unionProjectionField
 }
 
 type unionProjectionField struct {
@@ -509,6 +510,10 @@ func (f *QueryFactory) unionSelectList(selectFields, groupFields, orderFields []
 	projection := collectUnionProjection(selectFields, groupFields, orderFields)
 	switch {
 	case projection.selectAll:
+		// Doris 多表 UNION 会改写 FROM，qualified wildcard 依赖的原始表别名无法保留。
+		if projection.qualifiedSelectAll && f.expr.Type() == sql_expr.Doris && len(tables) > 1 {
+			return "", fmt.Errorf("doris multi-table union does not support SELECT *; use explicit fields")
+		}
 		if f.expr.Type() == sql_expr.Doris && len(f.tableFieldsMap) > 0 {
 			fields, err := doris_parser.ExpandSelectAllUnionFields(tables, f.tableFieldsMap)
 			if err != nil {
@@ -534,9 +539,14 @@ func (f *QueryFactory) unionSelectList(selectFields, groupFields, orderFields []
 
 func collectUnionProjection(selectFields, groupFields, orderFields []string) unionProjection {
 	selectAll := false
+	qualifiedSelectAll := false
 	allParts := [][]string{selectFields, groupFields, orderFields}
 	for _, parts := range allParts {
 		for _, part := range parts {
+			if hasTopLevelQualifiedUnionWildcard(part) {
+				qualifiedSelectAll = true
+				break
+			}
 			if hasTopLevelUnionWildcard(part) {
 				selectAll = true
 				break
@@ -575,8 +585,8 @@ func collectUnionProjection(selectFields, groupFields, orderFields []string) uni
 		fields = append(fields, field)
 	}
 
-	if selectAll {
-		return unionProjection{selectAll: true, fields: fields}
+	if selectAll || qualifiedSelectAll {
+		return unionProjection{selectAll: true, qualifiedSelectAll: qualifiedSelectAll, fields: fields}
 	}
 	if len(fields) == 0 {
 		return unionProjection{dummy: true}
@@ -967,6 +977,14 @@ func hasTopLevelUnionWildcard(s string) bool {
 		return true
 	}
 
+	return scanTopLevelUnionWildcard(s, isUnionWildcardToken)
+}
+
+func hasTopLevelQualifiedUnionWildcard(s string) bool {
+	return scanTopLevelUnionWildcard(s, isUnionQualifiedWildcardToken)
+}
+
+func scanTopLevelUnionWildcard(s string, match func(string, int) bool) bool {
 	depth := 0
 	for idx := 0; idx < len(s); idx++ {
 		switch s[idx] {
@@ -987,7 +1005,7 @@ func hasTopLevelUnionWildcard(s string) bool {
 				depth--
 			}
 		case '*':
-			if depth == 0 && isUnionWildcardToken(s, idx) {
+			if depth == 0 && match(s, idx) {
 				return true
 			}
 		}
@@ -1010,7 +1028,13 @@ func isUnionDistinctStarExpression(s string) bool {
 func isUnionWildcardToken(s string, idx int) bool {
 	prev := previousNonSpaceUnionByte(s, idx)
 	next := nextNonSpaceUnionByte(s, idx+1)
-	return (prev == 0 || prev == ',' || prev == '.') && (next == 0 || next == ',')
+	return (prev == 0 || prev == ',') && (next == 0 || next == ',')
+}
+
+func isUnionQualifiedWildcardToken(s string, idx int) bool {
+	prev := previousNonSpaceUnionByte(s, idx)
+	next := nextNonSpaceUnionByte(s, idx+1)
+	return prev == '.' && (next == 0 || next == ',')
 }
 
 func (f *QueryFactory) SQL() (sql string, err error) {

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -518,7 +518,9 @@ func (f *QueryFactory) unionSelectList(selectFields, groupFields, orderFields []
 			if err := doris_parser.ValidateUnionProjectionFieldNames(tables, toDorisUnionProjectionFields(projection.fields), f.tableFieldsMap); err != nil {
 				return "", err
 			}
-			fields = appendMissingUnionProjectionFields(fields, unionProjectionFieldNames(projection.fields))
+			if field := firstMissingUnionProjectionField(fields, unionProjectionFieldNames(projection.fields)); field != "" {
+				return "", fmt.Errorf("doris multi-table union SELECT * cannot be combined with field dependency %s; use explicit fields", field)
+			}
 			if len(fields) > 0 {
 				return strings.Join(fields, ", "), nil
 			}
@@ -607,19 +609,17 @@ func unionProjectionFieldNames(fields []unionProjectionField) []string {
 	return names
 }
 
-func appendMissingUnionProjectionFields(fields []string, extraFields []string) []string {
+func firstMissingUnionProjectionField(fields []string, extraFields []string) string {
 	seen := make(map[string]struct{}, len(fields))
 	for _, field := range fields {
 		seen[field] = struct{}{}
 	}
 	for _, field := range extraFields {
-		if _, ok := seen[field]; ok {
-			continue
+		if _, ok := seen[field]; !ok {
+			return field
 		}
-		seen[field] = struct{}{}
-		fields = append(fields, field)
 	}
-	return fields
+	return ""
 }
 
 func toDorisUnionProjectionFields(fields []unionProjectionField) []doris_parser.UnionProjectionField {

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -511,6 +511,9 @@ func (f *QueryFactory) unionSelectList(selectFields, groupFields, orderFields []
 	switch {
 	case projection.selectAll:
 		if f.expr.Type() == sql_expr.Doris && len(f.tableFieldsMap) > 0 {
+			if projection.qualifiedSelectAll {
+				return "", fmt.Errorf("doris multi-table union does not support SELECT *; use explicit fields")
+			}
 			fields, err := doris_parser.ExpandSelectAllUnionFields(tables, f.tableFieldsMap)
 			if err != nil {
 				return "", err
@@ -615,15 +618,19 @@ func firstMissingUnionProjectionField(fields []string, extraFields []string) str
 		addUnionProjectionOutputName(seen, field)
 	}
 	for _, field := range extraFields {
-		if _, ok := seen[field]; !ok {
-			return field
+		if unionProjectionOutputNameExists(seen, field) {
+			continue
 		}
+		return field
 	}
 	return ""
 }
 
 func addUnionProjectionOutputName(seen map[string]struct{}, field string) {
 	seen[field] = struct{}{}
+	if key := normalizedUnionProjectionName(field); key != "" {
+		seen[key] = struct{}{}
+	}
 	upperField := strings.ToUpper(field)
 	idx := strings.LastIndex(upperField, " AS `")
 	if idx < 0 {
@@ -632,7 +639,35 @@ func addUnionProjectionOutputName(seen map[string]struct{}, field string) {
 	alias := field[idx+len(" AS "):]
 	if strings.HasPrefix(alias, "`") && strings.HasSuffix(alias, "`") {
 		seen[alias] = struct{}{}
+		if key := normalizedUnionProjectionName(alias); key != "" {
+			seen[key] = struct{}{}
+		}
 	}
+}
+
+func unionProjectionOutputNameExists(seen map[string]struct{}, field string) bool {
+	if _, ok := seen[field]; ok {
+		return true
+	}
+	if key := normalizedUnionProjectionName(field); key != "" {
+		_, ok := seen[key]
+		return ok
+	}
+	return false
+}
+
+func normalizedUnionProjectionName(field string) string {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return ""
+	}
+	if strings.HasPrefix(field, "`") && strings.HasSuffix(field, "`") {
+		field = strings.TrimSuffix(strings.TrimPrefix(field, "`"), "`")
+	}
+	if strings.ContainsAny(field, " ()") {
+		return ""
+	}
+	return strings.ToLower(field)
 }
 
 func toDorisUnionProjectionFields(fields []unionProjectionField) []doris_parser.UnionProjectionField {

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -510,10 +510,6 @@ func (f *QueryFactory) unionSelectList(selectFields, groupFields, orderFields []
 	projection := collectUnionProjection(selectFields, groupFields, orderFields)
 	switch {
 	case projection.selectAll:
-		// Doris 多表 UNION 会改写 FROM，qualified wildcard 依赖的原始表别名无法保留。
-		if projection.qualifiedSelectAll && f.expr.Type() == sql_expr.Doris && len(tables) > 1 {
-			return "", fmt.Errorf("doris multi-table union does not support SELECT *; use explicit fields")
-		}
 		if f.expr.Type() == sql_expr.Doris && len(f.tableFieldsMap) > 0 {
 			fields, err := doris_parser.ExpandSelectAllUnionFields(tables, f.tableFieldsMap)
 			if err != nil {
@@ -676,6 +672,9 @@ func collectUnionColumnsFromSQLPart(part string, ignoreNames map[string]struct{}
 			end += idx + 1
 			name := part[idx+1 : end]
 			idx = end
+			if isUnionQualifiedWildcardRoot(part, idx+1) {
+				continue
+			}
 			if shouldSkipUnionColumnName(part, start, name, ignoreNames, true) {
 				continue
 			}
@@ -710,12 +709,29 @@ func collectUnionColumnsFromSQLPart(part string, ignoreNames map[string]struct{}
 		if nextNonSpaceUnionByte(part, idx+1) == '(' {
 			continue
 		}
+		if isUnionQualifiedWildcardRoot(part, idx+1) {
+			continue
+		}
 		fields = append(fields, unionProjectionField{
 			field:        fmt.Sprintf("`%s`", name),
 			validateName: name + collectUnionObjectPathSuffix(part, idx+1),
 		})
 	}
 	return fields
+}
+
+func isUnionQualifiedWildcardRoot(part string, start int) bool {
+	for start < len(part) && part[start] == ' ' {
+		start++
+	}
+	if start >= len(part) || part[start] != '.' {
+		return false
+	}
+	start++
+	for start < len(part) && part[start] == ' ' {
+		start++
+	}
+	return start < len(part) && part[start] == '*'
 }
 
 func shouldSkipUnionColumnName(part string, start int, name string, ignoreNames map[string]struct{}, quoted bool) bool {

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -288,6 +288,19 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, `path`",
 		},
 		{
+			name:         "multi table SELECT star 字段依赖按大小写不敏感匹配",
+			selectFields: []string{"*", "`dtEventTimeStamp` AS `_timestamp_`"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"dteventtimestamp": {FieldType: "bigint"},
+				},
+				"`db_a`.doris": {
+					"dteventtimestamp": {FieldType: "int"},
+				},
+			},
+			expected: "`dteventtimestamp`",
+		},
+		{
 			name:         "multi table SELECT star 保留显式依赖字段",
 			selectFields: []string{"*", "`value` AS `_value_`"},
 			tableFieldsMap: TableFieldsMap{
@@ -348,7 +361,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, `path`",
 		},
 		{
-			name:         "multi table qualified wildcard 按公共字段投影",
+			name:         "multi table qualified wildcard 返回明确错误",
 			selectFields: []string{"t.*"},
 			tableFieldsMap: TableFieldsMap{
 				"`db_b`.doris": {
@@ -362,7 +375,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 					"other":  {FieldType: "text"},
 				},
 			},
-			expected: "`path`",
+			expectedErr: "doris multi-table union does not support SELECT *; use explicit fields",
 		},
 		{
 			name:         "无真实字段依赖时使用常量投影",

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -122,7 +122,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 		selectFields   []string
 		tableFieldsMap TableFieldsMap
 		expected       string
-		errContains    string
+		expectedErr    string
 	}{
 		{
 			name:         "字段存在且类型兼容",
@@ -149,7 +149,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 				"`db_b`.doris": {"path": {FieldType: "text"}},
 				"`db_a`.doris": {"log": {FieldType: "text"}},
 			},
-			errContains: "missing",
+			expectedErr: "doris multi-table union field `path` is missing from table `db_a`.doris",
 		},
 		{
 			name:         "对象 root 投影允许 leaf schema 校验",
@@ -187,7 +187,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 					"resource.retry_count": {FieldType: "int"},
 				},
 			},
-			errContains: "missing",
+			expectedErr: "doris multi-table union field `resource` is missing from table `db_a`.doris",
 		},
 		{
 			name:         "类型不兼容返回明确错误",
@@ -196,7 +196,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 				"`db_b`.doris": {"path": {FieldType: "text"}},
 				"`db_a`.doris": {"path": {FieldType: "bigint"}},
 			},
-			errContains: "type mismatch",
+			expectedErr: "doris multi-table union field `path` type mismatch: table `db_b`.doris has text, table `db_a`.doris has bigint",
 		},
 		{
 			name:         "JSON 类型不自动投影",
@@ -205,7 +205,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 				"`db_b`.doris": {"payload": {FieldType: "json"}},
 				"`db_a`.doris": {"payload": {FieldType: "json"}},
 			},
-			errContains: "unsupported type",
+			expectedErr: "doris multi-table union field `payload` in table `db_b`.doris has unsupported type json",
 		},
 		{
 			name:         "multi table SELECT star 嵌套字段按完整字段名取交集",
@@ -261,7 +261,7 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			expected: "`path`, `value`",
 		},
 		{
-			name:         "multi table SELECT star 显式依赖缺失时报错",
+			name:         "multi table SELECT star 显式依赖字段不参与交集剔除",
 			selectFields: []string{"*", "`value` AS `_value_`"},
 			tableFieldsMap: TableFieldsMap{
 				"`db_b`.doris": {
@@ -270,7 +270,9 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 				},
 				"`db_a`.doris": {"path": {FieldType: "varchar(128)"}},
 			},
-			errContains: "missing",
+			// `*` 可按 schema 交集保留 `path`，但外层显式依赖的 `value`
+			// 不能被静默丢弃；db_a 缺少该字段时必须返回明确错误。
+			expectedErr: "doris multi-table union field `value` is missing from table `db_a`.doris",
 		},
 		{
 			name:         "multi table qualified wildcard 按公共字段投影",
@@ -305,9 +307,9 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			query := &metadata.Query{Measurement: sql_expr.Doris}
 			f := NewQueryFactory(context.Background(), query).WithTableFieldsMap(tt.tableFieldsMap)
 			got, err := f.unionSelectList(tt.selectFields, nil, nil, tables)
-			if tt.errContains != "" {
+			if tt.expectedErr != "" {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errContains)
+				assert.EqualError(t, err, tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -239,6 +239,19 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, CAST(dimensions['retry_count'] AS BIGINT) AS `dimensions.retry_count`",
 		},
 		{
+			name:         "multi table SELECT star 嵌套 decimal 字段保持精确 cast 类型",
+			selectFields: []string{"*"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"dimensions.amount": {FieldType: "decimal(20,4)"},
+				},
+				"`db_a`.doris": {
+					"dimensions.amount": {FieldType: "decimal(30,8)"},
+				},
+			},
+			expected: "CAST(dimensions['amount'] AS DECIMAL(30,8)) AS `dimensions.amount`",
+		},
+		{
 			name:         "multi table SELECT star 转换成公共字段投影",
 			selectFields: []string{"*"},
 			tableFieldsMap: TableFieldsMap{
@@ -288,6 +301,21 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			// `*` 可按 schema 交集保留 `path`，但外层显式依赖的 `value`
 			// 不能被静默丢弃；db_a 缺少该字段时必须返回明确错误。
 			expectedErr: "doris multi-table union field `value` is missing from table `db_a`.doris",
+		},
+		{
+			name:         "multi table SELECT star 拒绝额外对象依赖字段",
+			selectFields: []string{"*", "CAST(dimensions['pipelineName'] AS TEXT) AS `pipeline_name`"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"dimensions.pipelineName": {FieldType: "text"},
+					"path":                    {FieldType: "text"},
+				},
+				"`db_a`.doris": {
+					"dimensions.pipelineName": {FieldType: "varchar(128)"},
+					"path":                    {FieldType: "varchar(128)"},
+				},
+			},
+			expectedErr: "doris multi-table union SELECT * cannot be combined with field dependency `dimensions`; use explicit fields",
 		},
 		{
 			name:         "multi table qualified wildcard 按公共字段投影",

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -100,6 +100,11 @@ func TestCollectUnionSelectFields(t *testing.T) {
 			selectFields: []string{"DISTINCT(*)"},
 			expected:     selectAll,
 		},
+		{
+			name:         "qualified wildcard 保守保留 select all",
+			selectFields: []string{"t.*"},
+			expected:     selectAll,
+		},
 	}
 
 	for _, tt := range tests {
@@ -266,6 +271,15 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 				"`db_a`.doris": {"path": {FieldType: "varchar(128)"}},
 			},
 			errContains: "missing",
+		},
+		{
+			name:         "multi table qualified wildcard 返回明确错误",
+			selectFields: []string{"t.*"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {"path": {FieldType: "text"}},
+				"`db_a`.doris": {"path": {FieldType: "text"}},
+			},
+			errContains: "SELECT *",
 		},
 		{
 			name:         "无真实字段依赖时使用常量投影",

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -203,13 +203,69 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			errContains: "unsupported type",
 		},
 		{
-			name:         "multi table SELECT star 不再静默生成 DB-side union",
+			name:         "multi table SELECT star 嵌套字段按完整字段名取交集",
 			selectFields: []string{"*"},
 			tableFieldsMap: TableFieldsMap{
-				"`db_b`.doris": {"path": {FieldType: "text"}},
-				"`db_a`.doris": {"path": {FieldType: "text"}},
+				"`db_b`.doris": {
+					"dimensions.pipelineName": {FieldType: "text"},
+					"dimensions.retry_count":  {FieldType: "int"},
+				},
+				"`db_a`.doris": {
+					"dimensions.pipelineName": {FieldType: "varchar(128)"},
+					"dimensions.retry_count":  {FieldType: "double"},
+					"dimensions.only_current": {FieldType: "varchar(128)"},
+				},
 			},
-			errContains: "SELECT *",
+			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`",
+		},
+		{
+			name:         "multi table SELECT star 转换成公共字段投影",
+			selectFields: []string{"*"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"dimensions.pipelineName": {FieldType: "text"},
+					"dimensions.retry_count":  {FieldType: "int"},
+					"path":                    {FieldType: "text"},
+					"status":                  {FieldType: "text"},
+					"extra":                   {FieldType: "bigint"},
+				},
+				"`db_a`.doris": {
+					"dimensions.pipelineName": {FieldType: "varchar(128)"},
+					"dimensions.retry_count":  {FieldType: "double"},
+					"dimensions.only_current": {FieldType: "varchar(128)"},
+					"path":                    {FieldType: "varchar(128)"},
+					"status":                  {FieldType: "bigint"},
+				},
+			},
+			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, `path`",
+		},
+		{
+			name:         "multi table SELECT star 保留显式依赖字段",
+			selectFields: []string{"*", "`value` AS `_value_`"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"path":  {FieldType: "text"},
+					"value": {FieldType: "bigint"},
+					"extra": {FieldType: "bigint"},
+				},
+				"`db_a`.doris": {
+					"path":  {FieldType: "varchar(128)"},
+					"value": {FieldType: "int"},
+				},
+			},
+			expected: "`path`, `value`",
+		},
+		{
+			name:         "multi table SELECT star 显式依赖缺失时报错",
+			selectFields: []string{"*", "`value` AS `_value_`"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"path":  {FieldType: "text"},
+					"value": {FieldType: "bigint"},
+				},
+				"`db_a`.doris": {"path": {FieldType: "varchar(128)"}},
+			},
+			errContains: "missing",
 		},
 		{
 			name:         "无真实字段依赖时使用常量投影",

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -252,6 +252,21 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			expected: "CAST(dimensions['amount'] AS DECIMAL(30,8)) AS `dimensions.amount`",
 		},
 		{
+			name:         "multi table SELECT star 跳过超过 Doris precision 上限的 decimal 字段",
+			selectFields: []string{"*"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"dimensions.amount": {FieldType: "decimal(38,18)"},
+					"path":              {FieldType: "text"},
+				},
+				"`db_a`.doris": {
+					"dimensions.amount": {FieldType: "decimal(38,0)"},
+					"path":              {FieldType: "varchar(128)"},
+				},
+			},
+			expected: "`path`",
+		},
+		{
 			name:         "multi table SELECT star 转换成公共字段投影",
 			selectFields: []string{"*"},
 			tableFieldsMap: TableFieldsMap{
@@ -316,6 +331,21 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 				},
 			},
 			expectedErr: "doris multi-table union SELECT * cannot be combined with field dependency `dimensions`; use explicit fields",
+		},
+		{
+			name:         "multi table SELECT star 允许已展开的嵌套 leaf alias 依赖",
+			selectFields: []string{"*", "`dimensions.pipelineName`"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"dimensions.pipelineName": {FieldType: "text"},
+					"path":                    {FieldType: "text"},
+				},
+				"`db_a`.doris": {
+					"dimensions.pipelineName": {FieldType: "varchar(128)"},
+					"path":                    {FieldType: "varchar(128)"},
+				},
+			},
+			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, `path`",
 		},
 		{
 			name:         "multi table qualified wildcard 按公共字段投影",

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -224,6 +224,21 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`",
 		},
 		{
+			name:         "multi table SELECT star 嵌套字段使用安全公共 cast 类型",
+			selectFields: []string{"*"},
+			tableFieldsMap: TableFieldsMap{
+				"`db_b`.doris": {
+					"dimensions.pipelineName": {FieldType: "varchar(128)"},
+					"dimensions.retry_count":  {FieldType: "int"},
+				},
+				"`db_a`.doris": {
+					"dimensions.pipelineName": {FieldType: "text"},
+					"dimensions.retry_count":  {FieldType: "bigint"},
+				},
+			},
+			expected: "CAST(dimensions['pipelineName'] AS TEXT) AS `dimensions.pipelineName`, CAST(dimensions['retry_count'] AS BIGINT) AS `dimensions.retry_count`",
+		},
+		{
 			name:         "multi table SELECT star 转换成公共字段投影",
 			selectFields: []string{"*"},
 			tableFieldsMap: TableFieldsMap{

--- a/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_union_fields_test.go
@@ -273,13 +273,21 @@ func TestQueryFactoryUnionSelectListValidation(t *testing.T) {
 			errContains: "missing",
 		},
 		{
-			name:         "multi table qualified wildcard 返回明确错误",
+			name:         "multi table qualified wildcard 按公共字段投影",
 			selectFields: []string{"t.*"},
 			tableFieldsMap: TableFieldsMap{
-				"`db_b`.doris": {"path": {FieldType: "text"}},
-				"`db_a`.doris": {"path": {FieldType: "text"}},
+				"`db_b`.doris": {
+					"path":   {FieldType: "text"},
+					"status": {FieldType: "text"},
+					"extra":  {FieldType: "bigint"},
+				},
+				"`db_a`.doris": {
+					"path":   {FieldType: "varchar(128)"},
+					"status": {FieldType: "bigint"},
+					"other":  {FieldType: "text"},
+				},
 			},
-			errContains: "SELECT *",
+			expected: "`path`",
 		},
 		{
 			name:         "无真实字段依赖时使用常量投影",


### PR DESCRIPTION
## 背景

修复 Doris 多表 UNION 场景下 `SELECT *` 不能直接透传的问题：不同表字段可能漂移，直接 `SELECT *` 会导致 UNION 两侧列数或类型不一致。

## 变更内容

- Doris 多表 UNION 的 plain `SELECT *` 按各表 schema 交集展开为显式公共字段投影。
- dotted 字段按完整 leaf 字段名求交集，并使用 Doris 对象访问表达式投影，例如 `dimensions.pipelineName` 会生成 `CAST(dimensions['pipelineName'] AS ...) AS dimensions.pipelineName`。
- 展开字段与外层依赖字段按 unquoted、大小写不敏感的 key 比较，兼容 Doris `SHOW COLUMNS` 返回小写字段名的情况。
- 保留 `t.*` 等 qualified wildcard 的显式拒绝逻辑，避免 FROM 被改写后原表 alias 失效；普通 bksql 聚合路径和自定义 SQL visitor 路径保持一致。
- `SELECT *` 与额外 nested-field root 依赖混用时返回明确错误，不再把 helper root 追加进内层 UNION 投影，避免外层 `SELECT *` 暴露额外列；如果依赖的是已经由 `SELECT *` 展开出的 nested leaf alias，则允许复用。
- 兼容类型使用安全公共 cast 类型：
  - 字符串族统一为 `TEXT`。
  - 整型族统一为 `BIGINT`，包含 `LARGEINT` 时使用 `LARGEINT`。
  - decimal/decimalv2/decimalv3 单独处理，按 precision/scale 计算公共 decimal 类型，避免被 cast 成 `DOUBLE` 丢精度。
  - decimal 公共类型超过 Doris 默认 precision 38 时视为不安全，不生成非法 cast。
- 普通 bksql 聚合路径和自定义 SQL visitor 路径同步处理上述规则。

## 测试

- `rtk go test ./internal/doris_parser`
- `rtk go test ./tsdb/bksql`
- `rtk git diff --check`
