### PR TITLE
fix: bkmonitorbeat 空进程配置不生成采集任务 --bug=136442029 --story=136442029

### DIFF
--- a/pkg/bkmonitorbeat/configs/processbeat.go
+++ b/pkg/bkmonitorbeat/configs/processbeat.go
@@ -59,8 +59,8 @@ func NewProcessbeatConfig(root *Config) *ProcessbeatConfig {
 
 func (c *ProcessbeatConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
-	// 如果禁用或不存在采集 dataid 则没必要生成采集配置
-	if c.Disable || (c.PortDataId == 0 && c.TopDataId == 0 && c.PerfDataId == 0) {
+	// 如果禁用、没有进程配置或不存在采集 dataid 则没必要生成采集配置
+	if c.Disable || len(c.Processes) == 0 || (c.PortDataId == 0 && c.TopDataId == 0 && c.PerfDataId == 0) {
 		return tasks
 	}
 

--- a/pkg/bkmonitorbeat/configs/processbeat_test.go
+++ b/pkg/bkmonitorbeat/configs/processbeat_test.go
@@ -1,0 +1,43 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package configs
+
+import "testing"
+
+func TestProcessbeatConfigGetTaskConfigList(t *testing.T) {
+	tests := []struct {
+		name   string
+		config ProcessbeatConfig
+	}{
+		{name: "port data ID", config: ProcessbeatConfig{PortDataId: 1}},
+		{name: "performance data ID", config: ProcessbeatConfig{PerfDataId: 1}},
+		{name: "top data ID", config: ProcessbeatConfig{TopDataId: 1}},
+	}
+	for _, tt := range tests {
+		t.Run("skip config without processes for "+tt.name, func(t *testing.T) {
+			if got := len(tt.config.GetTaskConfigList()); got != 0 {
+				t.Fatalf("expected no task without process configuration, got %d", got)
+			}
+		})
+	}
+
+	t.Run("keep config with processes", func(t *testing.T) {
+		config := &ProcessbeatConfig{
+			PortDataId: 1,
+			Processes: []ProcessbeatPortConfig{
+				{Name: "example"},
+			},
+		}
+
+		if got := len(config.GetTaskConfigList()); got != 1 {
+			t.Fatalf("expected one task with process configuration, got %d", got)
+		}
+	})
+}


### PR DESCRIPTION
## 变更内容

- 空 processes 配置不再生成 processbeat 任务，避免产生 processes: null 空消息
- 保持有效进程配置的任务生成、进程匹配和 proc_exists 上报行为不变

## 测试

- go test ./configs -run ^TestProcessbeatConfigGetTaskConfigList$ -count=1
- go test ./configs ./tasks/processbeat/... ./tasks/procconf/... ./beater/... -count=1
- go test -race ./configs -count=1
- Linux amd64 交叉编译 configs 测试包

close #1010158081136442029