### PR TITLE
fix: 修复 TSpider 时间聚合使用 _timestamp_ 别名分组的问题 --bug=161110817

### DIFF
--- a/pkg/unify-query/tsdb/bksql/instance_test.go
+++ b/pkg/unify-query/tsdb/bksql/instance_test.go
@@ -1081,7 +1081,7 @@ func TestInstance_bkSql(t *testing.T) {
 					},
 				},
 			},
-			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, (FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, _timestamp_",
+			expected: "SELECT `namespace`, COUNT(`login_rate`) AS `_value_`, MAX(FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0) AS `_timestamp_` FROM `132_lol_new_login_queue_login_1min` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `namespace`, (FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0)",
 		},
 		{
 			name: "tspider single segment aggregate sum by process and user",
@@ -1097,7 +1097,29 @@ func TestInstance_bkSql(t *testing.T) {
 					},
 				},
 			},
-			expected: "SELECT `process_name`, `user_id`, SUM(`err_count`) AS `_value_`, (FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0) AS `_timestamp_` FROM `100656_dwd_clouddev_process_monitor_statistics` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `process_name`, `user_id`, _timestamp_",
+			expected: "SELECT `process_name`, `user_id`, SUM(`err_count`) AS `_value_`, MAX(FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0) AS `_timestamp_` FROM `100656_dwd_clouddev_process_monitor_statistics` WHERE `dtEventTimeStamp` >= 1718189940000 AND `dtEventTimeStamp` < 1718193555000 AND `dtEventTime` >= '2024-06-12 18:59:00' AND `dtEventTime` <= '2024-06-12 19:59:16' AND `thedate` = '20240612' GROUP BY `process_name`, `user_id`, (FLOOR((dtEventTimeStamp + 0) / 60000) * 60000 - 0)",
+		},
+		{
+			name: "tspider hourly aggregate groups by time bucket expression",
+			query: &metadata.Query{
+				StorageType: metadata.BkSqlStorageType,
+				DB:          "100680_alpha_server_perf_data",
+				Field:       "sum_Sub8MsFrames",
+				Aggregates: metadata.Aggregates{
+					{
+						Name:       "sum",
+						Dimensions: []string{"partition_hour", "datacenter", "deployment"},
+						Window:     time.Hour,
+					},
+				},
+				Orders: metadata.Orders{
+					{Name: "_time", Ast: true},
+				},
+				Size: 2000005,
+			},
+			start:    time.UnixMilli(1776905999999),
+			end:      time.UnixMilli(1784685599999),
+			expected: "SELECT `partition_hour`, `datacenter`, `deployment`, SUM(`sum_Sub8MsFrames`) AS `_value_`, MAX(FLOOR((dtEventTimeStamp + 0) / 3600000) * 3600000 - 0) AS `_timestamp_` FROM `100680_alpha_server_perf_data` WHERE `dtEventTimeStamp` >= 1776905999999 AND `dtEventTimeStamp` < 1784685599999 AND `dtEventTime` >= '2026-04-23 08:59:59' AND `dtEventTime` <= '2026-07-22 10:00:00' AND `thedate` >= '20260423' AND `thedate` <= '20260722' GROUP BY `partition_hour`, `datacenter`, `deployment`, (FLOOR((dtEventTimeStamp + 0) / 3600000) * 3600000 - 0) ORDER BY `_timestamp_` ASC LIMIT 2000005",
 		},
 		{
 			name: "conditions with or",
@@ -1767,6 +1789,10 @@ WHERE
 				"namespace":        {FieldType: sql_expr.DorisTypeString},
 				"process_name":     {FieldType: sql_expr.DorisTypeText},
 				"user_id":          {FieldType: sql_expr.DorisTypeText},
+				"partition_hour":   {FieldType: sql_expr.DorisTypeText},
+				"datacenter":       {FieldType: sql_expr.DorisTypeText},
+				"deployment":       {FieldType: sql_expr.DorisTypeText},
+				"sum_Sub8MsFrames": {FieldType: sql_expr.DorisTypeDouble},
 				"ip":               {FieldType: sql_expr.DorisTypeString},
 				"thedate":          {FieldType: sql_expr.DorisTypeString},
 				"dtEventTimeStamp": {FieldType: sql_expr.DorisTypeDate},

--- a/pkg/unify-query/tsdb/bksql/sql_expr/base.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/base.go
@@ -105,6 +105,7 @@ func NewSQLExpr(key string) SQLExpr {
 				forceEq:                   true,
 				disableShardKeyTimeBucket: true,
 				disableTimeBucketCast:     true,
+				groupTimeBucketByExpr:     true,
 			},
 		}
 	default:

--- a/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
+++ b/pkg/unify-query/tsdb/bksql/sql_expr/doris.go
@@ -90,6 +90,10 @@ type DorisSQLExpr struct {
 	// TSpider 的 MySQL 语法检查不兼容该 CAST 写法。
 	disableTimeBucketCast bool
 
+	// groupTimeBucketByExpr 为 true 时，使用完整时间桶表达式分组。
+	// TSpider 的语义检查不会将 SELECT 别名识别为 GROUP BY 字段。
+	groupTimeBucketByExpr bool
+
 	isSetLabels bool
 	lock        sync.Mutex
 }
@@ -263,8 +267,13 @@ func (d *DorisSQLExpr) ParserAggregatesAndOrders(selectDistinct []string, aggreg
 			timeField = fmt.Sprintf(`(CAST((FLOOR(%s %s %d) / %d) AS INT) * %d %s %d)`, d.timeField, fh1, timeZoneOffset, window.Milliseconds(), window.Milliseconds(), fh2, timeZoneOffset)
 		}
 
-		selectFields = append(selectFields, fmt.Sprintf("%s AS `%s`", timeField, TimeStamp))
-		groupByFields = append(groupByFields, TimeStamp)
+		if d.groupTimeBucketByExpr {
+			selectFields = append(selectFields, fmt.Sprintf("MAX%s AS `%s`", timeField, TimeStamp))
+			groupByFields = append(groupByFields, timeField)
+		} else {
+			selectFields = append(selectFields, fmt.Sprintf("%s AS `%s`", timeField, TimeStamp))
+			groupByFields = append(groupByFields, TimeStamp)
+		}
 
 		// 只有时间聚合的条件下，才可以使用时间聚合排序
 		dimensionSet.Add(FieldTime)


### PR DESCRIPTION
## What changed

- TSpider 时间聚合改为使用完整时间桶表达式进行 `GROUP BY`。
- 使用 `MAX(时间桶表达式)` 输出 `_timestamp_`，避免 BKData 将 SELECT 别名识别为物理字段。
- 保持 Doris 原有的 `GROUP BY _timestamp_` 行为不变。
- 增加与线上 trace 一致的 1 小时时间聚合回归测试。

## Root cause

PR #1401 让单段 BKSQL PromQL 查询复用 TSpider/Doris 聚合 SQL 生成逻辑。TSpider 随后生成 `GROUP BY _timestamp_`，但 BKData/TSpider 的语义检查不会将该名称识别为 SELECT 别名，最终报错“字段 _timestamp_ 在表中不存在”。

## Impact

影响包含时间窗口的 TSpider PromQL 聚合查询；非时间聚合、原始查询、Doris 及其他存储不受本次修改影响。