### PR TITLE
fix: 修复 chrony 查询与脚本采集的资源泄漏问题

### DIFF
--- a/pkg/bkmonitorbeat/tasks/timesync/client_linux.go
+++ b/pkg/bkmonitorbeat/tasks/timesync/client_linux.go
@@ -26,6 +26,10 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
+var newChronyConn = func(addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("udp", addr, timeout)
+}
+
 type Client struct {
 	opt *Option
 }
@@ -99,7 +103,7 @@ func (c *Client) queryNtpd() (*Stat, error) {
 }
 
 func (c *Client) queryChrony() (*Stat, error) {
-	conn, err := net.DialTimeout("udp", c.opt.ChronyAddr, c.opt.Timeout)
+	conn, err := newChronyConn(c.opt.ChronyAddr, c.opt.Timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +113,7 @@ func (c *Client) queryChrony() (*Stat, error) {
 		Sequence:   1,
 		Connection: conn,
 	}
-	packet, err := client.Communicate(chrony.NewSourcesPacket())
+	packet, err := c.communicateChrony(conn, &client, chrony.NewSourcesPacket())
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +124,7 @@ func (c *Client) queryChrony() (*Stat, error) {
 
 	stat := newStat("chrony")
 	for i := 0; i < sources.NSources; i++ {
-		packet, err = client.Communicate(chrony.NewSourceDataPacket(int32(i)))
+		packet, err = c.communicateChrony(conn, &client, chrony.NewSourceDataPacket(int32(i)))
 		if err != nil {
 			logger.Warnf("client communicate error: %v", err)
 			stat.Err++
@@ -146,4 +150,12 @@ func (c *Client) queryChrony() (*Stat, error) {
 		stat.Add(sourceData.LatestMeas)
 	}
 	return stat, nil
+}
+
+func (c *Client) communicateChrony(conn net.Conn, client *chrony.Client, packet chrony.RequestPacket) (chrony.ResponsePacket, error) {
+	if err := conn.SetDeadline(time.Now().Add(c.opt.Timeout)); err != nil {
+		return nil, err
+	}
+
+	return client.Communicate(packet)
 }

--- a/pkg/bkmonitorbeat/tasks/timesync/client_linux_test.go
+++ b/pkg/bkmonitorbeat/tasks/timesync/client_linux_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package timesync
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQueryChronyTimeoutClosesConn(t *testing.T) {
+	originalNewChronyConn := newChronyConn
+	defer func() {
+		newChronyConn = originalNewChronyConn
+	}()
+
+	clientConn, serverConn := net.Pipe()
+	newChronyConn = func(addr string, timeout time.Duration) (net.Conn, error) {
+		return clientConn, nil
+	}
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		defer serverConn.Close()
+
+		buf := make([]byte, 1024)
+		_, _ = serverConn.Read(buf)
+		time.Sleep(200 * time.Millisecond)
+	}()
+
+	cli := NewClient(&Option{
+		ChronyAddr: "[::1]:323",
+		Timeout:    50 * time.Millisecond,
+	})
+
+	start := time.Now()
+	_, err := cli.queryChrony()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "timeout") {
+		t.Fatalf("expected timeout-related error, got %v", err)
+	}
+	if elapsed > 150*time.Millisecond {
+		t.Fatalf("expected queryChrony to return near timeout, took %v", elapsed)
+	}
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("server side connection was not closed in time")
+	}
+}

--- a/pkg/bkmonitorbeat/utils/pipes.go
+++ b/pkg/bkmonitorbeat/utils/pipes.go
@@ -55,6 +55,18 @@ func runString(ctx context.Context, s string, userEnvs map[string]string, userna
 			logger.Infof("item:%s", item)
 		}
 	}
+
+	// Pre-check all executables exist before forking, to avoid pidfd leak on
+	// exec failure in Go < 1.23.1 (go.dev/issue/69284: fork succeeds, allocates
+	// pidfd via CLONE_PIDFD, but exec fails and pidfd is never closed).
+	for _, cs := range sp {
+		if len(cs) > 0 {
+			if _, err := exec.LookPath(cs[0]); err != nil {
+				return "", fmt.Errorf("executable not found %q: %w", cs[0], err)
+			}
+		}
+	}
+
 	notify := make(chan error, 1)
 	defer close(notify)
 


### PR DESCRIPTION
## 变更说明

- 为 chrony 查询设置 I/O 超时，避免 chronyd 无响应时 `Read` 长时间阻塞，导致 goroutine 和 UDP socket 持续累积。
- 脚本采集任务在启动子进程前预检可执行文件；命令不存在时直接返回，避免 Go 1.23.0 中 fork 后 exec 失败造成 pidfd 泄漏。

## 验证

- 补充 chrony 查询超时与连接关闭的单元测试。