### PR TITLE
fix: (unify-query)修复 Doris raw 查询字段别名导致 NULL 投影和排序 --bug=160722631

### DIFF
--- a/pkg/unify-query/query/structured/query_ts_test.go
+++ b/pkg/unify-query/query/structured/query_ts_test.go
@@ -694,7 +694,7 @@ func TestBkData_SQL_ToFinalSQL(t *testing.T) {
 				ReferenceName: "a",
 				Limit:         10,
 			},
-			wantSQL: "SELECT *, NULL AS `_value_`, `dtEventTimeStamp` AS `_timestamp_` FROM `2_bklog_unit_test`.doris WHERE `dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` <= 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313' LIMIT 10",
+			wantSQL: "SELECT *, `dtEventTimeStamp` AS `_timestamp_` FROM `2_bklog_unit_test`.doris WHERE `dtEventTimeStamp` >= 1741795260000 AND `dtEventTimeStamp` <= 1741796260000 AND `dtEventTime` >= '2025-03-13 00:01:00' AND `dtEventTime` <= '2025-03-13 00:17:41' AND `thedate` = '20250313' LIMIT 10",
 		},
 		{
 			// 用户自定义 SQL 仅聚合（count），仍追加时间窗口（与带 SELECT 列表的 user sql 一致）

--- a/pkg/unify-query/tsdb/bksql/format_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_test.go
@@ -249,6 +249,26 @@ func TestNewSqlFactory(t *testing.T) {
 			},
 			expected: "SELECT CAST(__ext['container_id'] AS STRING) AS `__ext__bk_46__container_id`, COUNT(CAST(__ext['container_id'] AS STRING)) AS `_value_`, ((CAST((FLOOR(__shard_key__ / 1000) + 0) / 1440 AS INT) * 1440 - 0) * 60 * 1000) AS `_timestamp_` FROM `5000140_bklog_container_log_demo_analysis`.doris WHERE `dtEventTimeStamp` >= 1741935945000 AND `dtEventTimeStamp` <= 1742456145000 AND `dtEventTime` >= '2025-03-14 15:05:45' AND `dtEventTime` <= '2025-03-20 15:35:46' AND `thedate` >= '20250314' AND `thedate` <= '20250320' GROUP BY __ext__bk_46__container_id, _timestamp_",
 		},
+		"Doris 原始查询携带字段别名时不应生成 NULL 投影和排序": {
+			start: time.Unix(1784108029, 336*int64(time.Millisecond)),
+			end:   time.Unix(1784108929, 336*int64(time.Millisecond)),
+			query: &metadata.Query{
+				DB:          "2_bklog_2_p8oibru8se2clq50",
+				Measurement: sql_expr.Doris,
+				Field:       "dtEventTimeStamp",
+				FieldAlias: metadata.FieldAlias{
+					"dtEventTimeStamp": "dtEventTimeStampNanos",
+				},
+				Size: 10000,
+				Orders: metadata.Orders{
+					{
+						Name: "dtEventTimeStamp",
+						Ast:  false,
+					},
+				},
+			},
+			expected: "SELECT *, `dtEventTimeStamp` AS `_timestamp_` FROM `2_bklog_2_p8oibru8se2clq50`.doris WHERE `dtEventTimeStamp` >= 1784108029336 AND `dtEventTimeStamp` <= 1784108929336 AND `dtEventTime` >= '2026-07-15 17:33:49' AND `dtEventTime` <= '2026-07-15 17:48:50' AND `thedate` = '20260715' ORDER BY `dtEventTimeStamp` DESC LIMIT 10000",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := metadata.InitHashID(context.Background())

--- a/pkg/unify-query/tsdb/bksql/format_test.go
+++ b/pkg/unify-query/tsdb/bksql/format_test.go
@@ -269,6 +269,46 @@ func TestNewSqlFactory(t *testing.T) {
 			},
 			expected: "SELECT *, `dtEventTimeStamp` AS `_timestamp_` FROM `2_bklog_2_p8oibru8se2clq50`.doris WHERE `dtEventTimeStamp` >= 1784108029336 AND `dtEventTimeStamp` <= 1784108929336 AND `dtEventTime` >= '2026-07-15 17:33:49' AND `dtEventTime` <= '2026-07-15 17:48:50' AND `thedate` = '20260715' ORDER BY `dtEventTimeStamp` DESC LIMIT 10000",
 		},
+		"Doris 原始查询未投影 _value_ 时应跳过 _value 排序": {
+			start: time.Unix(1784108029, 336*int64(time.Millisecond)),
+			end:   time.Unix(1784108929, 336*int64(time.Millisecond)),
+			query: &metadata.Query{
+				DB:          "2_bklog_2_p8oibru8se2clq50",
+				Measurement: sql_expr.Doris,
+				Field:       "dtEventTimeStamp",
+				FieldAlias: metadata.FieldAlias{
+					"dtEventTimeStamp": "dtEventTimeStampNanos",
+				},
+				Size: 10000,
+				Orders: metadata.Orders{
+					{
+						Name: sql_expr.FieldValue,
+						Ast:  false,
+					},
+				},
+			},
+			expected: "SELECT *, `dtEventTimeStamp` AS `_timestamp_` FROM `2_bklog_2_p8oibru8se2clq50`.doris WHERE `dtEventTimeStamp` >= 1784108029336 AND `dtEventTimeStamp` <= 1784108929336 AND `dtEventTime` >= '2026-07-15 17:33:49' AND `dtEventTime` <= '2026-07-15 17:48:50' AND `thedate` = '20260715' LIMIT 10000",
+		},
+		"Doris 原始查询缺失非时间字段别名时应跳过排序": {
+			start: time.Unix(1784108029, 336*int64(time.Millisecond)),
+			end:   time.Unix(1784108929, 336*int64(time.Millisecond)),
+			query: &metadata.Query{
+				DB:          "2_bklog_2_p8oibru8se2clq50",
+				Measurement: sql_expr.Doris,
+				Field:       "dtEventTimeStamp",
+				FieldAlias: metadata.FieldAlias{
+					"pod_namespace": "__ext.pod.namespace",
+				},
+				Size: 10000,
+				Orders: metadata.Orders{
+					{
+						Name: "pod_namespace",
+						Ast:  false,
+					},
+				},
+			},
+			expected: "SELECT *, `dtEventTimeStamp` AS `_value_`, `dtEventTimeStamp` AS `_timestamp_` FROM `2_bklog_2_p8oibru8se2clq50`.doris WHERE `dtEventTimeStamp` >= 1784108029336 AND `dtEventTimeStamp` <= 1784108929336 AND `dtEventTime` >= '2026-07-15 17:33:49' AND `dtEventTime` <= '2026-07-15 17:48:50' AND `thedate` = '20260715' LIMIT 10000",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := metadata.InitHashID(context.Background())

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -293,7 +293,7 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 			selectFields = append(selectFields, SelectAll)
 		}
 
-		if valueField != "" {
+		if valueField != "" && valueField != metadata.Null {
 			selectFields = append(selectFields, fmt.Sprintf("%s AS `%s`", valueField, Value))
 		}
 		if d.timeField != "" {
@@ -321,7 +321,10 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 			orderField = order.Name
 		}
 
-		orderField, _ = d.dimTransform(orderField)
+		orderField = d.orderFieldTransform(orderField)
+		if orderField == "" {
+			continue
+		}
 
 		// 移除重复的排序字段
 		if orderNameSet.Existed(orderField) {
@@ -337,6 +340,19 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 	}
 
 	return selectFields, groupByFields, orderByFields, dimensionSet, timeAggregate, err
+}
+
+func (d *DorisSQLExpr) orderFieldTransform(field string) string {
+	transformed, _ := d.dimTransform(field)
+	if transformed != metadata.Null {
+		return transformed
+	}
+
+	if field == d.timeField || d.fieldAlias.OriginField(field) != "" {
+		return fmt.Sprintf("`%s`", normalizeDorisFieldName(field))
+	}
+
+	return ""
 }
 
 func (d *DorisSQLExpr) ParserRangeTime(timeField string, start, end time.Time) string {

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -191,6 +191,7 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 	var (
 		window         time.Duration
 		timeZoneOffset int64
+		// valueProjected 标记 SELECT 中是否真的生成了 `_value_`，避免 raw 查询跳过 NULL 投影后仍按 `_value` 排序。
 		valueProjected bool
 	)
 

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -191,6 +191,7 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 	var (
 		window         time.Duration
 		timeZoneOffset int64
+		valueProjected bool
 	)
 
 	dimensionSet = set.New[string]([]string{FieldValue}...)
@@ -224,10 +225,12 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 		switch agg.Name {
 		case "cardinality":
 			selectFields = append(selectFields, fmt.Sprintf("COUNT(DISTINCT %s) AS `%s`", valueField, Value))
+			valueProjected = true
 		// date_histogram 不支持无需进行函数聚合
 		case "date_histogram":
 		default:
 			selectFields = append(selectFields, fmt.Sprintf("%s(%s) AS `%s`", strings.ToUpper(agg.Name), valueField, Value))
+			valueProjected = true
 		}
 
 		if agg.Window > 0 {
@@ -295,6 +298,7 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 
 		if valueField != "" && valueField != metadata.Null {
 			selectFields = append(selectFields, fmt.Sprintf("%s AS `%s`", valueField, Value))
+			valueProjected = true
 		}
 		if d.timeField != "" {
 			selectFields = append(selectFields, fmt.Sprintf("`%s` AS `%s`", d.timeField, TimeStamp))
@@ -314,6 +318,9 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 		var orderField string
 		switch order.Name {
 		case FieldValue:
+			if !valueProjected {
+				continue
+			}
 			orderField = Value
 		case FieldTime:
 			orderField = TimeStamp
@@ -348,7 +355,7 @@ func (d *DorisSQLExpr) orderFieldTransform(field string) string {
 		return transformed
 	}
 
-	if field == d.timeField || d.fieldAlias.OriginField(field) != "" {
+	if field == d.timeField {
 		return fmt.Sprintf("`%s`", normalizeDorisFieldName(field))
 	}
 


### PR DESCRIPTION
## 变更说明

修复 Doris raw 查询在携带字段别名时生成不可执行 SQL 的问题。

## 根因

核心原因是 `dimTransform` 判断字段是否存在时依赖的是 `fieldsMap`，也就是 BKBase `SHOW CREATE TABLE` 返回的物理表字段；它没有反映 `query.FieldAlias` 中的逻辑字段存在性。

这次请求使用逻辑字段 `dtEventTimeStamp`，同时路由字段别名配置为：

```text
dtEventTimeStamp -> dtEventTimeStampNanos
```

`dimTransform("dtEventTimeStamp")` 会先按 `FieldAlias` 转成物理字段 `dtEventTimeStampNanos`，然后再到 `fieldsMap` 中查找。但当前 Doris raw SQL 构造路径没有命中 `dtEventTimeStampNanos` 的字段表结构，所以 `dimTransform` 返回 `NULL`。

由此产生两处异常 SQL：

1. `_value_` 投影路径：`query.Field` 来自请求里的 `field_name=dtEventTimeStamp`，进入 `ParserAggregatesAndOrders` 后赋给 `vf := d.valueField`。`dimTransform(vf)` 返回 `NULL` 后，旧逻辑继续拼成 `NULL AS _value_`，Doris 会报 `NULL_LITERAL` 类型错误。

2. 排序路径：请求里的 `order_by=["-dtEventTimeStamp"]` 转成 `metadata.Order{Name:"dtEventTimeStamp", Ast:false}`。旧逻辑对排序字段执行 `dimTransform` 后得到 `NULL`，最终生成 `ORDER BY NULL DESC`。

## 修复内容

- raw 无聚合查询中，如果 valueField 转换结果为 `NULL`，不再追加 `NULL AS _value_`。
- 排序字段转换失败为 `NULL` 时，对内置时间字段或 `FieldAlias` 中存在的逻辑字段回退到原始字段名，避免生成 `ORDER BY NULL`。
- 增加 Doris raw 查询携带字段别名的表驱动测试覆盖。

## 验证

```bash
cd pkg/unify-query
go test ./tsdb/bksql ./tsdb/bksql/sql_expr -count=1
go test ./query/structured -count=1
```
