### PR TITLE
fix: (unify-query) mapping 为空时回退原生 query_string

### DIFF
--- a/pkg/unify-query/internal/online_cases/query_golden_cases/README.md
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/README.md
@@ -17,12 +17,12 @@ sanitized request
 
 ## 当前覆盖
 
-数据集当前包含 30 个可执行 case。其中 13 个 case 的 input 与当前 expected outputs 均直接来自可关联的生产历史日志；16 个问题回归 case 的 expected outputs 由修复后的真实 handler 重新回放，其中 2 个 TSpider case 有生产 trace 证据，另外 14 个 ES/Doris case 的问题形态与旧行为来自已合并 PR 的生产问题描述、测试和修复前 commit 回放，来源明确标记为 `merged_pr`；1 个 InfluxDB case 只有生产 input 形态，outputs 由固定 fixture 经当前真实 handler 回放得到，标记为暂定覆盖，不计入生产 output 采样收敛。
+数据集当前包含 31 个可执行 case。其中 13 个 case 的 input 与当前 expected outputs 均直接来自可关联的生产历史日志；17 个问题回归 case 的 expected outputs 由修复后的真实 handler 重新回放，其中 2 个 TSpider case 有生产 trace 证据，1 个 ES case 有生产日志和 trace 证据，另外 14 个 ES/Doris case 的问题形态与旧行为来自已合并 PR 的生产问题描述、测试和修复前 commit 回放，来源明确标记为 `merged_pr`；1 个 InfluxDB case 只有生产 input 形态，outputs 由固定 fixture 经当前真实 handler 回放得到，标记为暂定覆盖，不计入生产 output 采样收敛。
 
 | 分类 | Case 数 | 已覆盖形态 | Output 来源 |
 | --- | ---: | --- | --- |
 | VictoriaMetrics | 3 | 简单 PromQL、复杂聚合/区间/二元表达式、多结果表合并 | 生产日志 |
-| Elasticsearch | 14 | aggregate/raw × 有无 query_string、regexp/wildcard/布尔语义、聚合枚举提取、字段元数据滞后、多 RT 无效索引跳过、data source 别名、`table_id_conditions` 查询与 field_map | 生产日志 + 修复后 handler 回放 |
+| Elasticsearch | 15 | aggregate/raw × 有无 query_string、regexp/wildcard/布尔语义、缺失 mapping 回退、聚合枚举提取、字段元数据滞后、多 RT 无效索引跳过、data source 别名、`table_id_conditions` 查询与 field_map | 生产日志 + 修复后 handler 回放 |
 | Doris | 7 | aggregate、raw、ES→Doris 时间分段路由、多表显式投影、`SELECT *` 类型交集、对象叶子大小写/精度、缺失字段 contains | 生产日志 + 修复后 handler 回放 |
 | TSpider | 3 | aggregate、raw、PromQL 8 reference/16 output | 生产日志 + 修复后 handler 回放 |
 | HDFS | 2 | aggregate、raw | 生产日志 |
@@ -35,6 +35,8 @@ sanitized request
 `tspider_promql_multi_reference_001` 来自后续问题修复：一个 PromQL input 解析出 8 个 reference，固定路由为每个 reference 选择同一个 BKSQL 结果表，每个 reference 再产生 schema + aggregate 两个请求，因此完整 output multiset 为 16 条。该 case 同时锁定 TSpider 时间桶必须按完整表达式分组，不能按 SELECT 别名 `_timestamp_` 分组。
 
 14 个合并 PR 回溯 case 锁定 ES query_string 的 regexp、wildcard、布尔词项和聚合枚举语义，显式路由字段元数据滞后、多 RT 空索引跳过、data source 别名、`table_id_conditions` 与 field_map，以及 Doris 多物理表 UNION 和缺失字段 contains。它们没有保留原始 trace ID，均在修复前 commit 得到 RED、在当前代码得到 GREEN，因此只计入问题回归覆盖，不改写前述分类采样收敛统计。多数 ES case 为 `1 input × 1 reference × 1 route × 2 stages = 2 outputs`；field_map 只生成 index/mapping 请求，多 RT 跳过 case 只保留有效 RT 的 2 个 outputs。Doris UNION case 生成 2 条 schema 请求和 1 条合并查询，缺失字段 case 生成 1 条 schema 请求和 1 条查询。
+
+`es_query_string_missing_mapping_phrase_001` 来自可关联的生产日志和 trace：ES mapping 元数据短暂为空，但同一索引的 search 已正常命中。修复前 handler 将否定短语生成 `term`；修复后在整份 mapping 缺失时回退原生 `query_string`，由实际搜索分片按真实 mapping 解析。该 case 使用同一份脱敏 input 和固定依赖完成 RED→GREEN，不把失败 DSL 固化为正确答案。
 
 生产采样过程、四个时间窗的形似分布和当前边界见 [SAMPLING.md](SAMPLING.md)。
 

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/SAMPLING.md
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/SAMPLING.md
@@ -87,6 +87,8 @@ HDFS 查询日志容易被同名指标误命中，因此先扩大本地候选池
 
 这条链路中 BKBase 执行端记录为 HDFS，但 UQ 路由的 `measurement` 为空，实际选择的是 TSpider SQL 表达式；因此 case 按 UQ 待测 builder 归入 TSpider，而不是按 BKBase 内部执行设备归入 HDFS。问题发生时的 aggregate SQL 使用 `_timestamp_` 别名分组；修复合入后，golden expected 改为 `MAX(时间桶表达式)` 并按完整时间桶表达式分组，来源标记为 `post_fix_handler_replay`，不把失败 SQL 当作正确基线。
 
+2026-07-27 又从一条可关联的生产问题请求中确认了 ES mapping 元数据暂时为空、search 数据面仍可用的形态。脱敏后的 `es_query_string_missing_mapping_phrase_001` 保留 aggregate query、否定引号短语、空 mapping 依赖和最终 search 两阶段输出。修复前相同 fixture 将短语生成 `term`，修复后回退原生 `query_string`，RED→GREEN 的唯一预期差异位于 search DSL；该问题驱动 case 同样不改变前述四窗收敛统计。
+
 ### 最近 90 天已合并 UQ PR 回溯
 
 2026-07-23 按 `mergedAt >= 2026-04-24` 且改动 `pkg/unify-query/` 的口径，从仓库同期 87 个已合并 PR 中筛出 41 个 UQ PR，并逐个检查问题语义、代码路径、原有测试和 golden 覆盖。19 个 PR 涉及 parser、route expansion、query builder 或稳定的下游请求构造，其中 8 个由上一轮 case 覆盖，2 个由已有 case 精确覆盖，本轮为其余 9 个补充 case；另外 22 个只影响响应处理、并发安全、观测、性能、错误契约或测试，不适合用正向 downstream-output golden 表达。

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/case.yaml
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/case.yaml
@@ -1,0 +1,25 @@
+id: es_query_string_missing_mapping_phrase_001
+storage: es
+enabled: true
+shape_signature: query_ts/range/es/aggregate/query_string/not_phrase/mapping_empty/output_index_search
+source:
+  kind: production_log
+  outputs_kind: post_fix_handler_replay
+  sampled_at: "2026-07-27"
+  fingerprint: sha256:2b8bedc9aa5023b1acda0423e998d28147e0ccd3ef2aaa850e44f150e7590187
+tags:
+  - query_ts_api
+  - aggregation
+  - query_string
+  - missing_mapping
+  - post_fix_expected
+  - regression_fix
+  - production_shape
+notes:
+  - 生产问题形态仅保留 mapping 为空时否定短语查询被错误降级的结构，所有标识和值均已不可逆替换。
+  - 正确 output 在 mapping 为空时回退原生 query_string，由实际搜索分片按真实 mapping 解析；不保留线上失败 DSL。
+files:
+  request: request.json
+  route: route.json
+  dependencies: dependencies.json
+  expect_outputs: expect.outputs.json

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/dependencies.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/dependencies.json
@@ -1,0 +1,14 @@
+{
+  "elasticsearch": {
+    "mapping": {},
+    "search": {
+      "took": 1,
+      "timed_out": false,
+      "hits": {
+        "total": {"value": 0, "relation": "eq"},
+        "hits": []
+      },
+      "aggregations": {}
+    }
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/expect.outputs.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/expect.outputs.json
@@ -1,0 +1,70 @@
+[
+  {
+    "backend": "elasticsearch",
+    "method": "GET",
+    "path": "/golden_missing_mapping_logs"
+  },
+  {
+    "backend": "elasticsearch",
+    "method": "POST",
+    "path": "/golden_missing_mapping_logs/_search",
+    "body": {
+      "aggregations": {
+        "service": {
+          "aggregations": {
+            "dtEventTimeStamp": {
+              "aggregations": {
+                "_value": {
+                  "value_count": {
+                    "field": "events_total"
+                  }
+                }
+              },
+              "date_histogram": {
+                "extended_bounds": {
+                  "max": 1784702135999,
+                  "min": 1784701739999
+                },
+                "field": "dtEventTimeStamp",
+                "interval": "1m",
+                "min_doc_count": 0,
+                "time_zone": "UTC"
+              }
+            }
+          },
+          "terms": {
+            "field": "service",
+            "missing": " ",
+            "size": 10000
+          }
+        }
+      },
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "range": {
+                "dtEventTimeStamp": {
+                  "format": "epoch_second",
+                  "from": 1784701739,
+                  "include_lower": true,
+                  "include_upper": true,
+                  "to": 1784702135
+                }
+              }
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "fields": ["*", "__*"],
+                "lenient": true,
+                "query": "NOT (message:\"ignored phrase\")"
+              }
+            }
+          ]
+        }
+      },
+      "size": 0
+    }
+  }
+]

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/request.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/request.json
@@ -1,0 +1,42 @@
+{
+  "method": "POST",
+  "path": "/query/ts",
+  "headers": {
+    "Content-Type": "application/json",
+    "Bk-Query-Source": "golden",
+    "X-Bk-Scope-Space-Uid": "bkcc__golden_es_missing_mapping",
+    "X-Bk-Tenant-Id": "tenant_golden"
+  },
+  "body": {
+    "space_uid": "bkcc__golden_es_missing_mapping",
+    "query_list": [
+      {
+        "data_source": "bk_log",
+        "table_id": "demo_missing_mapping_logs.partition_1",
+        "field_name": "events_total",
+        "function": [
+          {
+            "method": "sum",
+            "dimensions": ["service"]
+          }
+        ],
+        "time_aggregation": {
+          "function": "count_over_time",
+          "window": "1m"
+        },
+        "reference_name": "a",
+        "conditions": {
+          "field_list": [],
+          "condition_list": []
+        },
+        "query_string": "NOT (message:\"ignored phrase\")"
+      }
+    ],
+    "metric_merge": "a",
+    "start_time": "1784701776",
+    "end_time": "1784702076",
+    "step": "60s",
+    "timezone": "UTC",
+    "instant": false
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/route.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_phrase_001/route.json
@@ -1,0 +1,27 @@
+{
+  "space_uid": "bkcc__golden_es_missing_mapping",
+  "result_tables": [
+    {
+      "table_id": "demo_missing_mapping_logs.partition_1"
+    }
+  ],
+  "result_table_details": {
+    "demo_missing_mapping_logs.partition_1": {
+      "storage_id": 2002,
+      "storage_name": "es_cluster_missing_mapping",
+      "storage_type": "elasticsearch",
+      "cluster_name": "es_cluster_missing_mapping",
+      "db": "golden_missing_mapping_logs",
+      "table_id": "demo_missing_mapping_logs.partition_1",
+      "fields": ["events_total"],
+      "data_label": "demo_missing_mapping_logs",
+      "tags_key": ["service"],
+      "source_type": "bklog"
+    }
+  },
+  "storages": {
+    "2002": {
+      "type": "elasticsearch"
+    }
+  }
+}

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -351,6 +351,11 @@ func (s *FormatFactory) queryString(str string, isPrefix bool) elastic.Query {
 }
 
 func (f *FormatFactory) ParserQueryString(ctx context.Context, q string, isPrefix bool) elastic.Query {
+	if len(f.fieldsMap) == 0 {
+		// 没有 mapping 时无法可靠区分 text 与 keyword，交由实际 ES 分片按真实 mapping 解析。
+		return f.queryString(q, isPrefix)
+	}
+
 	node := lucene_parser.ParseLuceneWithVisitor(ctx, q, lucene_parser.Option{
 		FieldsMap: f.fieldsMap,
 	})

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -37,6 +37,8 @@ import (
 
 var _ tsdb.Instance = (*Instance)(nil)
 
+const esIndexMetadataErrorMaxLength = 512
+
 type Instance struct {
 	tsdb.DefaultInstance
 
@@ -171,22 +173,27 @@ func resolveIndexMetadata(ctx context.Context, span *trace.Span, cli *elastic.Cl
 
 	span.Set("get-indexes", aliases)
 	indices, indicesErr := cli.IndexGet(aliases...).Do(ctx)
+	span.Set("index-get-fallback", indicesErr != nil)
 	if indicesErr != nil {
+		indexGetError := truncateString(indicesErr.Error(), esIndexMetadataErrorMaxLength)
+		span.Set("index-get-error", indexGetError)
 		// 兼容没有索引接口的情况，例如 bkbase
 		metadata.NewMessage(
 			metadata.MsgQueryES,
-			"索引查询 index 接口异常: %+v",
+			"索引查询 index 接口异常，回退 mapping 接口: aliases=%+v, error=%s",
 			aliases,
+			indexGetError,
 		).Warn(ctx)
 
 		span.Set("get-mapping", aliases)
 		res, err := cli.GetMapping().Index(aliases...).Type("").Do(ctx)
 		if err != nil {
+			span.Set("get-mapping-error", truncateString(err.Error(), esIndexMetadataErrorMaxLength))
 			return nil, nil, nil, metadata.NewMessage(
 				metadata.MsgQueryES,
 				"索引查询异常: %+v",
 				aliases,
-			).Error(ctx, indicesErr)
+			).Error(ctx, err)
 		}
 
 		for index, r := range res {
@@ -240,15 +247,16 @@ func (i *Instance) fieldMapWithPhysicalIndexes(ctx context.Context, fieldAlias m
 	if err != nil {
 		return nil, nil, err
 	}
+	span.Set("mapping-length", len(mappings))
+	span.Set("physical-index-length", len(physicalIndexes))
 
 	iof := NewIndexOptionFormat(fieldAlias)
 
 	// 忽略 mapping 为空的情况的报错
 	if len(mappings) == 0 {
+		span.Set("field-map-length", 0)
 		return iof.FieldsMap(), physicalIndexes, nil
 	}
-
-	span.Set("mapping-length", len(mappings))
 
 	indexes := make([]string, 0)
 	for k := range mappings {

--- a/pkg/unify-query/tsdb/elasticsearch/instance_missing_mapping_fallback_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance_missing_mapping_fallback_test.go
@@ -1222,6 +1222,82 @@ func TestRecordESQueryShards(t *testing.T) {
 	})
 }
 
+func TestFieldMapRecordsEmptyGetMappingFallback(t *testing.T) {
+	mock.Init()
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+
+	const alias = "test_alias_empty_mapping_observability"
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		mock.EsUrl+"/"+alias,
+		httpmock.NewStringResponder(http.StatusInternalServerError, `{"error":{"reason":"index get unsupported"}}`),
+	)
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		mock.EsUrl+"/"+alias+"/_mapping/",
+		httpmock.NewStringResponder(http.StatusOK, `{}`),
+	)
+
+	inst, err := NewInstance(ctx, &InstanceOption{
+		Connect: Connect{Address: mock.EsUrl},
+		Timeout: time.Minute,
+	})
+	require.NoError(t, err)
+
+	rec := setupESTraceRecorder(t)
+	fieldsMap, physicalIndexes, err := inst.fieldMapWithPhysicalIndexes(ctx, nil, alias)
+	require.NoError(t, err)
+	assert.Empty(t, fieldsMap)
+	assert.Empty(t, physicalIndexes)
+
+	attrs := endedSpanAttrs(t, rec)
+	fallback, ok := esSpanAttrBool(attrs, "index-get-fallback")
+	require.True(t, ok)
+	assert.True(t, fallback)
+	indexGetError, ok := esSpanAttrString(attrs, "index-get-error")
+	require.True(t, ok)
+	assert.Contains(t, indexGetError, "index get unsupported")
+	mappingLength, ok := esSpanAttrInt(attrs, "mapping-length")
+	require.True(t, ok)
+	assert.Equal(t, int64(0), mappingLength)
+	physicalIndexLength, ok := esSpanAttrInt(attrs, "physical-index-length")
+	require.True(t, ok)
+	assert.Equal(t, int64(0), physicalIndexLength)
+	fieldMapLength, ok := esSpanAttrInt(attrs, "field-map-length")
+	require.True(t, ok)
+	assert.Equal(t, int64(0), fieldMapLength)
+}
+
+func TestFieldMapReturnsGetMappingError(t *testing.T) {
+	mock.Init()
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+
+	const alias = "test_alias_get_mapping_error"
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		mock.EsUrl+"/"+alias,
+		httpmock.NewStringResponder(http.StatusInternalServerError, `{"error":{"reason":"index get unsupported"}}`),
+	)
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		mock.EsUrl+"/"+alias+"/_mapping/",
+		httpmock.NewStringResponder(http.StatusBadGateway, `{"error":{"reason":"mapping unavailable"}}`),
+	)
+
+	inst, err := NewInstance(ctx, &InstanceOption{
+		Connect: Connect{Address: mock.EsUrl},
+		Timeout: time.Minute,
+	})
+	require.NoError(t, err)
+
+	_, _, err = inst.fieldMapWithPhysicalIndexes(ctx, nil, alias)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mapping unavailable")
+	assert.NotContains(t, err.Error(), "index get unsupported")
+}
+
 func setupESTraceRecorder(t *testing.T) *tracetest.SpanRecorder {
 	t.Helper()
 	rec := tracetest.NewSpanRecorder()

--- a/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
@@ -229,3 +229,50 @@ func TestQsToDsl(t *testing.T) {
 		})
 	}
 }
+
+func TestParserQueryStringMappingAvailability(t *testing.T) {
+	mock.Init()
+	ctx := metadata.InitHashID(context.Background())
+
+	for name, tc := range map[string]struct {
+		fieldsMap metadata.FieldsMap
+		expected  string
+	}{
+		"missing mapping falls back to native query string": {
+			fieldsMap: metadata.FieldsMap{},
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"NOT (message:\"ignored phrase\")"}}`,
+		},
+		"known text field keeps match phrase": {
+			fieldsMap: metadata.FieldsMap{
+				"message": {
+					FieldName:  "message",
+					FieldType:  Text,
+					IsAnalyzed: true,
+				},
+			},
+			expected: `{"bool":{"must_not":{"match_phrase":{"message":{"query":"ignored phrase"}}}}}`,
+		},
+		"known keyword field keeps term": {
+			fieldsMap: metadata.FieldsMap{
+				"message": {
+					FieldName: "message",
+					FieldType: KeyWord,
+				},
+			},
+			expected: `{"bool":{"must_not":{"term":{"message":"ignored phrase"}}}}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			query := NewFormatFactory(ctx).
+				WithFieldMap(tc.fieldsMap).
+				ParserQueryString(ctx, `NOT (message:"ignored phrase")`, false)
+			require.NotNil(t, query)
+			body, err := query.Source()
+			require.NoError(t, err)
+
+			bodyJSON, err := json.Marshal(body)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.expected, string(bodyJSON))
+		})
+	}
+}


### PR DESCRIPTION
## 背景

Elasticsearch 索引的 mapping 元数据短暂返回空结果时，搜索分片仍可能正常可用。此时 UQ 自定义 Lucene parser 无法区分 `text` 与 `keyword` 字段，未知字段上的引号短语会被构造成 `term`，从而改变原始 `query_string` 的查询语义。

## 改动

- 当整份字段 mapping 为空时，回退既有 Elasticsearch 原生 `query_string`，由实际搜索分片按真实 mapping 解析。
- mapping 非空时继续沿用现有 parser，保持 `text`、`keyword` 等已有行为不变。
- 补充 IndexGet fallback、GetMapping 错误以及 mapping/物理索引/字段数量的 trace 属性，并限制错误文本长度。
- 新增脱敏后的生产形态 golden case 和单元测试，覆盖空 mapping、已知 text、已知 keyword 及 mapping fallback。

## 验证

- RED：旧基线在空 mapping 下生成 `must_not term`，与期望的原生 `query_string` 不一致。
- GREEN：
  - `go test ./internal/lucene_parser ./tsdb/elasticsearch -count=1`
  - `go test ./internal/online_cases/query_golden_cases -count=1`
  - `go test ./service/http -run 'TestOnlineQueryGoldenCases|TestOnlineQueryGoldenSegmentedRouteControlsFanOut|TestCanonicalOnlineQueryGoldenOutputs' -count=1`
  - ES 新增测试 `-race -count=10`
  - `git diff --check`
- 使用项目声明的 Go 1.24.4 执行完整 `make test` 时，仅有 `TestPromQLQueryHandler/test_promql_by_bkdata_with_long_dim` 失败；该失败已在未修改的上游 `master` 基线上独立复现，不由本提交引入。
