### PR TITLE
feat: (unify-query)TSpider PromQL 聚合补充字段映射并改用时间字段分桶 --story=136107079

### DIFF
--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -682,7 +682,7 @@ func TestBkData_SQL_ToFinalSQL(t *testing.T) {
 				ReferenceName: "a",
 				SQL:           "SELECT dtEventTimeStamp, gseIndex FROM `2_bklog_unit_test` WHERE gseIndex > 0 LIMIT 20",
 			},
-			wantSQL: "SELECT NULL AS dtEventTimeStamp, NULL AS gseIndex FROM `2_bklog_unit_test` WHERE NULL > 0 AND (`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` <= 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313') LIMIT 20",
+			wantSQL: "SELECT NULL AS dtEventTimeStamp, NULL AS gseIndex FROM `2_bklog_unit_test` WHERE NULL > 0 AND (`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` < 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313') LIMIT 20",
 		},
 		{
 			// 无用户 SQL：走 buildSQL 路径，SELECT 中包含内置字段 _value_ / _timestamp_
@@ -706,7 +706,7 @@ func TestBkData_SQL_ToFinalSQL(t *testing.T) {
 				ReferenceName: "a",
 				SQL:           "SELECT count(*) FROM 2_bklog_unit_test LIMIT 1",
 			},
-			wantSQL: "SELECT count(*) FROM `2_bklog_unit_test` WHERE (`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` <= 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313') LIMIT 1",
+			wantSQL: "SELECT count(*) FROM `2_bklog_unit_test` WHERE (`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` < 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313') LIMIT 1",
 		},
 		{
 			// Doris：反引号库表 + count，时间条件以 AND 追加

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -120,6 +120,14 @@ func NewQueryFactory(ctx context.Context, query *metadata.Query) *QueryFactory {
 	return f
 }
 
+func formatPhysicalTableName(db, measurement string) string {
+	table := fmt.Sprintf("`%s`", db)
+	if measurement != "" && measurement != sql_expr.TSpider {
+		table += "." + measurement
+	}
+	return table
+}
+
 func (f *QueryFactory) WithMaxLimit(maxLimit int) *QueryFactory {
 	f.maxLimit = maxLimit
 	return f
@@ -432,11 +440,7 @@ func (f *QueryFactory) Tables() []string {
 	// 改成倒序遍历
 	for idx := len(dbs) - 1; idx >= 0; idx-- {
 		db := dbs[idx]
-		table := fmt.Sprintf("`%s`", db)
-		if f.query.Measurement != "" {
-			table += "." + f.query.Measurement
-		}
-		tables = append(tables, table)
+		tables = append(tables, formatPhysicalTableName(db, f.query.Measurement))
 	}
 
 	return tables

--- a/pkg/unify-query/tsdb/bksql/format.go
+++ b/pkg/unify-query/tsdb/bksql/format.go
@@ -106,11 +106,7 @@ func NewQueryFactory(ctx context.Context, query *metadata.Query) *QueryFactory {
 		f.timeField = dtEventTimeStamp
 	}
 
-	exprKey := query.Measurement
-	// TSpider 表多为单段 table_id，Measurement 为空；用户自定义 SQL 仍需走 Doris 同源解析，且不能改写 Measurement（否则表名会多出 .tspider）
-	if exprKey == "" && query.SQL != "" && query.StorageType == metadata.BkSqlStorageType {
-		exprKey = sql_expr.TSpider
-	}
+	exprKey := querySQLExprKey(query)
 
 	f.expr = sql_expr.NewSQLExpr(exprKey).
 		WithInternalFields(f.timeField, query.Field).
@@ -118,6 +114,26 @@ func NewQueryFactory(ctx context.Context, query *metadata.Query) *QueryFactory {
 		WithFieldAlias(query.FieldAlias)
 
 	return f
+}
+
+func querySQLExprKey(query *metadata.Query) string {
+	if query == nil {
+		return ""
+	}
+	if isTSpiderQuery(query) {
+		return sql_expr.TSpider
+	}
+	return query.Measurement
+}
+
+func isTSpiderQuery(query *metadata.Query) bool {
+	if query == nil {
+		return false
+	}
+	if query.Measurement == sql_expr.TSpider {
+		return true
+	}
+	return query.StorageType == metadata.BkSqlStorageType && query.Measurement == ""
 }
 
 func formatPhysicalTableName(db, measurement string) string {

--- a/pkg/unify-query/tsdb/bksql/format_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_test.go
@@ -294,7 +294,7 @@ func TestNewQueryFactory_BkSql_TSpider_UserSQL(t *testing.T) {
 	start := time.Unix(1741795260, 0)
 	end := time.Unix(1741796260, 0)
 
-	const whereTime = "(`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` <= 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313')"
+	const whereTime = "(`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` < 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313')"
 
 	t.Run("without_fields_map", func(t *testing.T) {
 		tests := []struct {

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -303,15 +303,22 @@ func (i *Instance) queryFieldMaps(ctx context.Context, query *metadata.Query, st
 
 	fieldsMap := make(metadata.FieldsMap)
 	tableFieldsMap := make(TableFieldsMap)
+	needTSpiderFieldMap := isTSpiderQuery(query)
+	var (
+		fieldMapTables  []string
+		lastFieldMapErr error
+	)
 
 	// 多表的字段进行合并查询，进行倒序遍历
 	for idx := len(dbs) - 1; idx >= 0; idx-- {
 		db := dbs[idx]
 		table := formatPhysicalTableName(db, f.query.Measurement)
+		fieldMapTables = append(fieldMapTables, table)
 
 		sql := f.expr.DescribeTableSQL(table)
 		res, err := i.getFieldsMap(ctx, newQuerySyncRequest(sql, query))
 		if err != nil {
+			lastFieldMapErr = err
 			continue
 		}
 		normalized := normalizeFieldsMap(res, query.FieldAlias)
@@ -328,6 +335,16 @@ func (i *Instance) queryFieldMaps(ctx context.Context, query *metadata.Query, st
 
 			fieldsMap[k] = v
 		}
+	}
+
+	if needTSpiderFieldMap && len(fieldsMap) == 0 {
+		tableNames := strings.Join(fieldMapTables, ", ")
+		if lastFieldMapErr != nil {
+			err = fmt.Errorf("query tspider field map failed for %s: %w", tableNames, lastFieldMapErr)
+			return nil, nil, err
+		}
+		err = fmt.Errorf("query tspider field map empty for %s", tableNames)
+		return nil, nil, err
 	}
 
 	return fieldsMap, tableFieldsMap, nil

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -226,7 +226,7 @@ func needFieldMap(query *metadata.Query) bool {
 		return false
 	}
 	switch query.Measurement {
-	case sql_expr.Doris, sql_expr.HDFS:
+	case sql_expr.Doris, sql_expr.HDFS, sql_expr.TSpider:
 		return true
 	case "":
 		return query.StorageType == metadata.BkSqlStorageType && query.SQL != ""

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -225,8 +225,11 @@ func needFieldMap(query *metadata.Query) bool {
 	if query == nil {
 		return false
 	}
+	if isTSpiderQuery(query) {
+		return true
+	}
 	switch query.Measurement {
-	case sql_expr.Doris, sql_expr.HDFS, sql_expr.TSpider:
+	case sql_expr.Doris, sql_expr.HDFS:
 		return true
 	case "":
 		return query.StorageType == metadata.BkSqlStorageType && query.SQL != ""
@@ -239,8 +242,8 @@ func (i *Instance) InitQueryFactory(ctx context.Context, query *metadata.Query, 
 	f := NewQueryFactory(ctx, query).
 		WithRangeTime(start, end)
 
-	// Doris / HDFS 均需获取字段表结构；TSpider 单段 table_id（Measurement 为空）+ 用户 SQL 与 NewQueryFactory 中
-	// TSpiderSQLExpr 路径一致，同样需要 FieldsMap，否则 dimTransform 会将未知列变为 NULL。
+	// Doris / HDFS 均需获取字段表结构；TSpider 与 Doris 共用 SQL 表达式，也需要 FieldsMap，
+	// 否则 dimTransform 会将未知列变为 NULL。
 	if needFieldMap(query) {
 		fieldsMap, tableFieldsMap, err := i.queryFieldMaps(ctx, query, start, end)
 		if err != nil {

--- a/pkg/unify-query/tsdb/bksql/instance.go
+++ b/pkg/unify-query/tsdb/bksql/instance.go
@@ -261,11 +261,7 @@ func (i *Instance) InitQueryFactory(ctx context.Context, query *metadata.Query, 
 }
 
 func (i *Instance) Table(query *metadata.Query) string {
-	table := fmt.Sprintf("`%s`", query.DB)
-	if query.Measurement != "" {
-		table += "." + query.Measurement
-	}
-	return table
+	return formatPhysicalTableName(query.DB, query.Measurement)
 }
 
 // QueryFieldMap 查询字段映射
@@ -308,10 +304,7 @@ func (i *Instance) queryFieldMaps(ctx context.Context, query *metadata.Query, st
 	// 多表的字段进行合并查询，进行倒序遍历
 	for idx := len(dbs) - 1; idx >= 0; idx-- {
 		db := dbs[idx]
-		table := fmt.Sprintf("`%s`", db)
-		if f.query.Measurement != "" {
-			table += "." + f.query.Measurement
-		}
+		table := formatPhysicalTableName(db, f.query.Measurement)
 
 		sql := f.expr.DescribeTableSQL(table)
 		res, err := i.getFieldsMap(ctx, newQuerySyncRequest(sql, query))

--- a/pkg/unify-query/tsdb/bksql/instance_test.go
+++ b/pkg/unify-query/tsdb/bksql/instance_test.go
@@ -125,9 +125,8 @@ func TestInstance_TSpider(t *testing.T) {
 
 	mock.BkSQL.Set(map[string]any{
 		// tspider
-		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`":         `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
-		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`.tspider": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
-		"SHOW CREATE TABLE `36_game_bot_num_5min_stat`":                  `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"dsname","Type":"varchar(128)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"bot_num","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"game_id","Type":"bigint(20)","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
+		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
+		"SHOW CREATE TABLE `36_game_bot_num_5min_stat`":          `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"dsname","Type":"varchar(128)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"bot_num","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"game_id","Type":"bigint(20)","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
 	})
 
 	end := time.UnixMilli(1730118889181)
@@ -1046,6 +1045,22 @@ func TestInstance_bkSql(t *testing.T) {
 				},
 			},
 			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, MAX(FLOOR((dtEventTimeStamp + 0) / 15000) * 15000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' AND `namespace` IN ('bgp2-new', 'gz100') GROUP BY `namespace`, (FLOOR((dtEventTimeStamp + 0) / 15000) * 15000 - 0)",
+		},
+		{
+			name: "tspider aggregate count uses unsuffixed table and time field bucket",
+			query: &metadata.Query{
+				DB:          "132_lol_new_login_queue_login_1min",
+				Measurement: sql_expr.TSpider,
+				Field:       "login_rate",
+				Aggregates: metadata.Aggregates{
+					{
+						Name:       "count",
+						Dimensions: []string{"namespace"},
+						Window:     time.Minute,
+					},
+				},
+			},
+			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` <= 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, _timestamp_",
 		},
 		{
 			name: "conditions with or",

--- a/pkg/unify-query/tsdb/bksql/instance_test.go
+++ b/pkg/unify-query/tsdb/bksql/instance_test.go
@@ -125,8 +125,9 @@ func TestInstance_TSpider(t *testing.T) {
 
 	mock.BkSQL.Set(map[string]any{
 		// tspider
-		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
-		"SHOW CREATE TABLE `36_game_bot_num_5min_stat`":          `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"dsname","Type":"varchar(128)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"bot_num","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"game_id","Type":"bigint(20)","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
+		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`":             `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
+		"SHOW CREATE TABLE `36_game_bot_num_5min_stat`":                      `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"dsname","Type":"varchar(128)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"bot_num","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"game_id","Type":"bigint(20)","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
+		"SHOW CREATE TABLE `100656_dwd_clouddev_process_monitor_statistics`": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"process_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"user_id","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"err_count","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
 	})
 
 	end := time.UnixMilli(1730118889181)
@@ -137,7 +138,6 @@ func TestInstance_TSpider(t *testing.T) {
 		start        time.Time
 		end          time.Time
 		fieldMap     bool
-		initNilFM    bool
 		initFieldMap bool
 		wantUserSQL  string
 	}{
@@ -148,15 +148,22 @@ func TestInstance_TSpider(t *testing.T) {
 			},
 			fieldMap: true,
 		},
-		"InitQueryFactory_NoUserSQL_FieldMapNil": {
+		"InitQueryFactory_PromQLSingleSegment_FieldMapAndSQL": {
 			query: &metadata.Query{
 				StorageType: metadata.BkSqlStorageType,
-				DB:          "132_lol_new_login_queue_login_1min",
+				DB:          "100656_dwd_clouddev_process_monitor_statistics",
 				Measurement: "",
-				Field:       "login_rate",
+				Field:       "err_count",
 				SQL:         "",
+				Aggregates: metadata.Aggregates{
+					{
+						Name:       "sum",
+						Dimensions: []string{"process_name", "user_id"},
+						Window:     time.Minute,
+					},
+				},
 			},
-			initNilFM: true,
+			initFieldMap: true,
 		},
 		"InitQueryFactory_PromQLMeasurement_FieldMap": {
 			query: &metadata.Query{
@@ -198,11 +205,6 @@ func TestInstance_TSpider(t *testing.T) {
 				assert.Equal(t, "bigint(20)", fieldsMap["dtEventTimeStamp"].FieldType)
 				assert.Equal(t, "double", fieldsMap["login_rate"].FieldType)
 				assert.Equal(t, 8, len(fieldsMap))
-			case c.initNilFM:
-				fact, err := ins.InitQueryFactory(ctx, c.query, s, e)
-				assert.Nil(t, err)
-				assert.NotNil(t, fact)
-				assert.Nil(t, fact.FieldMap())
 			case c.initFieldMap:
 				fact, err := ins.InitQueryFactory(ctx, c.query, s, e)
 				assert.Nil(t, err)
@@ -210,8 +212,14 @@ func TestInstance_TSpider(t *testing.T) {
 				fm := fact.FieldMap()
 				assert.NotEmpty(t, fm)
 				assert.Equal(t, "bigint(20)", fm["dtEventTimeStamp"].FieldType)
-				assert.Equal(t, "varchar(64)", fm["namespace"].FieldType)
-				assert.Equal(t, "double", fm["login_rate"].FieldType)
+				if _, ok := fm["err_count"]; ok {
+					assert.Equal(t, "text", fm["process_name"].FieldType)
+					assert.Equal(t, "text", fm["user_id"].FieldType)
+					assert.Equal(t, "double", fm["err_count"].FieldType)
+				} else {
+					assert.Equal(t, "varchar(64)", fm["namespace"].FieldType)
+					assert.Equal(t, "double", fm["login_rate"].FieldType)
+				}
 			case c.wantUserSQL != "":
 				fact, err := ins.InitQueryFactory(ctx, c.query, s, e)
 				assert.Nil(t, err)
@@ -1063,6 +1071,22 @@ func TestInstance_bkSql(t *testing.T) {
 			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` <= 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, _timestamp_",
 		},
 		{
+			name: "tspider single segment aggregate sum by process and user",
+			query: &metadata.Query{
+				StorageType: metadata.BkSqlStorageType,
+				DB:          "100656_dwd_clouddev_process_monitor_statistics",
+				Field:       "err_count",
+				Aggregates: metadata.Aggregates{
+					{
+						Name:       "sum",
+						Dimensions: []string{"process_name", "user_id"},
+						Window:     time.Minute,
+					},
+				},
+			},
+			expected: "SELECT `process_name`, `user_id`, SUM(`err_count`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `100656_dwd_clouddev_process_monitor_statistics` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` <= 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `process_name`, `user_id`, _timestamp_",
+		},
+		{
 			name: "conditions with or",
 			query: &metadata.Query{
 				DB:    "132_lol_new_login_queue_login_1min",
@@ -1686,10 +1710,13 @@ GROUP BY
 				"origin_field":     {AliasName: "alias_field", FieldType: sql_expr.DorisTypeText},
 				"path":             {FieldType: sql_expr.DorisTypeString},
 				"namespace":        {FieldType: sql_expr.DorisTypeString},
+				"process_name":     {FieldType: sql_expr.DorisTypeText},
+				"user_id":          {FieldType: sql_expr.DorisTypeText},
 				"ip":               {FieldType: sql_expr.DorisTypeString},
 				"thedate":          {FieldType: sql_expr.DorisTypeString},
 				"dtEventTimeStamp": {FieldType: sql_expr.DorisTypeDate},
 				"login_rate":       {FieldType: sql_expr.DorisTypeInt},
+				"err_count":        {FieldType: sql_expr.DorisTypeDouble},
 				"gseIndex":         {FieldType: sql_expr.DorisTypeInt},
 				"iterationIndex":   {FieldType: sql_expr.DorisTypeBigInt},
 				"value":            {FieldType: sql_expr.DorisTypeInt},

--- a/pkg/unify-query/tsdb/bksql/instance_test.go
+++ b/pkg/unify-query/tsdb/bksql/instance_test.go
@@ -128,6 +128,7 @@ func TestInstance_TSpider(t *testing.T) {
 		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`":             `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
 		"SHOW CREATE TABLE `36_game_bot_num_5min_stat`":                      `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"dsname","Type":"varchar(128)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"bot_num","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"game_id","Type":"bigint(20)","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
 		"SHOW CREATE TABLE `100656_dwd_clouddev_process_monitor_statistics`": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"process_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"user_id","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"err_count","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
+		"SHOW CREATE TABLE `empty_tspider_field_map`":                        `{"result":true,"message":"成功","code":"00","data":{"list":[]},"errors":null}`,
 	})
 
 	end := time.UnixMilli(1730118889181)
@@ -140,6 +141,7 @@ func TestInstance_TSpider(t *testing.T) {
 		fieldMap     bool
 		initFieldMap bool
 		wantUserSQL  string
+		wantErr      string
 	}{
 		"ShowCreateTable_QueryFieldMap": {
 			query: &metadata.Query{
@@ -175,6 +177,14 @@ func TestInstance_TSpider(t *testing.T) {
 			},
 			initFieldMap: true,
 		},
+		"InitQueryFactory_TSpiderEmptyFieldMap_Error": {
+			query: &metadata.Query{
+				StorageType: metadata.BkSqlStorageType,
+				DB:          "empty_tspider_field_map",
+				Field:       "login_rate",
+			},
+			wantErr: "query tspider field map empty for `empty_tspider_field_map`",
+		},
 		"InitQueryFactory_UserSQL_FieldMapAndSQL": {
 			query: &metadata.Query{
 				StorageType: metadata.BkSqlStorageType,
@@ -185,7 +195,7 @@ func TestInstance_TSpider(t *testing.T) {
 			},
 			start:       time.Unix(1741795260, 0),
 			end:         time.Unix(1741796260, 0),
-			wantUserSQL: "SELECT `dsname`, SUM(`bot_num`) AS total FROM `36_game_bot_num_5min_stat` WHERE `game_id` = 1 AND (`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` <= 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313') GROUP BY `dsname` ORDER BY `total` DESC LIMIT 50",
+			wantUserSQL: "SELECT `dsname`, SUM(`bot_num`) AS total FROM `36_game_bot_num_5min_stat` WHERE `game_id` = 1 AND (`dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` < 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313') GROUP BY `dsname` ORDER BY `total` DESC LIMIT 50",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -196,6 +206,9 @@ func TestInstance_TSpider(t *testing.T) {
 				e = end
 			}
 			switch {
+			case c.wantErr != "":
+				_, err := ins.InitQueryFactory(ctx, c.query, s, e)
+				assert.ErrorContains(t, err, c.wantErr)
 			case c.fieldMap:
 				fieldsMap, err := ins.QueryFieldMap(ctx, c.query, s, e)
 				assert.Nil(t, err)
@@ -1068,7 +1081,7 @@ func TestInstance_bkSql(t *testing.T) {
 					},
 				},
 			},
-			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` <= 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, _timestamp_",
+			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, _timestamp_",
 		},
 		{
 			name: "tspider single segment aggregate sum by process and user",
@@ -1084,7 +1097,7 @@ func TestInstance_bkSql(t *testing.T) {
 					},
 				},
 			},
-			expected: "SELECT `process_name`, `user_id`, SUM(`err_count`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `100656_dwd_clouddev_process_monitor_statistics` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` <= 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `process_name`, `user_id`, _timestamp_",
+			expected: "SELECT `process_name`, `user_id`, SUM(`err_count`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `100656_dwd_clouddev_process_monitor_statistics` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `process_name`, `user_id`, _timestamp_",
 		},
 		{
 			name: "conditions with or",

--- a/pkg/unify-query/tsdb/bksql/instance_test.go
+++ b/pkg/unify-query/tsdb/bksql/instance_test.go
@@ -1081,7 +1081,7 @@ func TestInstance_bkSql(t *testing.T) {
 					},
 				},
 			},
-			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, _timestamp_",
+			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, (FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, _timestamp_",
 		},
 		{
 			name: "tspider single segment aggregate sum by process and user",
@@ -1097,7 +1097,7 @@ func TestInstance_bkSql(t *testing.T) {
 					},
 				},
 			},
-			expected: "SELECT `process_name`, `user_id`, SUM(`err_count`) AS `_value_`, (CAST((FLOOR(dtEventTimeStamp + 0) / 60000) AS INT) * 60000 - 0) AS `_timestamp_` FROM `100656_dwd_clouddev_process_monitor_statistics` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `process_name`, `user_id`, _timestamp_",
+			expected: "SELECT `process_name`, `user_id`, SUM(`err_count`) AS `_value_`, (FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0) AS `_timestamp_` FROM `100656_dwd_clouddev_process_monitor_statistics` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `process_name`, `user_id`, _timestamp_",
 		},
 		{
 			name: "conditions with or",

--- a/pkg/unify-query/tsdb/bksql/instance_test.go
+++ b/pkg/unify-query/tsdb/bksql/instance_test.go
@@ -117,28 +117,30 @@ func TestInstance_ShowCreateTable_HDFS(t *testing.T) {
 	assert.False(t, fieldsMap["dteventtimestamp"].IsAnalyzed)
 }
 
-// TestInstance_TSpider 覆盖 TSpider 相关路径：SHOW CREATE 字段解析、InitQueryFactory 是否拉表结构、用户 SQL 下的 FieldsMap 与生成 SQL。
-// TSpider 使用 "Field" 作为字段名标识，Measurement 为空；SHOW CREATE 与 pkg/unify-query/mock/handler.go 中 mockBKBaseHandler 内 TSpider 表项保持一致（Set 为合并写入）。
+// TestInstance_TSpider 覆盖 TSpider 相关路径：SHOW CREATE 字段解析、PromQL 聚合路径拉表结构、用户 SQL 下的 FieldsMap 与生成 SQL。
+// TSpider 使用 "Field" 作为字段名标识；SHOW CREATE 与 pkg/unify-query/mock/handler.go 中 mockBKBaseHandler 内 TSpider 表项保持一致（Set 为合并写入）。
 func TestInstance_TSpider(t *testing.T) {
 	ctx := metadata.InitHashID(context.Background())
 	ins := createTestInstance(ctx)
 
 	mock.BkSQL.Set(map[string]any{
 		// tspider
-		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
-		"SHOW CREATE TABLE `36_game_bot_num_5min_stat`":          `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"dsname","Type":"varchar(128)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"bot_num","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"game_id","Type":"bigint(20)","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
+		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`":         `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
+		"SHOW CREATE TABLE `132_lol_new_login_queue_login_1min`.tspider": `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"MUL","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"flow_id","Type":"bigint(20)","Null":"YES","Key":"MUL","Default":null,"Extra":""},{"Field":"flow_name","Type":"text","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"namespace","Type":"varchar(64)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"login_rate","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null,"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000"}`,
+		"SHOW CREATE TABLE `36_game_bot_num_5min_stat`":                  `{"result":true,"message":"成功","code":"00","data":{"list":[{"Field":"thedate","Type":"int(11)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTime","Type":"varchar(32)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"dtEventTimeStamp","Type":"bigint(20)","Null":"NO","Key":"","Default":null,"Extra":""},{"Field":"localTime","Type":"varchar(32)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"dsname","Type":"varchar(128)","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"bot_num","Type":"double","Null":"YES","Key":"","Default":null,"Extra":""},{"Field":"game_id","Type":"bigint(20)","Null":"YES","Key":"","Default":null,"Extra":""}]},"errors":null}`,
 	})
 
 	end := time.UnixMilli(1730118889181)
 	start := time.UnixMilli(1730118589181)
 
 	for name, c := range map[string]struct {
-		query       *metadata.Query
-		start       time.Time
-		end         time.Time
-		fieldMap    bool
-		initNilFM   bool
-		wantUserSQL string
+		query        *metadata.Query
+		start        time.Time
+		end          time.Time
+		fieldMap     bool
+		initNilFM    bool
+		initFieldMap bool
+		wantUserSQL  string
 	}{
 		"ShowCreateTable_QueryFieldMap": {
 			query: &metadata.Query{
@@ -156,6 +158,16 @@ func TestInstance_TSpider(t *testing.T) {
 				SQL:         "",
 			},
 			initNilFM: true,
+		},
+		"InitQueryFactory_PromQLMeasurement_FieldMap": {
+			query: &metadata.Query{
+				StorageType: metadata.BkSqlStorageType,
+				DB:          "132_lol_new_login_queue_login_1min",
+				Measurement: sql_expr.TSpider,
+				Field:       "login_rate",
+				SQL:         "",
+			},
+			initFieldMap: true,
 		},
 		"InitQueryFactory_UserSQL_FieldMapAndSQL": {
 			query: &metadata.Query{
@@ -192,6 +204,15 @@ func TestInstance_TSpider(t *testing.T) {
 				assert.Nil(t, err)
 				assert.NotNil(t, fact)
 				assert.Nil(t, fact.FieldMap())
+			case c.initFieldMap:
+				fact, err := ins.InitQueryFactory(ctx, c.query, s, e)
+				assert.Nil(t, err)
+				assert.NotNil(t, fact)
+				fm := fact.FieldMap()
+				assert.NotEmpty(t, fm)
+				assert.Equal(t, "bigint(20)", fm["dtEventTimeStamp"].FieldType)
+				assert.Equal(t, "varchar(64)", fm["namespace"].FieldType)
+				assert.Equal(t, "double", fm["login_rate"].FieldType)
 			case c.wantUserSQL != "":
 				fact, err := ins.InitQueryFactory(ctx, c.query, s, e)
 				assert.Nil(t, err)

--- a/pkg/unify-query/tsdb/bksql/sql_expr/base.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/base.go
@@ -104,6 +104,7 @@ func NewSQLExpr(key string) SQLExpr {
 				ignoreFieldSet:            set.New[string](),
 				forceEq:                   true,
 				disableShardKeyTimeBucket: true,
+				disableTimeBucketCast:     true,
 			},
 		}
 	default:

--- a/pkg/unify-query/tsdb/bksql/sql_expr/base.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/base.go
@@ -101,8 +101,9 @@ func NewSQLExpr(key string) SQLExpr {
 	case TSpider:
 		return &TSpiderSQLExpr{
 			DorisSQLExpr: DorisSQLExpr{
-				ignoreFieldSet: set.New[string](),
-				forceEq:        true,
+				ignoreFieldSet:            set.New[string](),
+				forceEq:                   true,
+				disableShardKeyTimeBucket: true,
 			},
 		}
 	default:

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -82,6 +82,10 @@ type DorisSQLExpr struct {
 	// 而是直接使用 = / != 进行精确匹配。适用于 TSpider 等不支持全文检索的存储。
 	forceEq bool
 
+	// disableShardKeyTimeBucket 为 true 时，分钟级时间聚合也使用 timeField。
+	// TSpider 表没有 Doris 的 __shard_key__ 字段，需要走该兼容路径。
+	disableShardKeyTimeBucket bool
+
 	isSetLabels bool
 	lock        sync.Mutex
 }
@@ -244,9 +248,9 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 			timeZoneOffset *= -1
 		}
 
-		// 如果是按照分钟聚合，则使用 __shard_key__ 作为时间字段
+		// Doris 按分钟聚合时优先使用 __shard_key__，TSpider 等不具备该字段的存储使用 timeField。
 		var timeField string
-		if int64(window.Seconds())%60 == 0 {
+		if !d.disableShardKeyTimeBucket && int64(window.Seconds())%60 == 0 {
 			windowMinutes := int(window.Minutes())
 			timeField = fmt.Sprintf(`((CAST((FLOOR(%s / 1000) %s %d) / %d AS INT) * %d %s %d) * 60 * 1000)`, ShardKey, fh1, timeZoneOffset/6e4, windowMinutes, windowMinutes, fh2, timeZoneOffset/6e4)
 		} else {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -86,6 +86,10 @@ type DorisSQLExpr struct {
 	// TSpider 表没有 Doris 的 __shard_key__ 字段，需要走该兼容路径。
 	disableShardKeyTimeBucket bool
 
+	// disableTimeBucketCast 为 true 时，timeField 时间桶不生成 CAST(... AS INT)。
+	// TSpider 的 MySQL 语法检查不兼容该 CAST 写法。
+	disableTimeBucketCast bool
+
 	isSetLabels bool
 	lock        sync.Mutex
 }
@@ -253,6 +257,8 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 		if !d.disableShardKeyTimeBucket && int64(window.Seconds())%60 == 0 {
 			windowMinutes := int(window.Minutes())
 			timeField = fmt.Sprintf(`((CAST((FLOOR(%s / 1000) %s %d) / %d AS INT) * %d %s %d) * 60 * 1000)`, ShardKey, fh1, timeZoneOffset/6e4, windowMinutes, windowMinutes, fh2, timeZoneOffset/6e4)
+		} else if d.disableTimeBucketCast {
+			timeField = fmt.Sprintf(`(FLOOR((%s %s %d) / %d) * %d %s %d)`, d.timeField, fh1, timeZoneOffset, window.Milliseconds(), window.Milliseconds(), fh2, timeZoneOffset)
 		} else {
 			timeField = fmt.Sprintf(`(CAST((FLOOR(%s %s %d) / %d) AS INT) * %d %s %d)`, d.timeField, fh1, timeZoneOffset, window.Milliseconds(), window.Milliseconds(), fh2, timeZoneOffset)
 		}

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -1040,4 +1041,107 @@ func TestDorisSQLExpr_ParserAggregatesAndOrders_ValueFieldIgnore(t *testing.T) {
 		}
 		assert.Equal(t, "COUNT(`log`) AS `"+Value+"`", valueExpr)
 	})
+}
+
+func TestTSpiderSQLExpr_ParserAggregatesAndOrders_UsesFieldsMapAndTimeField(t *testing.T) {
+	encode := func(s string) string { return "`" + s + "`" }
+	fieldsMap := metadata.FieldsMap{
+		"dtEventTimeStamp": {FieldType: DorisTypeBigInt},
+		"suc_rate":         {FieldType: DorisTypeDouble},
+		"err_cnt":          {FieldType: DorisTypeDouble},
+		"err_count":        {FieldType: DorisTypeDouble},
+		"process_name":     {FieldType: DorisTypeText},
+		"user_id":          {FieldType: DorisTypeText},
+	}
+
+	t.Run("avg uses real value field and dtEventTimeStamp bucket", func(t *testing.T) {
+		expr := NewSQLExpr(TSpider).
+			WithInternalFields("dtEventTimeStamp", "suc_rate").
+			WithFieldsMap(fieldsMap).
+			WithEncode(encode)
+
+		selectFields, _, _, _, _, err := expr.ParserAggregatesAndOrders(
+			nil,
+			metadata.Aggregates{{Name: "avg", Window: time.Minute}},
+			metadata.Orders{},
+		)
+		assert.NoError(t, err)
+
+		got := strings.Join(selectFields, ", ")
+		assert.Contains(t, got, "AVG(`suc_rate`) AS `"+Value+"`")
+		assert.Contains(t, got, "dtEventTimeStamp")
+		assert.NotContains(t, got, "AVG(NULL)")
+		assert.NotContains(t, got, ShardKey)
+	})
+
+	t.Run("sum by dimension uses real fields and dtEventTimeStamp bucket", func(t *testing.T) {
+		expr := NewSQLExpr(TSpider).
+			WithInternalFields("dtEventTimeStamp", "err_cnt").
+			WithFieldsMap(fieldsMap).
+			WithEncode(encode)
+
+		selectFields, groupByFields, _, _, _, err := expr.ParserAggregatesAndOrders(
+			nil,
+			metadata.Aggregates{{Name: "sum", Dimensions: []string{"user_id"}, Window: time.Minute}},
+			metadata.Orders{},
+		)
+		assert.NoError(t, err)
+
+		gotSelect := strings.Join(selectFields, ", ")
+		gotGroupBy := strings.Join(groupByFields, ", ")
+		assert.Contains(t, gotSelect, "`user_id`")
+		assert.Contains(t, gotSelect, "SUM(`err_cnt`) AS `"+Value+"`")
+		assert.Contains(t, gotSelect, "dtEventTimeStamp")
+		assert.Contains(t, gotGroupBy, "`user_id`")
+		assert.NotContains(t, gotSelect, "NULL AS user_id")
+		assert.NotContains(t, gotSelect, "SUM(NULL)")
+		assert.NotContains(t, gotSelect, ShardKey)
+	})
+
+	t.Run("sum by process_name and user_id matches promql trace regression", func(t *testing.T) {
+		expr := NewSQLExpr(TSpider).
+			WithInternalFields("dtEventTimeStamp", "err_count").
+			WithFieldsMap(fieldsMap).
+			WithEncode(encode)
+
+		selectFields, groupByFields, _, _, _, err := expr.ParserAggregatesAndOrders(
+			nil,
+			metadata.Aggregates{{Name: "sum", Dimensions: []string{"process_name", "user_id"}, Window: time.Minute}},
+			metadata.Orders{},
+		)
+		assert.NoError(t, err)
+
+		gotSelect := strings.Join(selectFields, ", ")
+		gotGroupBy := strings.Join(groupByFields, ", ")
+		assert.Contains(t, gotSelect, "`process_name`")
+		assert.Contains(t, gotSelect, "`user_id`")
+		assert.Contains(t, gotSelect, "SUM(`err_count`) AS `"+Value+"`")
+		assert.Contains(t, gotSelect, "dtEventTimeStamp")
+		assert.Contains(t, gotGroupBy, "`process_name`")
+		assert.Contains(t, gotGroupBy, "`user_id`")
+		assert.NotContains(t, gotSelect, "NULL AS process_name")
+		assert.NotContains(t, gotSelect, "NULL AS user_id")
+		assert.NotContains(t, gotSelect, "SUM(NULL)")
+		assert.NotContains(t, gotSelect, ShardKey)
+	})
+}
+
+func TestDorisSQLExpr_ParserAggregatesAndOrders_UsesShardKeyForMinuteBucket(t *testing.T) {
+	expr := NewSQLExpr(Doris).
+		WithInternalFields("dtEventTimeStamp", "login_rate").
+		WithFieldsMap(metadata.FieldsMap{
+			"dtEventTimeStamp": {FieldType: DorisTypeBigInt},
+			"login_rate":       {FieldType: DorisTypeDouble},
+		}).
+		WithEncode(func(s string) string { return "`" + s + "`" })
+
+	selectFields, _, _, _, _, err := expr.ParserAggregatesAndOrders(
+		nil,
+		metadata.Aggregates{{Name: "count", Window: time.Minute}},
+		metadata.Orders{},
+	)
+	assert.NoError(t, err)
+
+	got := strings.Join(selectFields, ", ")
+	assert.Contains(t, got, ShardKey)
 }

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris_test.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -1041,107 +1040,4 @@ func TestDorisSQLExpr_ParserAggregatesAndOrders_ValueFieldIgnore(t *testing.T) {
 		}
 		assert.Equal(t, "COUNT(`log`) AS `"+Value+"`", valueExpr)
 	})
-}
-
-func TestTSpiderSQLExpr_ParserAggregatesAndOrders_UsesFieldsMapAndTimeField(t *testing.T) {
-	encode := func(s string) string { return "`" + s + "`" }
-	fieldsMap := metadata.FieldsMap{
-		"dtEventTimeStamp": {FieldType: DorisTypeBigInt},
-		"suc_rate":         {FieldType: DorisTypeDouble},
-		"err_cnt":          {FieldType: DorisTypeDouble},
-		"err_count":        {FieldType: DorisTypeDouble},
-		"process_name":     {FieldType: DorisTypeText},
-		"user_id":          {FieldType: DorisTypeText},
-	}
-
-	t.Run("avg uses real value field and dtEventTimeStamp bucket", func(t *testing.T) {
-		expr := NewSQLExpr(TSpider).
-			WithInternalFields("dtEventTimeStamp", "suc_rate").
-			WithFieldsMap(fieldsMap).
-			WithEncode(encode)
-
-		selectFields, _, _, _, _, err := expr.ParserAggregatesAndOrders(
-			nil,
-			metadata.Aggregates{{Name: "avg", Window: time.Minute}},
-			metadata.Orders{},
-		)
-		assert.NoError(t, err)
-
-		got := strings.Join(selectFields, ", ")
-		assert.Contains(t, got, "AVG(`suc_rate`) AS `"+Value+"`")
-		assert.Contains(t, got, "dtEventTimeStamp")
-		assert.NotContains(t, got, "AVG(NULL)")
-		assert.NotContains(t, got, ShardKey)
-	})
-
-	t.Run("sum by dimension uses real fields and dtEventTimeStamp bucket", func(t *testing.T) {
-		expr := NewSQLExpr(TSpider).
-			WithInternalFields("dtEventTimeStamp", "err_cnt").
-			WithFieldsMap(fieldsMap).
-			WithEncode(encode)
-
-		selectFields, groupByFields, _, _, _, err := expr.ParserAggregatesAndOrders(
-			nil,
-			metadata.Aggregates{{Name: "sum", Dimensions: []string{"user_id"}, Window: time.Minute}},
-			metadata.Orders{},
-		)
-		assert.NoError(t, err)
-
-		gotSelect := strings.Join(selectFields, ", ")
-		gotGroupBy := strings.Join(groupByFields, ", ")
-		assert.Contains(t, gotSelect, "`user_id`")
-		assert.Contains(t, gotSelect, "SUM(`err_cnt`) AS `"+Value+"`")
-		assert.Contains(t, gotSelect, "dtEventTimeStamp")
-		assert.Contains(t, gotGroupBy, "`user_id`")
-		assert.NotContains(t, gotSelect, "NULL AS user_id")
-		assert.NotContains(t, gotSelect, "SUM(NULL)")
-		assert.NotContains(t, gotSelect, ShardKey)
-	})
-
-	t.Run("sum by process_name and user_id matches promql trace regression", func(t *testing.T) {
-		expr := NewSQLExpr(TSpider).
-			WithInternalFields("dtEventTimeStamp", "err_count").
-			WithFieldsMap(fieldsMap).
-			WithEncode(encode)
-
-		selectFields, groupByFields, _, _, _, err := expr.ParserAggregatesAndOrders(
-			nil,
-			metadata.Aggregates{{Name: "sum", Dimensions: []string{"process_name", "user_id"}, Window: time.Minute}},
-			metadata.Orders{},
-		)
-		assert.NoError(t, err)
-
-		gotSelect := strings.Join(selectFields, ", ")
-		gotGroupBy := strings.Join(groupByFields, ", ")
-		assert.Contains(t, gotSelect, "`process_name`")
-		assert.Contains(t, gotSelect, "`user_id`")
-		assert.Contains(t, gotSelect, "SUM(`err_count`) AS `"+Value+"`")
-		assert.Contains(t, gotSelect, "dtEventTimeStamp")
-		assert.Contains(t, gotGroupBy, "`process_name`")
-		assert.Contains(t, gotGroupBy, "`user_id`")
-		assert.NotContains(t, gotSelect, "NULL AS process_name")
-		assert.NotContains(t, gotSelect, "NULL AS user_id")
-		assert.NotContains(t, gotSelect, "SUM(NULL)")
-		assert.NotContains(t, gotSelect, ShardKey)
-	})
-}
-
-func TestDorisSQLExpr_ParserAggregatesAndOrders_UsesShardKeyForMinuteBucket(t *testing.T) {
-	expr := NewSQLExpr(Doris).
-		WithInternalFields("dtEventTimeStamp", "login_rate").
-		WithFieldsMap(metadata.FieldsMap{
-			"dtEventTimeStamp": {FieldType: DorisTypeBigInt},
-			"login_rate":       {FieldType: DorisTypeDouble},
-		}).
-		WithEncode(func(s string) string { return "`" + s + "`" })
-
-	selectFields, _, _, _, _, err := expr.ParserAggregatesAndOrders(
-		nil,
-		metadata.Aggregates{{Name: "count", Window: time.Minute}},
-		metadata.Orders{},
-	)
-	assert.NoError(t, err)
-
-	got := strings.Join(selectFields, ", ")
-	assert.Contains(t, got, ShardKey)
 }

--- a/pkg/unify-query/tsdb/bksql/sql_expr/tspider.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/tspider.go
@@ -11,6 +11,7 @@ package sql_expr
 
 import (
 	"context"
+	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/doris_parser"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
@@ -54,6 +55,10 @@ func (t *TSpiderSQLExpr) WithFieldsMap(fieldsMap metadata.FieldsMap) SQLExpr {
 func (t *TSpiderSQLExpr) WithKeepColumns(cols []string) SQLExpr {
 	t.DorisSQLExpr.WithKeepColumns(cols)
 	return t
+}
+
+func (t *TSpiderSQLExpr) ParserRangeTime(timeField string, start, end time.Time) string {
+	return t.DefaultSQLExpr.ParserRangeTime(timeField, start, end)
 }
 
 func (t *TSpiderSQLExpr) ParserSQL(ctx context.Context, q string, tables []string, where string, offset, limit int, tableFieldsMap doris_parser.TableFieldsMap) (string, error) {


### PR DESCRIPTION
## 背景
TSpider 指标通过 PromQL 聚合查询时，UQ 会复用 Doris 的 SQL 表达式生成逻辑。线上发现部分 TSpider 查询生成了异常 SQL：真实存在的指标/维度字段被改写成 NULL，例如 SUM(NULL)、NULL AS user_id，同时分钟聚合使用了 Doris 的 __shard_key__ 分桶字段，但实际 TSpider 表结构中不存在该字段，导致 BKSQL 语义检查失败。
## 摘要
本 PR 修复 TSpider PromQL 聚合 SQL 生成逻辑：
- TSpider PromQL 聚合路径补充加载表结构 FieldsMap，确保 err_count、process_name、user_id 等真实字段能正确生成 SQL，不再被误判为未知字段并改写成 NULL。
- TSpider 分钟级时间聚合不再使用 Doris 专属的 __shard_key__，改为使用 dtEventTimeStamp 做时间分桶，并保持 < end 半开区间。
- 保持 Doris 原有 __shard_key__ 分桶逻辑不变。
- 补充回归测试，覆盖截图中的 sum(sum_over_time(...err_count[1m])) by (process_name, user_id) 场景。