### PR TITLE
fix(unify-query): 修复 ES 索引查询范围被限制为半年 --bug=160831615

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -632,7 +632,6 @@ func (i *Instance) explainDB(ctx context.Context, db string, needAddTime bool, s
 	end = end.In(loc)
 
 	left := end.Unix() - start.Unix()
-	// 超过 6 个月
 
 	span.Set("timezone", loc.String())
 	span.Set("start", start.String())
@@ -642,11 +641,6 @@ func (i *Instance) explainDB(ctx context.Context, db string, needAddTime bool, s
 	var unit string
 
 	if left > int64(time.Hour.Seconds()*24*14) {
-		halfYear := time.Hour * 24 * 30 * 6
-		if left > int64(halfYear.Seconds()) {
-			start = end.Add(halfYear * -1)
-		}
-
 		unit = "month"
 	} else {
 		unit = "day"

--- a/pkg/unify-query/tsdb/elasticsearch/instance_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance_test.go
@@ -119,7 +119,18 @@ func TestInstance_getAlias(t *testing.T) {
 			end:         time.Date(2024, 8, 1, 20, 0, 0, 0, time.UTC),
 			needAddTime: true,
 			sourceType:  structured.BkData,
-			expected:    []string{"db_test_202402*", "db_test_202403*", "db_test_202404*", "db_test_202405*", "db_test_202406*", "db_test_202407*", "db_test_202408*"},
+			expected:    []string{"db_test_202401*", "db_test_202402*", "db_test_202403*", "db_test_202404*", "db_test_202405*", "db_test_202406*", "db_test_202407*", "db_test_202408*"},
+		},
+		"2y with bklog": {
+			start:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			end:         time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC),
+			needAddTime: true,
+			expected: []string{
+				"db_test_202401*", "db_test_202402*", "db_test_202403*", "db_test_202404*", "db_test_202405*", "db_test_202406*",
+				"db_test_202407*", "db_test_202408*", "db_test_202409*", "db_test_202410*", "db_test_202411*", "db_test_202412*",
+				"db_test_202501*", "db_test_202502*", "db_test_202503*", "db_test_202504*", "db_test_202505*", "db_test_202506*",
+				"db_test_202507*", "db_test_202508*", "db_test_202509*", "db_test_202510*", "db_test_202511*", "db_test_202512*",
+			},
 		},
 		"2m and db": {
 			start:       time.Date(2024, 1, 1, 20, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## 问题

用户查询两年时间范围的 bklog 索引集时，UQ 生成的 ES range 条件仍是完整两年，但索引别名展开只覆盖结束时间前约 6 个月，导致更早月份的数据不会被查询。

线上 trace 中可见：

- 请求时间范围：`2024-01-01 00:00:00 ~ 2025-12-31 23:59:59`（Asia/Shanghai）
- ES range：仍使用完整两年范围
- ES indexes：只展开 `202507* ~ 202512*`

## 历史上下文

半年限制不是本次新增逻辑。`git blame` 显示该逻辑最早来自 `214fed073`（`feat: es 查询优化 --story=118743765 (#456)`，2024-07-31），随后在 `a52ca631`（`feat: es 索引时间分片修复 --story=119103950 (#482)`，2024-08-13）重构时保留，并且历史测试里的 7 个月用例也固化了只返回后 6 个月索引的行为。

因此这里更像是历史上的查询范围保护/索引数保护，而不是偶发 bug。但当前实现没有向调用方返回错误、告警或 partial 标识，而是静默缩小索引范围；同时 ES range 条件仍展示完整两年，调用方会误以为完整查询成功，最终造成数据缺失。

## 修复

- 移除 ES `explainDB` 中超过 6 个月时强制改写 `start = end - 180天` 的静默截断逻辑。
- 保留超过 14 天按月展开索引的策略，但完整覆盖请求的起止时间。
- 补充两年 bklog 查询范围的索引展开用例，并修正 7 个月 bkdata 用例期望。

## 风险与后续

该变更会让长时间范围查询展开更多月级索引，可能增加 ES 查询开销。如果仍需要限制长时间查询，建议后续改成显式策略：通过配置控制最大展开范围/最大索引数，并在超过限制时返回明确错误或 partial 信息，而不是静默截断。

## 验证

- `go test ./tsdb/elasticsearch -run TestInstance_getAlias -count=1`
- `go test ./tsdb/elasticsearch`
