### PR TITLE
fix(unify-query): 避免 ES 别名扫描并限制查询跨度

### DIFF
--- a/pkg/unify-query/es/alias.go
+++ b/pkg/unify-query/es/alias.go
@@ -22,7 +22,8 @@ import (
 var aliasMap map[string]map[string]bool
 var aliasLock *sync.RWMutex
 
-// AliasExist 判断别名是否存在
+// AliasExist 判断别名是否存在。
+// Deprecated: 查询链路已不再依赖 alias 缓存，仅为兼容旧调用保留。
 func AliasExist(tableID string, alias string) bool {
 	aliasLock.RLock()
 	defer aliasLock.RUnlock()
@@ -36,7 +37,8 @@ func AliasExist(tableID string, alias string) bool {
 	return ok
 }
 
-// RefreshAllAlias 并发刷新整个别名map
+// RefreshAllAlias 并发刷新整个别名 map，会请求实际 ES _alias 接口。
+// Deprecated: 服务不会再调用该方法，仅为兼容旧调用保留。
 func RefreshAllAlias() {
 	type aliasRefreshTarget struct {
 		tableID   string

--- a/pkg/unify-query/es/client.go
+++ b/pkg/unify-query/es/client.go
@@ -11,6 +11,7 @@ package es
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -20,7 +21,7 @@ import (
 )
 
 type Client interface {
-	Search(body string, indexNames ...string) (string, error)
+	Search(ctx context.Context, body string, indexNames ...string) (string, error)
 	Aliases() (string, error)
 	AliasWithIndex(index string) (string, error)
 	Indices() (string, error)
@@ -52,20 +53,38 @@ var NewClient = func(info *ESInfo) (Client, error) {
 }
 
 // Search es 接口 _search 代理
-func (c *ESClient) Search(body string, indexNames ...string) (string, error) {
-	c.tokenChan <- 1
+func (c *ESClient) Search(ctx context.Context, body string, indexNames ...string) (string, error) {
+	select {
+	case c.tokenChan <- 1:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
 	defer func() {
 		<-c.tokenChan
 	}()
 	es := c.client
-	result, err := es.Search(es.Search.WithIndex(indexNames...), es.Search.WithBody(strings.NewReader(body)))
+	result, err := es.Search(
+		es.Search.WithContext(ctx),
+		es.Search.WithIndex(indexNames...),
+		es.Search.WithBody(strings.NewReader(body)),
+		es.Search.WithIgnoreUnavailable(true),
+		es.Search.WithAllowNoIndices(true),
+	)
 	if err != nil {
-		log.Errorf(context.TODO(), "search index:%v,body:%s failed for:%s", indexNames, body, err)
+		log.Errorf(ctx, "search index:%v,body:%s failed for:%s", indexNames, body, err)
 		return "", err
 	}
+	defer result.Body.Close()
+
 	res, err := io.ReadAll(result.Body)
-	log.Debugf(context.TODO(), "search index:%v,body:%s get result:%s", indexNames, body, res)
-	return string(res), err
+	if err != nil {
+		return "", err
+	}
+	if result.IsError() {
+		return "", fmt.Errorf("es search failed: status=%s body=%s", result.Status(), res)
+	}
+	log.Debugf(ctx, "search index:%v,body:%s get result:%s", indexNames, body, res)
+	return string(res), nil
 }
 
 // Aliases 获取 alias
@@ -85,7 +104,8 @@ func (c *ESClient) Aliases() (string, error) {
 	return string(res), err
 }
 
-// AliasWithIndex 通过 index 获取 alias
+// AliasWithIndex 通过 index 获取 alias。
+// Deprecated: 服务查询链路已不再调用该接口。
 func (c *ESClient) AliasWithIndex(index string) (string, error) {
 	c.tokenChan <- 1
 	defer func() {

--- a/pkg/unify-query/es/client_test.go
+++ b/pkg/unify-query/es/client_test.go
@@ -1,0 +1,59 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package es
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
+)
+
+func TestSearchAllowsMissingTargets(t *testing.T) {
+	log.InitTestLogger()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/missing,existing/_search", r.URL.Path)
+		assert.Equal(t, "true", r.URL.Query().Get("ignore_unavailable"))
+		assert.Equal(t, "true", r.URL.Query().Get("allow_no_indices"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":0},"hits":[]}}`)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&ESInfo{Host: server.URL, MaxConcurrency: 1})
+	require.NoError(t, err)
+	result, err := client.Search(context.Background(), `{}`, "missing", "existing")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"hits":{"total":{"value":0},"hits":[]}}`, result)
+}
+
+func TestSearchReturnsElasticsearchError(t *testing.T) {
+	log.InitTestLogger()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"bad query"}`)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&ESInfo{Host: server.URL, MaxConcurrency: 1})
+	require.NoError(t, err)
+	_, err = client.Search(context.Background(), `{}`, "existing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400 Bad Request")
+}

--- a/pkg/unify-query/es/es.go
+++ b/pkg/unify-query/es/es.go
@@ -29,15 +29,15 @@ func init() {
 }
 
 // SearchByStorage 根据存储信息以及查询语句，获取es查询结果
-func SearchByStorage(storageID int, body string, aliases []string) (string, error) {
+func SearchByStorage(ctx context.Context, storageID int, body string, targets []string) (string, error) {
 	storageLock.RLock()
-	defer storageLock.RUnlock()
 	client, ok := storageMap[strconv.Itoa(storageID)]
+	storageLock.RUnlock()
 	if !ok {
-		log.Errorf(context.TODO(), "get storage by id:%d failed", storageID)
+		log.Errorf(ctx, "get storage by id:%d failed", storageID)
 		return "", ErrStorageNotFound
 	}
-	return client.Search(body, aliases...)
+	return client.Search(ctx, body, targets...)
 }
 
 // GetStorageID 根据 tableID 获取 es 集群信息

--- a/pkg/unify-query/es/mocktest/mock_client.go
+++ b/pkg/unify-query/es/mocktest/mock_client.go
@@ -14,6 +14,7 @@
 package mocktest
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -88,10 +89,10 @@ func (mr *MockClientMockRecorder) Indices() *gomock.Call {
 }
 
 // Search mocks base method.
-func (m *MockClient) Search(arg0 string, arg1 ...string) (string, error) {
+func (m *MockClient) Search(arg0 context.Context, arg1 string, arg2 ...string) (string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Search", varargs...)
@@ -101,8 +102,8 @@ func (m *MockClient) Search(arg0 string, arg1 ...string) (string, error) {
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockClientMockRecorder) Search(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Search(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockClient)(nil).Search), varargs...)
 }

--- a/pkg/unify-query/query/es/errors.go
+++ b/pkg/unify-query/query/es/errors.go
@@ -12,5 +12,9 @@ package es
 import "errors"
 
 var (
-	ErrNoAliases = errors.New("no aliases found")
+	ErrNoAliases          = errors.New("no aliases found")
+	ErrInvalidTimeRange   = errors.New("invalid query time range")
+	ErrTimeRangeTooLarge  = errors.New("query time range is too large")
+	ErrInvalidDateFormat  = errors.New("invalid es date format")
+	ErrInvalidAliasFormat = errors.New("invalid es alias format")
 )

--- a/pkg/unify-query/query/es/es.go
+++ b/pkg/unify-query/query/es/es.go
@@ -11,11 +11,17 @@ package es
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/es"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
+)
+
+const (
+	consulAliasFormat = "{index}_{time}_read"
+	consulDateFormat  = "20060102"
 )
 
 // Params 查询传入参数
@@ -28,57 +34,88 @@ type Params struct {
 	Start int64
 	// 查询时间终点
 	End int64
-	// 是否模糊匹配，该参数开启时，按旧版get_es_data的查询逻辑进行查询
-	// 开启模糊匹配后，start和end将失效，查询的index将直接传入
-	// 关闭模糊匹配时，查询模块将根据format、index、start、end自动生成一系列查询别名传入到查询请求中
+	// 是否模糊匹配。开启时会根据查询时间生成带日期的索引通配符。
+	// 关闭时根据 format、index、start、end 生成查询别名。
 	FuzzyMatching bool
 }
 
 // Query 查询数据，将结果以json格式返回
-func Query(q *Params) (string, error) {
-	info, err := es.GetStorageID(q.TableID)
-	if err != nil {
-		log.Errorf(context.TODO(), "get storage id by table id:%s failed,error:%s", q.TableID, err)
+func Query(ctx context.Context, q *Params) (string, error) {
+	if err := validateTimeRange(q); err != nil {
 		return "", err
 	}
-	aliases := formatAliases(info, q)
-	if len(aliases) == 0 {
-		log.Errorf(context.TODO(), "no alias found by query:%#v", q)
+
+	info, err := es.GetStorageID(q.TableID)
+	if err != nil {
+		log.Errorf(ctx, "get storage id by table id:%s failed,error:%s", q.TableID, err)
+		return "", err
+	}
+	targets, err := formatQueryTargets(info, q)
+	if err != nil {
+		return "", err
+	}
+	if len(targets) == 0 {
+		log.Errorf(ctx, "no es query target found by query:%#v", q)
 		return "", ErrNoAliases
 	}
-	return es.SearchByStorage(info.StorageID, q.Body, aliases)
+	return es.SearchByStorage(ctx, info.StorageID, q.Body, targets)
 }
 
-// 根据格式处理成对应的alias
-func formatAliases(info *es.TableInfo, q *Params) []string {
-	// 启动模糊匹配时，直接传入index即可
-	if q.FuzzyMatching {
-		log.Debugf(context.TODO(), "query %#v use fuzzy matching", q)
-		return []string{es.ConvertTableIDToFuzzyIndexName(q.TableID)}
+func validateTimeRange(q *Params) error {
+	if q == nil || q.End <= q.Start {
+		return ErrInvalidTimeRange
 	}
-	// 否则根据format规则生成一系列别名查询
-	appendTimeList := make([]string, 0)
+
+	maxTimeRange := maxQueryTimeRange()
 	start := time.Unix(q.Start, 0)
 	end := time.Unix(q.End, 0)
-	temp := start
-	// 去重
-	lastDate := ""
-	for temp.Before(end) {
-		appendTime := temp.Format(info.DateFormat)
-		if lastDate != appendTime {
-			appendTimeList = append(appendTimeList, appendTime)
-			lastDate = appendTime
-		}
-		temp = temp.Add(time.Duration(info.DateStep) * time.Hour)
+	if end.Sub(start) > maxTimeRange {
+		return fmt.Errorf("%w: maximum is %s", ErrTimeRangeTooLarge, maxTimeRange)
 	}
-	result := make([]string, 0)
-	for _, appendTime := range appendTimeList {
-		alias := strings.Replace(info.AliasFormat, "{index}", es.ConvertTableIDToIndexName(q.TableID), -1)
-		alias = strings.Replace(alias, "{time}", appendTime, -1)
-		if es.AliasExist(q.TableID, alias) {
-			result = append(result, alias)
+	return nil
+}
+
+// 根据格式处理成对应的 alias 或索引通配符。
+func formatQueryTargets(info *es.TableInfo, q *Params) ([]string, error) {
+	if info == nil || info.DateFormat != consulDateFormat {
+		return nil, ErrInvalidDateFormat
+	}
+
+	// 3.8 ES 元数据默认按 UTC 创建索引和别名；旧 Consul 协议没有下发自定义时区。
+	start := time.Unix(q.Start, 0).UTC()
+	end := time.Unix(q.End, 0).UTC()
+	appendTimeList := make([]string, 0)
+	appendTimeSet := make(map[string]struct{})
+	startDate := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
+	endDate := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, end.Location())
+	for current := startDate; !current.After(endDate); current = current.AddDate(0, 0, 1) {
+		date := current.Format(info.DateFormat)
+		if _, ok := appendTimeSet[date]; ok {
+			continue
 		}
+		appendTimeSet[date] = struct{}{}
+		appendTimeList = append(appendTimeList, date)
+	}
+
+	result := make([]string, 0)
+	indexName := es.ConvertTableIDToIndexName(q.TableID)
+	if !q.FuzzyMatching && info.AliasFormat != consulAliasFormat {
+		return nil, ErrInvalidAliasFormat
+	}
+	for _, date := range appendTimeList {
+		if q.FuzzyMatching {
+			// 兼容 v1/v2 物理索引，同时用表名前缀边界避免匹配到其他结果表。
+			result = append(result,
+				fmt.Sprintf("%s_%s*", indexName, date),
+				fmt.Sprintf("v2_%s_%s*", indexName, date),
+			)
+			continue
+		}
+		alias := strings.Replace(info.AliasFormat, "{index}", indexName, -1)
+		// Consul 只下发日格式，实际 read alias 可按小时创建，因此日期后保留受限通配符。
+		alias = strings.Replace(alias, "{time}", date+"*", -1)
+		result = append(result, alias)
 	}
 	log.Debugf(context.TODO(), "query %#v get aliases:%v", q, result)
-	return result
+	return result, nil
 }

--- a/pkg/unify-query/query/es/es_test.go
+++ b/pkg/unify-query/query/es/es_test.go
@@ -10,7 +10,8 @@
 package es_test
 
 import (
-	"encoding/json"
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -34,34 +35,24 @@ type TestSuite struct {
 // TestSearch
 func TestSearch(t *testing.T) {
 	log.InitTestLogger()
+	t.Setenv(inner.MaxQueryTimeRangeEnv, "168h")
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	// mock掉client，模拟真实查询es数据动作
 	client := mocktest.NewMockClient(ctrl)
 
-	// 模拟一个时间和请求，制造假的alias信息
-	start := time.Now().Add(-24 * time.Hour)
-	now := time.Now()
+	// 模拟一个时间和请求，确认查询直接使用按日期生成的 alias。
+	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
 	tableID := "testbb.ttt"
 	index := "testbb_ttt"
 	body := "{\"size\":5}"
 	startTimeFormat := start.Format("20060102")
-	nowTimeFormat := now.Format("20060102")
-	startTime := fmt.Sprintf("%s_%s_read", index, startTimeFormat)
-	nowTime := fmt.Sprintf("%s_%s_read", index, nowTimeFormat)
-	aliases := []string{startTime, nowTime}
-	aliasInfo := map[string]*es.AliasInfo{
-		"testbb_ttt_20210407_01": {
-			Aliases: map[string]interface{}{
-				startTime: map[string]interface{}{},
-				nowTime:   map[string]interface{}{},
-			},
-		},
-	}
-	aliasInfoStr, _ := json.Marshal(aliasInfo)
-	client.EXPECT().AliasWithIndex("*"+index+"*").Return(string(aliasInfoStr), nil)
-	client.EXPECT().Search(body, aliases).Return(`any result`, nil)
+	endTimeFormat := end.Format("20060102")
+	startTime := fmt.Sprintf("%s_%s*_read", index, startTimeFormat)
+	endTime := fmt.Sprintf("%s_%s*_read", index, endTimeFormat)
+	client.EXPECT().Search(gomock.Any(), body, startTime, endTime).Return(`any result`, nil)
 	stubs := gostub.StubFunc(&es.NewClient, client, nil)
 	defer stubs.Reset()
 
@@ -85,18 +76,21 @@ func TestSearch(t *testing.T) {
 	assert.Nil(t, err)
 	err = es.ReloadStorage(storages)
 	assert.Nil(t, err)
-	es.RefreshAllAlias()
-	assert.Nil(t, err)
 	q := &inner.Params{
 		TableID: tableID,
 		Body:    body,
 		Start:   start.Unix(),
-		End:     now.Unix(),
+		End:     end.Unix(),
 	}
 
 	// 测试基于假的alias,storage,table信息能否正常返回查询结果
-	result, err := inner.Query(q)
+	result, err := inner.Query(context.Background(), q)
 	assert.Nil(t, err)
 	assert.Equal(t, "any result", result)
 
+	// fuzzy 模式也必须先通过跨度校验，超限请求不能触发 ES 查询。
+	q.FuzzyMatching = true
+	q.End = start.Add(7*24*time.Hour + time.Second).Unix()
+	_, err = inner.Query(context.Background(), q)
+	assert.True(t, errors.Is(err, inner.ErrTimeRangeTooLarge))
 }

--- a/pkg/unify-query/query/es/setting.go
+++ b/pkg/unify-query/query/es/setting.go
@@ -1,0 +1,41 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package es
+
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	MaxQueryTimeRangeConfigPath = "es.max_query_time_range"
+	MaxQueryTimeRangeEnv        = "UNIFY_QUERY_ES_MAX_QUERY_TIME_RANGE"
+	legacyMaxQueryTimeRangeEnv  = "UNIFY-QUERY_ES_MAX_QUERY_TIME_RANGE"
+	defaultMaxQueryTimeRange    = 7 * 24 * time.Hour
+)
+
+func init() {
+	viper.SetDefault(MaxQueryTimeRangeConfigPath, defaultMaxQueryTimeRange)
+	// 显式绑定全下划线变量，避免现有 UNIFY-QUERY 前缀中的连字符影响部署系统注入。
+	_ = viper.BindEnv(
+		MaxQueryTimeRangeConfigPath,
+		MaxQueryTimeRangeEnv,
+		legacyMaxQueryTimeRangeEnv,
+	)
+}
+
+func maxQueryTimeRange() time.Duration {
+	duration := viper.GetDuration(MaxQueryTimeRangeConfigPath)
+	if duration <= 0 {
+		return defaultMaxQueryTimeRange
+	}
+	return duration
+}

--- a/pkg/unify-query/query/es/setting_test.go
+++ b/pkg/unify-query/query/es/setting_test.go
@@ -1,0 +1,114 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package es
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corees "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/es"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
+)
+
+func TestValidateTimeRange(t *testing.T) {
+	t.Setenv(MaxQueryTimeRangeEnv, "168h")
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.Local)
+
+	testCases := []struct {
+		name string
+		end  time.Time
+		err  error
+	}{
+		{name: "exact maximum", end: start.Add(7 * 24 * time.Hour)},
+		{name: "over maximum", end: start.Add(7*24*time.Hour + time.Second), err: ErrTimeRangeTooLarge},
+		{name: "empty range", end: start, err: ErrInvalidTimeRange},
+		{name: "reversed range", end: start.Add(-time.Second), err: ErrInvalidTimeRange},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := validateTimeRange(&Params{Start: start.Unix(), End: testCase.end.Unix()})
+			if testCase.err == nil {
+				require.NoError(t, err)
+				return
+			}
+			assert.True(t, errors.Is(err, testCase.err), err)
+		})
+	}
+	assert.ErrorIs(t, validateTimeRange(nil), ErrInvalidTimeRange)
+}
+
+func TestMaxQueryTimeRangeFromEnvironment(t *testing.T) {
+	t.Setenv(MaxQueryTimeRangeEnv, "48h")
+	assert.Equal(t, 48*time.Hour, maxQueryTimeRange())
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	err := validateTimeRange(&Params{Start: start.Unix(), End: start.Add(48*time.Hour + time.Second).Unix()})
+	assert.ErrorIs(t, err, ErrTimeRangeTooLarge)
+}
+
+func TestMaxQueryTimeRangeFromLegacyEnvironment(t *testing.T) {
+	t.Setenv(MaxQueryTimeRangeEnv, "")
+	t.Setenv(legacyMaxQueryTimeRangeEnv, "24h")
+	assert.Equal(t, 24*time.Hour, maxQueryTimeRange())
+}
+
+func TestMaxQueryTimeRangeFallsBackForInvalidValue(t *testing.T) {
+	t.Setenv(MaxQueryTimeRangeEnv, "not-a-duration")
+	assert.Equal(t, defaultMaxQueryTimeRange, maxQueryTimeRange())
+}
+
+func TestFormatQueryTargetsIncludesCrossBoundaryEnd(t *testing.T) {
+	log.InitTestLogger()
+	start := time.Date(2024, 1, 1, 23, 30, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	info := &corees.TableInfo{
+		AliasFormat: "{index}_{time}_read",
+		DateFormat:  "20060102",
+		DateStep:    120,
+	}
+
+	aliases, err := formatQueryTargets(info, &Params{
+		TableID: "testbb.ttt",
+		Start:   start.Unix(),
+		End:     end.Unix(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"testbb_ttt_20240101*_read", "testbb_ttt_20240102*_read"}, aliases)
+
+	fuzzyAliases, err := formatQueryTargets(info, &Params{
+		TableID:       "testbb.ttt",
+		Start:         start.Unix(),
+		End:           end.Unix(),
+		FuzzyMatching: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"testbb_ttt_20240101*",
+		"v2_testbb_ttt_20240101*",
+		"testbb_ttt_20240102*",
+		"v2_testbb_ttt_20240102*",
+	}, fuzzyAliases)
+}
+
+func TestFormatQueryTargetsRejectsInvalidFormats(t *testing.T) {
+	_, err := formatQueryTargets(&corees.TableInfo{}, &Params{})
+	assert.ErrorIs(t, err, ErrInvalidDateFormat)
+
+	_, err = formatQueryTargets(&corees.TableInfo{DateFormat: "2006010215"}, &Params{})
+	assert.ErrorIs(t, err, ErrInvalidDateFormat)
+
+	_, err = formatQueryTargets(&corees.TableInfo{DateFormat: "20060102"}, &Params{})
+	assert.ErrorIs(t, err, ErrInvalidAliasFormat)
+}

--- a/pkg/unify-query/service/es/hook.go
+++ b/pkg/unify-query/service/es/hook.go
@@ -22,18 +22,15 @@ import (
 // setDefaultConfig
 func setDefaultConfig() {
 	viper.SetDefault(MaxConcurrencyConfigPath, 200)
-	viper.SetDefault(AliasRefreshPeriodConfigPath, "1m")
 }
 
 // LoadConfig
 func LoadConfig() {
 
 	MaxConcurrency = viper.GetInt(MaxConcurrencyConfigPath)
-	AliasRefreshPeriod = viper.GetDuration(AliasRefreshPeriodConfigPath)
 
-	log.Debugf(context.TODO(), "reload success new config max concurrency->[%d] alias refresh period->[%s]"+
-		"going to reload the service.",
-		MaxConcurrency, AliasRefreshPeriod)
+	log.Debugf(context.TODO(), "reload success new config max concurrency->[%d], going to reload the service.",
+		MaxConcurrency)
 }
 
 // init

--- a/pkg/unify-query/service/es/service.go
+++ b/pkg/unify-query/service/es/service.go
@@ -12,7 +12,6 @@ package es
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/spf13/viper"
 
@@ -162,32 +161,6 @@ func (s *Service) loopReloadTableInfo(ctx context.Context) error {
 	return nil
 }
 
-// loopRefreshAliasInfo
-func (s *Service) loopRefreshAliasInfo(ctx context.Context) error {
-	es.RefreshAllAlias()
-	duration := AliasRefreshPeriod
-
-	ticker := time.NewTicker(duration)
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				log.Warnf(context.TODO(), "alias refresh exit")
-				return
-			case <-ticker.C:
-				log.Debugf(context.TODO(), "ticker alarm,start refresh alias")
-				es.RefreshAllAlias()
-				log.Debugf(context.TODO(), "refresh alias done")
-			}
-		}
-
-	}()
-	return nil
-}
-
 // Reload
 func (s *Service) Reload(ctx context.Context) {
 	if s.wg == nil {
@@ -213,11 +186,6 @@ func (s *Service) Reload(ctx context.Context) {
 	err = s.loopReloadTableInfo(s.ctx)
 	if err != nil {
 		log.Errorf(context.TODO(), "start loop reload es table info failed for->[%s]", err)
-		return
-	}
-	err = s.loopRefreshAliasInfo(s.ctx)
-	if err != nil {
-		log.Errorf(context.TODO(), "start loop refresh es alias info failed for->[%s]", err)
 		return
 	}
 	log.Warnf(context.TODO(), "es service reloaded or start success.")

--- a/pkg/unify-query/service/es/settings.go
+++ b/pkg/unify-query/service/es/settings.go
@@ -9,14 +9,10 @@
 
 package es
 
-import "time"
-
 const (
-	MaxConcurrencyConfigPath     = "es.max_concurrency"
-	AliasRefreshPeriodConfigPath = "es.alias_refresh_period"
+	MaxConcurrencyConfigPath = "es.max_concurrency"
 )
 
 var (
-	MaxConcurrency     int
-	AliasRefreshPeriod time.Duration
+	MaxConcurrency int
 )

--- a/pkg/unify-query/service/http/es.go
+++ b/pkg/unify-query/service/http/es.go
@@ -12,6 +12,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/gin-gonic/gin"
@@ -79,6 +80,13 @@ func HandleESQueryRequest(c *gin.Context) {
 		c.JSON(400, ErrResponse{err.Error()})
 		return
 	}
+	if req == nil || req.Time == nil || req.Query == nil {
+		err = errors.New("invalid es query request")
+		log.Errorf(ctx, "validate es request failed for->[%s]", err)
+		metric.APIRequestInc(ctx, servicePath, metric.StatusFailed, user.SpaceUid)
+		c.JSON(400, ErrResponse{err.Error()})
+		return
+	}
 	params := &es.Params{
 		TableID:       req.TableID,
 		Start:         req.Time.Start,
@@ -86,7 +94,7 @@ func HandleESQueryRequest(c *gin.Context) {
 		Body:          req.Query.Body,
 		FuzzyMatching: req.Query.FuzzyMatching,
 	}
-	result, err := es.Query(params)
+	result, err := es.Query(ctx, params)
 	if err != nil {
 		log.Errorf(context.TODO(), "query es failed for->[%s]", err)
 		metric.APIRequestInc(ctx, servicePath, metric.StatusFailed, user.SpaceUid)

--- a/pkg/unify-query/service/http/es_test.go
+++ b/pkg/unify-query/service/http/es_test.go
@@ -10,7 +10,6 @@
 package http_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"strconv"
@@ -38,27 +37,16 @@ func TestHandleESRequest(t *testing.T) {
 	// mock掉client，模拟真实查询es数据动作
 	client := mocktest.NewMockClient(ctrl)
 
-	// 模拟一个时间和请求，制造假的alias信息
-	start := time.Now().Add(-24 * time.Hour)
-	now := time.Now()
+	// 模拟一个时间和请求，确认 HTTP 请求直接使用按日期生成的 alias。
+	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
 	index := "testbb_ttt"
 	body := "{\"size\":5}"
 	startTimeFormat := start.Format("20060102")
-	nowTimeFormat := now.Format("20060102")
-	startTime := fmt.Sprintf("%s_%s_read", index, startTimeFormat)
-	nowTime := fmt.Sprintf("%s_%s_read", index, nowTimeFormat)
-	aliases := []string{startTime, nowTime}
-	aliasInfo := map[string]*es.AliasInfo{
-		"testbb_ttt_20210407_01": {
-			Aliases: map[string]interface{}{
-				startTime: map[string]interface{}{},
-				nowTime:   map[string]interface{}{},
-			},
-		},
-	}
-	aliasInfoStr, _ := json.Marshal(aliasInfo)
-	client.EXPECT().AliasWithIndex("*"+index+"*").Return(string(aliasInfoStr), nil)
-	client.EXPECT().Search(body, aliases).Return(`any result`, nil)
+	endTimeFormat := end.Format("20060102")
+	startTime := fmt.Sprintf("%s_%s*_read", index, startTimeFormat)
+	endTime := fmt.Sprintf("%s_%s*_read", index, endTimeFormat)
+	client.EXPECT().Search(gomock.Any(), body, startTime, endTime).Return(`any result`, nil)
 	stubs := gostub.StubFunc(&es.NewClient, client, nil)
 	defer stubs.Reset()
 
@@ -79,7 +67,6 @@ func TestHandleESRequest(t *testing.T) {
 
 	es.ReloadStorage(storages)
 	es.ReloadTableInfo(infos)
-	es.RefreshAllAlias()
 	g := gin.Default()
 	g.POST("/es_query", servicehttp.HandleESQueryRequest)
 
@@ -88,7 +75,7 @@ func TestHandleESRequest(t *testing.T) {
 		result string
 	}{
 		{
-			data:   `{"table_id":"testbb.ttt","time":{"start":` + strconv.FormatInt(start.Unix(), 10) + `,"end":` + strconv.FormatInt(now.Unix(), 10) + `},"query":{"body":"{\"size\":5}"}}`,
+			data:   `{"table_id":"testbb.ttt","time":{"start":` + strconv.FormatInt(start.Unix(), 10) + `,"end":` + strconv.FormatInt(end.Unix(), 10) + `},"query":{"body":"{\"size\":5}"}}`,
 			result: `any result`,
 		},
 	}
@@ -99,4 +86,35 @@ func TestHandleESRequest(t *testing.T) {
 		assert.Equal(t, 200, w.Code)
 		assert.Equal(t, testCase.result, w.Body.String())
 	}
+}
+
+func TestHandleESRequestRejectsInvalidTimeRange(t *testing.T) {
+	log.InitTestLogger()
+	t.Setenv("UNIFY_QUERY_ES_MAX_QUERY_TIME_RANGE", "168h")
+	g := gin.Default()
+	g.POST("/es_query", servicehttp.HandleESQueryRequest)
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.Local)
+	end := start.Add(7*24*time.Hour + time.Second)
+	data := `{"table_id":"testbb.ttt","time":{"start":` + strconv.FormatInt(start.Unix(), 10) +
+		`,"end":` + strconv.FormatInt(end.Unix(), 10) + `},"query":{"body":"{}"}}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/es_query", strings.NewReader(data))
+	g.ServeHTTP(w, req)
+
+	assert.Equal(t, 400, w.Code)
+	assert.Contains(t, w.Body.String(), "query time range is too large")
+}
+
+func TestHandleESRequestRejectsMissingFields(t *testing.T) {
+	log.InitTestLogger()
+	g := gin.Default()
+	g.POST("/es_query", servicehttp.HandleESQueryRequest)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/es_query", strings.NewReader(`{"table_id":"testbb.ttt"}`))
+	g.ServeHTTP(w, req)
+
+	assert.Equal(t, 400, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid es query request")
 }

--- a/pkg/unify-query/unify-query.yaml
+++ b/pkg/unify-query/unify-query.yaml
@@ -43,7 +43,7 @@ influxdb:
   tolerance: 5
 es:
   max_concurrency: 200
-  alias_refresh_period: 1m
+  max_query_time_range: 168h
 http:
   address: 127.0.0.1
   path:


### PR DESCRIPTION
## 背景

3.8.x 的 unify-query ES 服务会在启动时及定时任务中，针对每个结果表请求真实 ES `_alias` 并缓存别名。该实现会带来周期性的集群元数据请求、别名缓存刷新窗口，以及新别名短时间内不可查询的问题。

## 改动

- 移除 `es.Service` 的启动及周期性 alias 刷新。
- 按 UTC 自然日直接构造受结果表约束的查询目标：
  - 普通模式：`<index>_YYYYMMDD*_read`，兼容日级和小时级 read alias。
  - fuzzy 模式：限定为对应日期的 v1/v2 索引模式，不再查询全历史。
- ES Search 增加 `ignore_unavailable=true` 和 `allow_no_indices=true`，允许部分或全部目标不存在。
- 透传请求 Context，等待并发令牌时支持取消，并正确关闭响应体、识别 ES HTTP 错误。
- 增加查询时间跨度限制：
  - 默认最大 `168h`，刚好 7 天允许。
  - 配置项：`es.max_query_time_range`。
  - 环境变量：`UNIFY_QUERY_ES_MAX_QUERY_TIME_RANGE`。
  - 非法或反向时间范围直接返回 400。
- 补充缺失请求字段校验，避免空指针。
- 旧 alias 缓存 API 标记为 Deprecated，仅保留源码兼容，生产查询链路不再调用。

## 影响

- 查询时不再预扫描真实 ES alias，也没有分钟级缓存一致性窗口。
- 不存在的日期 alias 不会导致整次查询 404；存在的目标正常返回，全部不存在时返回空结果。
- `fuzzy_matching=true` 现在也要求合法时间范围，且受最大跨度限制。

## 验证

- `go test -count=1 ./es ./query/es ./service/es`
- `go test -count=1 es.go settings.go es_test.go`（ES HTTP handler 定向测试）
- `go vet ./es ./query/es ./service/es`
- `git diff --check origin/3.8.x..HEAD`

完整 `service/http` 包测试仍被 3.8.x 基线已有的 `consul.SetInstance` 测试参数不匹配阻断，与本次修改无关。