### PR TITLE
feat(collector): 新增datadog receiver 接收 rum 数据转换为 OTEL 格式

### DIFF
--- a/pkg/collector/define/record.go
+++ b/pkg/collector/define/record.go
@@ -44,6 +44,7 @@ const (
 	SourceBeat        = "beat"
 	SourceTars        = "tars"
 	SourceLogPush     = "logpush"
+	SourceDatadogRum  = "datadogrum"
 
 	KeyToken        = "X-BK-TOKEN"
 	KeyDataID       = "X-BK-DATA-ID"
@@ -73,6 +74,7 @@ const (
 	RecordBeat           RecordType = "beat"
 	RecordTars           RecordType = "tars"
 	RecordLogPush        RecordType = "logpush"
+	RecordDatadogRum     RecordType = "datadogrum"
 )
 
 // IntoRecordType 将字符串描述转换为 RecordType 并返回是否为 Derived 类型

--- a/pkg/collector/internal/utils/utils.go
+++ b/pkg/collector/internal/utils/utils.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 
 	"github.com/TarsCloud/TarsGo/tars/util/current"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"google.golang.org/grpc/peer"
 )
 
@@ -95,7 +95,6 @@ func PathExist(path string) bool {
 	return true
 }
 
-
 func InsertString(m pcommon.Map, key string, value string) {
 	if _, ok := m.Get(key); !ok {
 		m.PutString(key, value)
@@ -106,4 +105,11 @@ func InsertInt(m pcommon.Map, key string, value int64) {
 	if _, ok := m.Get(key); !ok {
 		m.PutInt(key, value)
 	}
+}
+
+func Val[T any](ptr *T, defaultVal T) T {
+	if ptr == nil {
+		return defaultVal
+	}
+	return *ptr
 }

--- a/pkg/collector/receiver/datadogrum/http.go
+++ b/pkg/collector/receiver/datadogrum/http.go
@@ -1,0 +1,203 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package datadogrum
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/internal/throttle"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/internal/tokenparser"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/internal/utils"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/pipeline"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/converter"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/decoder"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/parser"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
+)
+
+const (
+	routeV2Rum    = "/api/v2/rum"
+	routeV1Rum    = "/v1/rum"
+	routeV2Replay = "/api/v2/replay"
+
+	// 默认写死，后期再扩展为配置项。
+	maxRequestBodyBytes   = 10 << 20 // 10MB
+	maxDecodedEventsBytes = 10 << 20 // 10MB
+	skipInvalid           = false
+)
+
+var metricMonitor = receiver.DefaultMetricMonitor.Source(define.SourceDatadogRum)
+
+var (
+	readyMu          sync.Mutex
+	routesRegistered bool
+)
+
+// HttpService is the Datadog RUM HTTP receiving service.
+type HttpService struct {
+	receiver.Publisher
+	pipeline.Validator
+}
+
+var httpSvc HttpService
+
+func init() {
+	receiver.RegisterReadyFunc(define.SourceDatadogRum, Ready)
+	throttle.RegisterHTTPRecordType(routeV2Rum, define.RecordRum)
+	throttle.RegisterHTTPRecordType(routeV1Rum, define.RecordRum)
+}
+
+// Factory returns the init function used by the upper layer.
+func Factory() func() {
+	return Ready
+}
+
+// Ready registers the Datadog RUM HTTP route during receiver startup.
+func Ready() {
+	readyMu.Lock()
+	defer readyMu.Unlock()
+	if routesRegistered {
+		return
+	}
+
+	receiver.RegisterRecvHttpRoute(define.SourceDatadogRum, []receiver.RouteWithFunc{
+		{
+			Method:       http.MethodPost,
+			RelativePath: routeV2Rum,
+			HandlerFunc:  httpSvc.Export,
+		},
+		{
+			Method:       http.MethodPost,
+			RelativePath: routeV1Rum,
+			HandlerFunc:  httpSvc.Export,
+		},
+		{
+			Method:       http.MethodPost,
+			RelativePath: routeV2Replay,
+			HandlerFunc:  httpSvc.Replay,
+		},
+	})
+	routesRegistered = true
+}
+
+// Export handles Datadog RUM HTTP upload requests.
+func (s HttpService) Export(w http.ResponseWriter, req *http.Request) {
+	defer utils.HandleCrash()
+	defer closeRequestBody(req)
+
+	clientIP := utils.ParseRequestIP(req.RemoteAddr, req.Header)
+	startTime := time.Now()
+
+	rawEvents, bodySize, err := decodeRequestEvents(req)
+	if err != nil {
+		writeBadRequest(w, clientIP, "failed to decode datadog rum request", err)
+		return
+	}
+
+	batch, err := parseRawEvents(rawEvents)
+	if err != nil {
+		writeBadRequest(w, clientIP, "failed to parse datadog rum events", err)
+		return
+	}
+
+	record := newRecord(req, clientIP, batch)
+	if err := s.validateRecord(w, record, clientIP); err != nil {
+		return
+	}
+
+	s.Publish(record)
+	receiver.RecordHandleMetrics(metricMonitor, record.Token, define.RequestHttp, define.RecordRum, bodySize, startTime)
+	receiver.WriteResponse(w, define.ContentTypeText, http.StatusOK, nil)
+}
+
+// Replay handles Datadog session replay upload requests.
+// 当前为占位实现，不处理任何逻辑，直接返回空响应。
+func (s HttpService) Replay(w http.ResponseWriter, req *http.Request) {
+	defer utils.HandleCrash()
+	defer closeRequestBody(req)
+
+	receiver.WriteResponse(w, define.ContentTypeText, http.StatusOK, nil)
+}
+
+func (s HttpService) validateRecord(w http.ResponseWriter, record *define.Record, clientIP string) error {
+	code, processorName, err := s.Validate(record)
+	if err == nil {
+		return nil
+	}
+
+	logger.Warnf("run pre-check failed, rtype=%s, code=%d, ip=%v, error: %s", define.RecordRum.S(), code, clientIP, err)
+	receiver.WriteErrResponse(w, define.ContentTypeText, int(code), err)
+	metricMonitor.IncPreCheckFailedCounter(define.RequestHttp, define.RecordRum, processorName, record.Token.Original, code)
+	return err
+}
+
+func closeRequestBody(req *http.Request) {
+	if req == nil || req.Body == nil {
+		return
+	}
+	_ = req.Body.Close()
+}
+
+func decodeRequestEvents(req *http.Request) ([][]byte, int, error) {
+	buf, err := decoder.ReadBody(req, maxRequestBodyBytes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read body: %w", err)
+	}
+
+	rawEvents, err := decoder.DecodeEvents(buf.Bytes(), maxDecodedEventsBytes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decode payload: %w", err)
+	}
+	return rawEvents, buf.Len(), nil
+}
+
+// parseRawEvents validates and converts raw payloads into a RUM batch.
+func parseRawEvents(rawEvents [][]byte) (*model.Batch, error) {
+	p := parser.New(skipInvalid)
+	return p.ParseBatch(rawEvents)
+}
+
+// newRecord creates the pipeline record for a parsed RUM batch.
+func newRecord(req *http.Request, ip string, batch *model.Batch) *define.Record {
+	query := req.URL.Query()
+	token := tokenparser.FromHttpRequest(req)
+	if token == "" {
+		token = query.Get("dd-api-key")
+	}
+	userAgent := req.Header.Get("user-agent")
+	metadata := tokenparser.FromHttpUserMetadata(req)
+	if userAgent != "" {
+		if metadata == nil {
+			metadata = make(map[string]string)
+		}
+		metadata["user-agent"] = userAgent
+	}
+	return &define.Record{
+		RequestType:   define.RequestHttp,
+		RequestClient: define.RequestClient{IP: ip},
+		RecordType:    define.RecordRum,
+		Data:          converter.Convert(batch, userAgent),
+		Token:         define.Token{Original: token},
+		Metadata:      metadata,
+	}
+}
+
+// writeBadRequest records and logs a malformed request before returning HTTP 400.
+func writeBadRequest(w http.ResponseWriter, ip string, msg string, err error) {
+	metricMonitor.IncInternalErrorCounter(define.RequestHttp, define.RecordRum)
+	receiver.WriteResponse(w, define.ContentTypeText, http.StatusBadRequest, nil)
+	logger.Errorf("%s, ip=%v, error: %s", msg, ip, err)
+}

--- a/pkg/collector/receiver/datadogrum/http_test.go
+++ b/pkg/collector/receiver/datadogrum/http_test.go
@@ -1,0 +1,54 @@
+package datadogrum
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/pipeline"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver"
+)
+
+type recordingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *recordingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestExportPublishesTraceRecord(t *testing.T) {
+	body := &recordingBody{Reader: bytes.NewBufferString(`{"type":"view","date":1700000000000,"application":{"id":"app","name":"shop"},"session":{"id":"session","type":"user"},"view":{"id":"view","url":"https://example.com"}}`)}
+	request := httptest.NewRequest(http.MethodPost, "/api/v2/rum?X-BK-TOKEN=test-token", body)
+	request.RemoteAddr = "192.0.2.10:1234"
+	response := httptest.NewRecorder()
+
+	var published *define.Record
+	service := HttpService{
+		Publisher: receiver.Publisher{Func: func(record *define.Record) { published = record }},
+		Validator: pipeline.Validator{Func: func(*define.Record) (define.StatusCode, string, error) {
+			return define.StatusCodeOK, "", nil
+		}},
+	}
+
+	service.Export(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.NotNil(t, published)
+	assert.Equal(t, define.RecordRum, published.RecordType)
+	assert.Equal(t, "192.0.2.10", published.RequestClient.IP)
+	traces, ok := published.Data.(ptrace.Traces)
+	require.True(t, ok)
+	require.Equal(t, 1, traces.ResourceSpans().Len())
+	assert.Equal(t, "page.view", traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+	assert.True(t, body.closed)
+}

--- a/pkg/collector/receiver/datadogrum/internal/converter/converter.go
+++ b/pkg/collector/receiver/datadogrum/internal/converter/converter.go
@@ -1,0 +1,1005 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Package converter translates parsed Datadog RUM events into OTLP traces.
+package converter
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/internal/utils"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+const (
+	scopeName         = "bk-rum"
+	defaultSDKVersion = "1.0.0"
+
+	attrViewPhase = "attributes.view.phase"
+	phaseStart    = "start"
+	phaseUpdate   = "update"
+	phaseEnd      = "end"
+)
+
+type AttributeBuilder struct {
+	attrs pcommon.Map
+}
+
+func NewAttributeBuilder(attrs pcommon.Map) *AttributeBuilder {
+	return &AttributeBuilder{attrs: attrs}
+}
+
+// Set adds a supported scalar or string slice attribute. Nil pointers and empty
+// strings are ignored; zero numeric values and false are intentionally kept.
+func (b *AttributeBuilder) Set(key string, value interface{}) *AttributeBuilder {
+	if b == nil || value == nil {
+		return b
+	}
+
+	v := reflect.ValueOf(value)
+	for v.IsValid() && (v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr) {
+		if v.IsNil() {
+			return b
+		}
+		v = v.Elem()
+	}
+	if !v.IsValid() {
+		return b
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		if v.String() != "" {
+			b.attrs.PutString(key, v.String())
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		b.attrs.PutInt(key, v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		unsigned := v.Uint()
+		if unsigned <= uint64(^uint64(0)>>1) {
+			b.attrs.PutInt(key, int64(unsigned))
+		} else {
+			// OTLP integer attributes are signed; preserve oversized unsigned values
+			// as decimal strings instead of silently dropping them.
+			b.attrs.PutString(key, strconv.FormatUint(unsigned, 10))
+		}
+	case reflect.Float32, reflect.Float64:
+		b.attrs.PutDouble(key, v.Float())
+	case reflect.Bool:
+		b.attrs.PutBool(key, v.Bool())
+
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.String || v.Len() == 0 {
+			return b
+		}
+		slice := b.attrs.PutEmptySlice(key)
+		for i := 0; i < v.Len(); i++ {
+			slice.AppendEmpty().SetStr(v.Index(i).String())
+		}
+	}
+	return b
+}
+
+// SetAll adds all supported fields and returns the builder for chaining.
+func (b *AttributeBuilder) SetAll(fields map[string]interface{}) *AttributeBuilder {
+	for key, value := range fields {
+		b.Set(key, value)
+	}
+	return b
+}
+
+// Convert converts every event in batch into one OTLP span. Each event gets a
+// separate ResourceSpans so events from different RUM applications or sessions
+// cannot accidentally share resource attributes.
+//
+// userAgent is the uploader's User-Agent (e.g. the RUM SDK / browser UA),
+// attached to resource spans as the http.user_agent attribute.
+func Convert(batch *model.Batch, userAgent string) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	if batch == nil {
+		return traces
+	}
+
+	for _, event := range batch.Events {
+		if isNilEvent(event) || event.GetCommon() == nil {
+			continue
+		}
+		appendEvent(traces, event, userAgent)
+	}
+	return traces
+}
+
+func isNilEvent(event model.Event) bool {
+	if event == nil {
+		return true
+	}
+	value := reflect.ValueOf(event)
+	return (value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface) && value.IsNil()
+}
+
+func appendEvent(traces ptrace.Traces, event model.Event, userAgent string) {
+	common := event.GetCommon()
+	resourceSpans := traces.ResourceSpans().AppendEmpty()
+	resourceAttrs := NewAttributeBuilder(resourceSpans.Resource().Attributes())
+	setResourceAttributes(resourceAttrs, common, userAgent)
+
+	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+	scopeSpans.Scope().SetName(scopeName)
+	version := defaultSDKVersion
+	if common.Internal != nil && common.Internal.BrowserSDKVersion != "" {
+		version = common.Internal.BrowserSDKVersion
+	}
+	scopeSpans.Scope().SetVersion(version)
+
+	span := scopeSpans.Spans().AppendEmpty()
+	span.SetTraceID(traceIDFor(event))
+	span.SetSpanID(spanIDFor(event))
+	span.SetStartTimestamp(eventStart(common.Date))
+	span.SetKind(ptrace.SpanKindInternal)
+	attrs := NewAttributeBuilder(span.Attributes())
+	attrs.Set("event.type", event.GetType().S()).Set("rum.source", common.Source)
+
+	switch event := event.(type) {
+	case *model.ViewEvent:
+		convertView(span, event, attrs)
+	case *model.ActionEvent:
+		convertAction(span, event, attrs)
+	case *model.ResourceEvent:
+		convertResource(span, event, attrs)
+	case *model.ErrorEvent:
+		convertError(span, event, attrs)
+	case *model.LongTaskEvent:
+		convertLongTask(span, event, attrs)
+	case *model.VitalEvent:
+		convertVital(span, event, attrs)
+
+	default:
+		span.SetName(event.GetType().S())
+		setEnd(span, 0)
+	}
+}
+
+func eventStart(date int64) pcommon.Timestamp {
+	return pcommon.NewTimestampFromTime(time.UnixMilli(date))
+}
+
+// serverDurationTimestamp converts a Datadog ServerDuration to an OTLP timestamp
+// offset. ServerDuration is already encoded in nanoseconds by the RUM intake
+// protocol; only CommonFields.Date is an epoch millisecond value.
+func serverDurationTimestamp(duration int64) pcommon.Timestamp {
+	return pcommon.Timestamp(duration)
+}
+
+func setEnd(span ptrace.Span, duration int64) {
+	if duration <= 0 {
+		duration = int64(time.Millisecond)
+	}
+	span.SetEndTimestamp(span.StartTimestamp() + serverDurationTimestamp(duration))
+}
+
+// traceIDFor 生成 OTLP TraceID。
+// 优先使用 Datadog 内置的 trace_id；不存在时按以下规则派生：
+//  1. 有 session.id 时：sha256("session\x00" + session.id) 取前 16 字节
+//  2. 无 session.id 时：sha256("application\x00" + application.id + "\x00" + date + "\x00" + event_type) 取前 16 字节
+//
+// 生成的 TraceID 为空时会填充最后一个字节，保证非空。
+func traceIDFor(event model.Event) pcommon.TraceID {
+	common := event.GetCommon()
+	if common.Internal != nil {
+		if id, ok := validTraceID(common.Internal.TraceID); ok {
+			return id
+		}
+	}
+
+	key := "application\x00" + common.Application.ID + "\x00" + strconv.FormatInt(common.Date, 10) + "\x00" + event.GetType().S()
+	if common.Session != nil && common.Session.ID != "" {
+		key = "session\x00" + common.Session.ID
+	}
+	digest := sha256.Sum256([]byte(key))
+	var id pcommon.TraceID
+	copy(id[:], digest[:16])
+	return nonEmptyTraceID(id)
+}
+
+// spanIDFor 生成 OTLP SpanID。
+// 优先使用 Datadog 内置的 span_id；不存在时按以下规则派生：
+//  1. 优先使用事件自身 ID（view/action/resource/error/long_task/vital id）：
+//     key = event_type + "\x00" + event_id，sha256 取前 8 字节
+//  2. 事件无 ID 时回退到：session.id + "\x00" + date + "\x00" + event_type
+//     sha256 取前 8 字节
+//
+// 生成的 SpanID 为空时会填充最后一个字节，保证非空。
+func spanIDFor(event model.Event) pcommon.SpanID {
+	common := event.GetCommon()
+	if common.Internal != nil {
+		if id, ok := validSpanID(common.Internal.SpanID); ok {
+			return id
+		}
+	}
+
+	identifier := eventIdentifier(event)
+	key := event.GetType().S() + "\x00" + identifier
+	if identifier == "" {
+		sessionID := ""
+		if common.Session != nil {
+			sessionID = common.Session.ID
+		}
+		key = sessionID + "\x00" + strconv.FormatInt(common.Date, 10) + "\x00" + event.GetType().S()
+	}
+	digest := sha256.Sum256([]byte(key))
+	var id pcommon.SpanID
+	copy(id[:], digest[:8])
+	return nonEmptySpanID(id)
+}
+
+// eventIdentifier 提取各类 RUM 事件自身的业务 ID，用于 spanIDFor 生成 SpanID。
+func eventIdentifier(event model.Event) string {
+	switch event := event.(type) {
+	case *model.ViewEvent:
+		return event.View.ID
+	case *model.ActionEvent:
+		return event.Action.ID
+	case *model.ResourceEvent:
+		return event.Resource.ID
+	case *model.ErrorEvent:
+		return event.Error.ID
+	case *model.LongTaskEvent:
+		return event.LongTask.ID
+	case *model.VitalEvent:
+		return event.Vital.ID
+	default:
+		return ""
+	}
+}
+
+func validTraceID(value string) (pcommon.TraceID, bool) {
+	var id pcommon.TraceID
+	if len(value) != 32 {
+		return pcommon.TraceID{}, false
+	}
+	if _, err := hex.Decode(id[:], []byte(value)); err != nil || id.IsEmpty() {
+		return pcommon.TraceID{}, false
+	}
+	return id, true
+}
+
+func validSpanID(value string) (pcommon.SpanID, bool) {
+	var id pcommon.SpanID
+	if len(value) != 16 {
+		return pcommon.SpanID{}, false
+	}
+	if _, err := hex.Decode(id[:], []byte(value)); err != nil || id.IsEmpty() {
+		return pcommon.SpanID{}, false
+	}
+	return id, true
+}
+
+// nonEmptyTraceID 保证 TraceID 非空；若 hash 结果全 0，则填充最后一个字节为 1。
+func nonEmptyTraceID(id pcommon.TraceID) pcommon.TraceID {
+	if id.IsEmpty() {
+		id[15] = 1
+	}
+	return id
+}
+
+// nonEmptySpanID 保证 SpanID 非空；若 hash 结果全 0，则填充最后一个字节为 1。
+func nonEmptySpanID(id pcommon.SpanID) pcommon.SpanID {
+	if id.IsEmpty() {
+		id[7] = 1
+	}
+	return id
+}
+
+func setResourceAttributes(b *AttributeBuilder, common *model.CommonFields, userAgent string) {
+	serviceName := common.Application.Name
+	if serviceName == "" {
+		serviceName = common.Service
+	}
+	if serviceName == "" {
+		serviceName = "datadog-rum"
+	}
+	b.Set("service.name", serviceName)
+
+	serviceVersion := common.Version
+	if serviceVersion == "" {
+		serviceVersion = common.BuildVersion
+	}
+	b.Set("service.version", serviceVersion)
+	b.Set("http.user_agent", userAgent)
+	b.Set("deployment.environment.name", environmentFromTags(common.Tags))
+	b.Set("application.id", common.Application.ID)
+	b.Set("session.id", sessionValue(common, func(session *model.Session) string { return session.ID }))
+	b.Set("session.type", sessionValue(common, func(session *model.Session) string { return session.Type }))
+	if common.Session != nil {
+		b.Set("session.has_replay", common.Session.HasReplay)
+	}
+	if common.User != nil {
+		b.Set("user.id", common.User.ID)
+		b.Set("user.anonymous_id", common.User.AnonymousID)
+	}
+
+	version := defaultSDKVersion
+	if common.Internal != nil && common.Internal.BrowserSDKVersion != "" {
+		version = common.Internal.BrowserSDKVersion
+	}
+	b.Set("telemetry.sdk.name", "@datadog@browser-sdk")
+	b.Set("telemetry.sdk.language", "webjs")
+	b.Set("telemetry.sdk.version", version)
+	if common.Internal != nil {
+		b.Set("dd.sdk.name", common.Internal.SDKName)
+		b.Set("dd.browser_sdk_version", common.Internal.BrowserSDKVersion)
+		b.Set("dd.start_session_replay_recording_manually", common.Internal.StartSessionReplayRecordingManually)
+		b.Set("dd.remote_configuration_id", common.Internal.RemoteConfigurationID)
+		b.Set("dd.cls.device_pixel_ratio", common.Internal.CLSDevicePixelRatio)
+		putSampleRate(b, "trace.sample_rate", common.Internal.TraceSampleRate)
+		putSampleRate(b, "profiling.sample_rate", common.Internal.ProfilingSampleRate)
+		if common.Internal.Configuration != nil {
+			configuration := common.Internal.Configuration
+			putSampleRate(b, "session.sample_rate", configuration.SessionSampleRate)
+			putSampleRate(b, "session.replay_sample_rate", configuration.SessionReplaySampleRate)
+			if common.Internal.TraceSampleRate == nil {
+				putSampleRate(b, "trace.sample_rate", configuration.TraceSampleRate)
+			}
+			if common.Internal.ProfilingSampleRate == nil {
+				putSampleRate(b, "profiling.sample_rate", configuration.ProfilingSampleRate)
+			}
+		}
+	}
+	b.Set("rum.source", common.Source)
+	b.Set("dd.tags", common.Tags)
+
+	if common.OS != nil {
+		b.Set("os.name", common.OS.Name)
+		b.Set("os.version", common.OS.Version)
+		b.Set("os.version_major", common.OS.VersionMajor)
+		b.Set("os.build", common.OS.Build)
+	}
+	if common.Device != nil {
+		b.Set("device.type", common.Device.Type)
+		b.Set("device.name", common.Device.Name)
+		b.Set("device.brand", common.Device.Brand)
+		b.Set("device.model", common.Device.Model)
+		b.Set("device.architecture", common.Device.Architecture)
+		b.Set("device.locale", common.Device.Locale)
+		b.Set("device.time_zone", common.Device.TimeZone)
+		b.Set("device.battery_level", common.Device.BatteryLevel)
+		b.Set("device.power_saving_mode", common.Device.PowerSavingMode)
+		b.Set("device.brightness_level", common.Device.BrightnessLevel)
+		b.Set("device.logical_cpu_count", common.Device.LogicalCPUCount)
+		b.Set("device.total_ram", common.Device.TotalRAM)
+		b.Set("device.is_low_ram", common.Device.IsLowRAM)
+	}
+	if common.Connectivity != nil {
+		b.Set("connectivity.status", common.Connectivity.Status)
+		b.Set("connectivity.effective_type", common.Connectivity.EffectiveType)
+		b.Set("connectivity.interfaces", common.Connectivity.Interfaces)
+		if common.Connectivity.Cellular != nil {
+			b.Set("connectivity.cellular.technology", common.Connectivity.Cellular.Technology)
+			b.Set("connectivity.cellular.carrier_name", common.Connectivity.Cellular.CarrierName)
+		}
+	}
+	if common.Display != nil && common.Display.Viewport != nil {
+		b.Set("viewport.width", common.Display.Viewport.Width)
+		b.Set("viewport.height", common.Display.Viewport.Height)
+	}
+}
+
+func sessionValue(common *model.CommonFields, getter func(*model.Session) string) string {
+	if common.Session == nil {
+		return ""
+	}
+	return getter(common.Session)
+}
+
+func environmentFromTags(tags string) string {
+	for _, tag := range strings.Split(tags, ",") {
+		key, value, ok := strings.Cut(strings.TrimSpace(tag), ":")
+		if ok && strings.EqualFold(strings.TrimSpace(key), "env") && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return "production"
+}
+
+func putSampleRate(b *AttributeBuilder, key string, value *float64) {
+	if value == nil {
+		return
+	}
+	// Datadog sample rates are percentages (0-100); normalize to [0, 1].
+	rate := *value / 100
+	if rate < 0 {
+		rate = 0
+	}
+	if rate > 1 {
+		rate = 1
+	}
+	b.Set(key, rate)
+}
+
+func putJSON(b *AttributeBuilder, key string, value any) {
+	if value == nil {
+		return
+	}
+	data, err := json.Marshal(value)
+	if err == nil {
+		b.Set(key, string(data))
+	}
+}
+
+func convertView(span ptrace.Span, event *model.ViewEvent, b *AttributeBuilder) {
+	view := event.View
+	span.SetName("page.view")
+	span.SetKind(ptrace.SpanKindInternal)
+	b.Set("view.id", view.ID)
+	b.Set("view.name", view.Name)
+	b.Set("view.url", view.URL)
+	b.Set("view.referrer", view.Referrer)
+	b.Set("view.previous", view.Referrer)
+	b.Set("view.loading_type", view.LoadingType)
+	b.Set("view.is_active", view.IsActive)
+	docVersion := -1
+	if event.Internal != nil {
+		docVersion = utils.Val(event.Internal.DocumentVersion, -1)
+	}
+	b.Set("view.version", docVersion)
+
+	// 优先级：end > start > update
+	switch {
+	case view.IsActive != nil && !*view.IsActive:
+		b.Set(attrViewPhase, phaseEnd)
+	case docVersion == 1:
+		b.Set(attrViewPhase, phaseStart)
+	case view.IsActive != nil && *view.IsActive && docVersion > 1:
+		b.Set(attrViewPhase, phaseUpdate)
+	}
+	b.Set("view.loading_time", view.LoadingTime)
+	// 代表当前文档卸载上一个页面的时间点，作为整个页面生命周期的零点
+	if view.Performance != nil {
+		b.Set("view.started_at", view.Performance.NavigationStart)
+	}
+	b.Set("view.url_path_group", view.URL)
+	b.Set("view.network_settled_time", view.NetworkSettledTime)
+	b.Set("view.interaction_to_next_view_time", view.InteractionToNextViewTime)
+	b.Set("view.time_spent", view.TimeSpent)
+	putViewCounts(b, view)
+	putViewVitals(b, view)
+	putViewPerformanceAttrs(b, view.Performance)
+	for name, value := range view.CustomTimings {
+		b.Set("view.custom_timing."+name, value)
+	}
+	putJSON(b, "view.page_state", view.PageState)
+	putJSON(b, "view.in_foreground_periods", view.InForegroundPeriods)
+	if event.GetType() == model.EventTypeViewUpdate {
+		b.Set("event.type", model.EventTypeViewUpdate.S())
+	}
+
+	duration := int64(time.Millisecond)
+	if view.TimeSpent != nil && *view.TimeSpent > 0 {
+		duration = *view.TimeSpent
+	} else if view.LoadingTime != nil && *view.LoadingTime > 0 {
+		duration = *view.LoadingTime
+	}
+	setEnd(span, duration)
+	addViewPerformanceEvents(span, view.Performance)
+}
+
+func putViewCounts(b *AttributeBuilder, view model.View) {
+	// EventCount 相关（带下划线）
+	if view.EventCount != nil {
+		b.Set("view.action_count", view.EventCount.Action)
+		b.Set("view.error_count", view.EventCount.Error)
+		b.Set("view.resource_count", view.EventCount.Resource)
+		b.Set("view.long_task_count", view.EventCount.LongTask)
+	}
+
+	// 独立的计数器（带点）
+	if view.Action != nil {
+		b.Set("view.action.count", view.Action.Count)
+	}
+	if view.Error != nil {
+		b.Set("view.error.count", view.Error.Count)
+	}
+	if view.Crash != nil {
+		b.Set("view.crash.count", view.Crash.Count)
+	}
+	if view.Resource != nil {
+		b.Set("view.resource.count", view.Resource.Count)
+	}
+	if view.LongTask != nil {
+		b.Set("view.long_task.count", view.LongTask.Count)
+	}
+	if view.Frustration != nil {
+		b.Set("view.frustration.count", view.Frustration.Count)
+	}
+}
+
+func putViewVitals(b *AttributeBuilder, view model.View) {
+	b.Set("view.first_contentful_paint", view.FirstContentfulPaint)
+	b.Set("view.largest_contentful_paint", view.LargestContentfulPaint)
+	b.Set("view.largest_contentful_paint_target_selector", view.LargestContentfulPaintTargetSelector)
+	b.Set("view.first_input_delay", view.FirstInputDelay)
+	b.Set("view.first_input_time", view.FirstInputTime)
+	b.Set("view.first_input_target_selector", view.FirstInputTargetSelector)
+	b.Set("view.interaction_to_next_paint", view.InteractionToNextPaint)
+	b.Set("view.interaction_to_next_paint_time", view.InteractionToNextPaintTime)
+	b.Set("view.interaction_to_next_paint_target_selector", view.InteractionToNextPaintTargetSelector)
+	b.Set("view.cumulative_layout_shift", view.CumulativeLayoutShift)
+	b.Set("view.cumulative_layout_shift_time", view.CumulativeLayoutShiftTime)
+	b.Set("view.cumulative_layout_shift_target_selector", view.CumulativeLayoutShiftTargetSelector)
+}
+
+func putViewPerformanceAttrs(b *AttributeBuilder, performance *model.ViewPerformance) {
+	if performance == nil {
+		return
+	}
+	b.Set("view.performance.navigation_start", performance.NavigationStart)
+	b.Set("view.performance.first_byte", performance.FirstByte)
+	b.Set("view.performance.dom_interactive", performance.DOMInteractive)
+	b.Set("view.performance.dom_content_loaded", performance.DOMContentLoaded)
+	b.Set("view.performance.dom_complete", performance.DOMComplete)
+	b.Set("view.performance.load_event", performance.LoadEvent)
+}
+
+func addViewPerformanceEvents(span ptrace.Span, performance *model.ViewPerformance) {
+	if performance == nil {
+		return
+	}
+	var last pcommon.Timestamp
+	addValueEvent(span, "firstContentfulPaint", fcpValue(performance), &last)
+	if performance.LCP != nil {
+		attrs := pcommon.NewMap()
+		b := NewAttributeBuilder(attrs)
+		b.SetAll(map[string]interface{}{
+			"target":          performance.LCP.Target,
+			"target_selector": performance.LCP.TargetSelector,
+			"resource_url":    performance.LCP.ResourceURL,
+			"element":         performance.LCP.Element,
+		})
+		putJSON(b, "sub_parts", performance.LCP.SubParts)
+
+		addValueEventWithAttrs(span, "largestContentfulPaint", performance.LCP.Timestamp, attrs, &last)
+	}
+	if performance.FID != nil {
+		attrs := pcommon.NewMap()
+		b := NewAttributeBuilder(attrs)
+		b.Set("duration", performance.FID.Duration)
+		b.Set("target_selector", performance.FID.TargetSelector)
+		addValueEventWithAttrs(span, "firstInputDelay", performance.FID.Timestamp, attrs, &last)
+	}
+	if performance.INP != nil {
+		attrs := pcommon.NewMap()
+		b := NewAttributeBuilder(attrs)
+		b.SetAll(map[string]interface{}{
+			"duration":        performance.INP.Duration,
+			"value":           performance.INP.Value,
+			"target_selector": performance.INP.TargetSelector,
+			"target":          performance.INP.Target,
+		})
+		putJSON(b, "sub_parts", performance.INP.SubParts)
+
+		addValueEventWithAttrs(span, "interactionToNextPaint", performance.INP.Timestamp, attrs, &last)
+	}
+	if performance.CLS != nil {
+		attrs := pcommon.NewMap()
+		b := NewAttributeBuilder(attrs)
+		b.Set("score", performance.CLS.Score)
+		b.Set("value", performance.CLS.Value)
+		b.Set("target_selector", performance.CLS.TargetSelector)
+		putJSON(b, "previous_rect", performance.CLS.PreviousRect)
+		putJSON(b, "current_rect", performance.CLS.CurrentRect)
+		addValueEventWithAttrs(span, "cumulativeLayoutShift", performance.CLS.Timestamp, attrs, &last)
+	}
+	addValueEvent(span, "responseStart", performance.FirstByte, &last)
+	addValueEvent(span, "domInteractive", performance.DOMInteractive, &last)
+	addValueEvent(span, "domContentLoadedEventEnd", performance.DOMContentLoaded, &last)
+	addValueEvent(span, "domComplete", performance.DOMComplete, &last)
+	addValueEvent(span, "loadEventEnd", performance.LoadEvent, &last)
+}
+
+func fcpValue(performance *model.ViewPerformance) *int64 {
+	if performance == nil || performance.FCP == nil {
+		return nil
+	}
+	return performance.FCP.Timestamp
+}
+
+func addValueEvent(span ptrace.Span, name string, value *int64, last *pcommon.Timestamp) {
+	addValueEventWithAttrs(span, name, value, pcommon.NewMap(), last)
+}
+
+func addValueEventWithAttrs(span ptrace.Span, name string, value *int64, attrs pcommon.Map, last *pcommon.Timestamp) {
+	if value == nil {
+		return
+	}
+	offset := *value
+	if offset < 0 {
+		offset = 0
+	}
+	timestamp := span.StartTimestamp() + serverDurationTimestamp(offset)
+	if last != nil && timestamp < *last {
+		attrs.PutInt("original_offset_ns", *value)
+		timestamp = *last
+	}
+	event := span.Events().AppendEmpty()
+	event.SetName(name)
+	event.SetTimestamp(timestamp)
+	attrs.CopyTo(event.Attributes())
+	if last != nil {
+		*last = timestamp
+	}
+}
+
+func convertAction(span ptrace.Span, event *model.ActionEvent, b *AttributeBuilder) {
+	action := event.Action
+	span.SetName("ui.action")
+	span.SetKind(ptrace.SpanKindInternal)
+	b.Set("action.id", action.ID)
+	b.Set("action.type", action.Type)
+	b.Set("action.name", action.Name)
+	b.Set("action.loading_time", action.LoadingTime)
+	b.Set("action.long_task_count", action.LongTaskCount)
+	b.Set("action.resource_count", action.ResourceCount)
+	b.Set("action.error_count", action.ErrorCount)
+	b.Set("action.in_foreground", action.ViewActive)
+	if action.Target != nil {
+		b.Set("action.target.name", action.Target.Name)
+		b.Set("action.target.selector", action.Target.Selector)
+		b.Set("action.target.width", action.Target.Width)
+		b.Set("action.target.height", action.Target.Height)
+	}
+	if action.Frustration != nil {
+		b.Set("action.frustration.types", action.Frustration.Type)
+	}
+	if action.EventCount != nil {
+		b.Set("action.event.error_count", action.EventCount.Error)
+		b.Set("action.event.resource_count", action.EventCount.Resource)
+		b.Set("action.event.long_task_count", action.EventCount.LongTask)
+	}
+	if action.CrashCount != nil {
+		b.Set("action.crash_count", action.CrashCount.Count)
+	}
+	if action.Position != nil {
+		b.Set("action.position.x", action.Position.X)
+		b.Set("action.position.y", action.Position.Y)
+	}
+	if action.Internal != nil {
+		b.Set("action.dd.target_selector_path", action.Internal.TargetSelectorPath)
+		b.Set("action.dd.selector", action.Internal.Selector)
+		b.Set("action.dd.composed_path_selector", action.Internal.ComposedPathSelector)
+		b.Set("action.dd.permanent_id", action.Internal.PermanentID)
+		b.Set("action.dd.name_source", action.Internal.NameSource)
+		b.Set("action.dd.width", action.Internal.Width)
+		b.Set("action.dd.height", action.Internal.Height)
+		b.Set("action.dd.position_x", action.Internal.PositionX)
+		b.Set("action.dd.position_y", action.Internal.PositionY)
+	}
+	if event.GetCommon().ViewContext != nil {
+		b.Set("view.id", event.GetCommon().ViewContext.ID)
+		b.Set("view.url", event.GetCommon().ViewContext.URL)
+	}
+	setEnd(span, valueOrDefault(action.LoadingTime, int64(time.Millisecond)))
+}
+
+func convertResource(span ptrace.Span, event *model.ResourceEvent, b *AttributeBuilder) {
+	resource := event.Resource
+	method := strings.ToUpper(strings.TrimSpace(resource.Method))
+	if method != "" {
+		span.SetName(method)
+	} else {
+		span.SetName("resource.load")
+	}
+	span.SetKind(ptrace.SpanKindClient)
+
+	resourceType := resource.Type
+	if resourceType == "" {
+		resourceType = "other"
+	}
+	b.Set("resource.type", resourceType)
+
+	parsed := parseURL(resource.URL)
+	b.Set("url.full", redactedURL(parsed, resource.URL))
+	b.Set("server.address", serverAddress(parsed, resource.URLHost))
+	if port, ok := serverPort(parsed); ok {
+		b.Set("server.port", port)
+	}
+
+	// http.request.method 与 url.template 仅适用于 Fetch/XHR；静态资源缺失。
+	if isRequestType(resource.Type) {
+		b.Set("http.request.method", method)
+		b.Set("url.template", urlTemplate(parsed))
+	}
+
+	if resource.StatusCode != nil && *resource.StatusCode > 0 {
+		b.Set("http.response.status_code", *resource.StatusCode)
+	}
+	b.Set("resource.protocol", resource.Protocol)
+
+	deliveryType := resource.DeliveryType
+	if deliveryType == "" {
+		deliveryType = "other"
+	}
+	b.Set("resource.delivery_type", deliveryType)
+	b.Set("resource.render_blocking_status", resource.RenderBlockingStatus)
+
+	// resource.size 协议定义为 decodedBodySize。
+	b.Set("resource.size", resource.DecodedBodySize)
+	b.Set("resource.encoded_body_size", resource.EncodedBodySize)
+	b.Set("resource.decoded_body_size", resource.DecodedBodySize)
+	b.Set("resource.transfer_size", resource.TransferSize)
+
+	if cacheHit(resource) {
+		b.Set("resource.cache.hit", true)
+	}
+
+	if resource.StatusCode != nil && *resource.StatusCode >= 100 && *resource.StatusCode <= 599 {
+		status := *resource.StatusCode
+		switch {
+		case status >= 200 && status < 300:
+			span.Status().SetCode(ptrace.StatusCodeOk)
+		case status >= 400 && status <= 599:
+			span.Status().SetCode(ptrace.StatusCodeError)
+			span.Status().SetMessage(http.StatusText(status))
+		default: // 1xx Informational 与 3xx Redirection 不视为错误
+			span.Status().SetCode(ptrace.StatusCodeUnset)
+		}
+	}
+
+	setEnd(span, valueOrDefault(resource.Duration, int64(time.Millisecond)))
+	addResourceTimingEvents(span, resource.Timing)
+}
+
+func addResourceTimingEvents(span ptrace.Span, timing *model.ResourceTiming) {
+	if timing == nil {
+		return
+	}
+	var last pcommon.Timestamp
+	addTimingEvent(span, "resource.redirect", timing.Redirect, &last)
+	addTimingEvent(span, "resource.worker", timing.Worker, &last)
+	addTimingEvent(span, "resource.dns", timing.DNS, &last)
+	addTimingEvent(span, "resource.connect", timing.Connect, &last)
+	addTimingEvent(span, "resource.ssl", timing.SSL, &last)
+	addTimingEvent(span, "resource.first_byte", timing.FirstByte, &last)
+	addTimingEvent(span, "resource.download", timing.Download, &last)
+}
+
+func addTimingEvent(span ptrace.Span, name string, timing *model.Timing, last *pcommon.Timestamp) {
+	if timing == nil || timing.Start == nil {
+		return
+	}
+	start := *timing.Start
+	if start < 0 {
+		start = 0
+	}
+	timestamp := span.StartTimestamp() + serverDurationTimestamp(start)
+	if timestamp < *last {
+		timestamp = *last
+	}
+	event := span.Events().AppendEmpty()
+	event.SetName(name)
+	event.SetTimestamp(timestamp)
+	b := NewAttributeBuilder(event.Attributes())
+	b.Set("timing.start_ns", start)
+	b.Set("timing.duration_ns", timing.Duration)
+	if timing.Duration != nil && *timing.Duration >= 0 {
+		b.Set("timing.end_ns", start+*timing.Duration)
+	}
+	*last = timestamp
+}
+
+var (
+	numericRe = regexp.MustCompile(`^\d+$`)
+	uuidRe    = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	longHexRe = regexp.MustCompile(`^[0-9a-fA-F]{8,}$`)
+)
+
+func parseURL(raw string) *url.URL {
+	if raw == "" {
+		return nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	return parsed
+}
+
+// redactedURL 返回去除 query 后的绝对 URL，避免在 url.full 上保留原始查询参数。
+func redactedURL(parsed *url.URL, fallback string) string {
+	if parsed == nil {
+		return fallback
+	}
+	redacted := *parsed
+	redacted.RawQuery = ""
+	return redacted.String()
+}
+
+// serverAddress 返回不含端口的 hostname；URL 无法解析时回退到 SDK 提供的 host。
+func serverAddress(parsed *url.URL, fallback string) string {
+	if parsed != nil && parsed.Hostname() != "" {
+		return parsed.Hostname()
+	}
+	return fallback
+}
+
+// serverPort 返回 URL 中显式书写的端口；URL 未写端口（含协议默认端口）时返回 false。
+func serverPort(parsed *url.URL) (int, bool) {
+	if parsed == nil {
+		return 0, false
+	}
+	portStr := parsed.Port()
+	if portStr == "" {
+		return 0, false
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0, false
+	}
+	return port, true
+}
+
+// urlTemplate 由 URL path 派生低基数路由模板：数字 ID、UUID、长十六进制段折叠为 :id。
+// 只保留 path，不含 host。URL 无 path 时返回空串。
+func urlTemplate(parsed *url.URL) string {
+	if parsed == nil || parsed.Path == "" {
+		return ""
+	}
+	segments := strings.Split(parsed.Path, "/")
+	for i, seg := range segments {
+		if seg == "" {
+			continue
+		}
+		if numericRe.MatchString(seg) || uuidRe.MatchString(seg) || longHexRe.MatchString(seg) {
+			segments[i] = ":id"
+		}
+	}
+	return strings.Join(segments, "/")
+}
+
+// isRequestType 判断 resource.type 是否为 Fetch/XHR。
+func isRequestType(resourceType string) bool {
+	switch strings.ToLower(resourceType) {
+	case "fetch", "xhr":
+		return true
+	}
+	return false
+}
+
+// cacheHit 推断资源是否命中缓存：
+//   - deliveryType 为 cache；
+//   - 或 transferSize=0 且 decodedBodySize>0。
+//
+// 无法确认命中时不写该字段（而非写 false）。
+func cacheHit(resource model.Resource) bool {
+	if strings.EqualFold(resource.DeliveryType, "cache") {
+		return true
+	}
+	return resource.TransferSize != nil && *resource.TransferSize == 0 &&
+		resource.DecodedBodySize != nil && *resource.DecodedBodySize > 0
+}
+
+func convertError(span ptrace.Span, event *model.ErrorEvent, b *AttributeBuilder) {
+	rumError := event.Error
+	span.SetName("exception")
+	span.SetKind(ptrace.SpanKindInternal)
+
+	source := convertErrorSource(rumError.Source, rumError.Type)
+	b.Set("error.source", source)
+	b.Set("error.type", errorTypeFromSource(source))
+	b.Set("error.message", rumError.Message)
+	b.Set("error.handled", strings.EqualFold(rumError.Handling, "handled"))
+	b.Set("error.stack", rumError.Stack)
+	b.Set("error.cross_origin", rumError.CrossOrigin)
+	b.Set("code.filepath", rumError.File)
+	b.Set("code.lineno", rumError.Line)
+	b.Set("code.column", rumError.Column)
+	if source == "resource" {
+		if rumError.Resource != nil {
+			b.Set("error.resource_url", rumError.Resource.URL)
+		}
+		b.Set("error.resource_tag", rumError.ResourceType)
+	}
+
+	span.Status().SetCode(ptrace.StatusCodeError)
+	span.Status().SetMessage(rumError.Message)
+	setEnd(span, int64(time.Millisecond))
+}
+
+// convertErrorSource 将 Datadog error.source 映射为 bk-rum 枚举：
+//   - network -> resource
+//   - source 且 error.type 含 Unhandledrejection -> unhandledrejection
+//   - source（其余） -> window.error
+//   - cross-origin -> window.error
+//   - 其余（console/report 等）原样透传
+func convertErrorSource(source, errorType string) string {
+	switch source {
+	case "network":
+		return "resource"
+	case "source":
+		if strings.Contains(strings.ToLower(errorType), "unhandledrejection") {
+			return "unhandledrejection"
+		}
+		return "window.error"
+	case "cross-origin":
+		return "window.error"
+	default:
+		return source
+	}
+}
+
+// errorTypeFromSource 由 bk-rum source 派生 bk-rum error.type 枚举。
+// 无法映射的 source（如原样透传的 console/report）返回空串，不输出该字段。
+func errorTypeFromSource(source string) string {
+	switch source {
+	case "window.error":
+		return "JavaScriptError"
+	case "unhandledrejection":
+		return "PromiseRejection"
+	case "resource":
+		return "ResourceError"
+	default:
+		return ""
+	}
+}
+
+func convertLongTask(span ptrace.Span, event *model.LongTaskEvent, b *AttributeBuilder) {
+	longTask := event.LongTask
+	span.SetName("browser.long_task")
+	span.SetKind(ptrace.SpanKindInternal)
+	b.Set("long_task.id", longTask.ID)
+	b.Set("long_task.name", longTask.Name)
+	b.Set("long_task.entry_type", longTask.EntryType)
+	b.Set("long_task.blocking_duration", longTask.BlockingDuration)
+	b.Set("long_task.first_ui_event_timestamp", longTask.FirstUIEventTimestamp)
+	b.Set("long_task.render_start", longTask.RenderStart)
+	b.Set("long_task.style_and_layout_start", longTask.StyleAndLayoutStart)
+	setEnd(span, valueOrDefault(longTask.Duration, int64(time.Millisecond)))
+}
+
+func convertVital(span ptrace.Span, event *model.VitalEvent, b *AttributeBuilder) {
+	vital := event.Vital
+	name := string(vital.Name)
+	if name == "" {
+		name = "vital"
+	} else {
+		name = "vital." + name
+	}
+	span.SetName(name)
+	span.SetKind(ptrace.SpanKindInternal)
+	b.Set("vital.id", vital.ID)
+	b.Set("vital.type", string(vital.Type))
+	b.Set("vital.name", vital.Name)
+	b.Set("vital.description", vital.Description)
+	b.Set("vital.step_type", string(vital.StepType))
+	b.Set("vital.operation_key", vital.OperationKey)
+	b.Set("vital.duration", vital.Duration)
+	b.Set("vital.failure_reason", string(vital.FailureReason))
+	if vital.Internal != nil {
+		b.Set("vital.computed_value", vital.Internal.ComputedValue)
+	}
+	setEnd(span, valueOrDefault(vital.Duration, int64(time.Millisecond)))
+}
+
+func valueOrDefault(value *int64, fallback int64) int64 {
+	if value == nil || *value <= 0 {
+		return fallback
+	}
+	return *value
+}

--- a/pkg/collector/receiver/datadogrum/internal/converter/converter_test.go
+++ b/pkg/collector/receiver/datadogrum/internal/converter/converter_test.go
@@ -1,0 +1,574 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+type (
+	attributeString  string
+	attributeInt     int
+	attributeUint    uint
+	attributeFloat   float32
+	attributeBool    bool
+	attributeStrings []string
+)
+
+func TestAttributeBuilderSetScalarsPointersAliasesAndSlices(t *testing.T) {
+	attrs := pcommon.NewMap()
+	zeroInt := attributeInt(0)
+	zeroUint := attributeUint(0)
+	zeroFloat := attributeFloat(0)
+	falseValue := attributeBool(false)
+	nilString := (*attributeString)(nil)
+	nilInt := (*attributeInt)(nil)
+
+	builder := NewAttributeBuilder(attrs)
+	assert.Same(t, builder, builder.Set("string", attributeString("value")))
+	builder.Set("signed", attributeInt(-7))
+	builder.Set("unsigned", attributeUint(7))
+	builder.Set("float", attributeFloat(1.5))
+	builder.Set("bool", attributeBool(true))
+	builder.Set("zero_int", zeroInt)
+	builder.Set("zero_uint", zeroUint)
+	builder.Set("zero_float", zeroFloat)
+	builder.Set("false", falseValue)
+	builder.Set("pointer_int", &zeroInt)
+	pointerString := attributeString("pointer")
+	builder.Set("pointer_string", &pointerString)
+	builder.Set("nil_string", nilString)
+	builder.Set("nil_int", nilInt)
+	builder.Set("strings", []string{"first", ""})
+	builder.Set("named_strings", attributeStrings{"named", ""})
+	assert.Same(t, builder, builder.SetAll(map[string]interface{}{
+		"set_all_string": attributeString("set-all"),
+		"set_all_int":    int64(0),
+		"set_all_bool":   false,
+	}))
+	builder.Set("empty_string", "")
+
+	raw := attrs.AsRaw()
+	assert.Equal(t, "value", raw["string"])
+	assert.Equal(t, int64(-7), raw["signed"])
+	assert.Equal(t, int64(7), raw["unsigned"])
+	assert.InDelta(t, 1.5, raw["float"], 0)
+	assert.Equal(t, true, raw["bool"])
+	assert.Equal(t, int64(0), raw["zero_int"])
+	assert.Equal(t, int64(0), raw["zero_uint"])
+	assert.Equal(t, float64(0), raw["zero_float"])
+	assert.Equal(t, false, raw["false"])
+	assert.Equal(t, int64(0), raw["pointer_int"])
+	assert.Equal(t, "pointer", raw["pointer_string"])
+	assert.Equal(t, []interface{}{"first", ""}, raw["strings"])
+	assert.Equal(t, []interface{}{"named", ""}, raw["named_strings"])
+	assert.Equal(t, "set-all", raw["set_all_string"])
+	assert.Equal(t, int64(0), raw["set_all_int"])
+	assert.Equal(t, false, raw["set_all_bool"])
+	assert.NotContains(t, raw, "empty_string")
+	assert.NotContains(t, raw, "nil_string")
+	assert.NotContains(t, raw, "nil_int")
+}
+
+func TestAttributeBuilderSetOversizedUnsignedAsString(t *testing.T) {
+	attrs := pcommon.NewMap()
+	maxInt64 := uint64(1<<63 - 1)
+	builder := NewAttributeBuilder(attrs)
+	builder.Set("max_int64", maxInt64)
+	builder.Set("oversized", maxInt64+1)
+
+	raw := attrs.AsRaw()
+	assert.Equal(t, int64(maxInt64), raw["max_int64"])
+	assert.Equal(t, "9223372036854775808", raw["oversized"])
+}
+
+func TestConvertCreatesOneSpanPerEvent(t *testing.T) {
+	date := int64(1_700_000_000_000)
+	batch := &model.Batch{Events: []model.Event{
+		&model.ViewEvent{CommonFields: common(date, model.EventTypeView, "view-1"), View: model.View{ViewContext: model.ViewContext{ID: "view-1", Name: "home"}}},
+		&model.ViewEvent{CommonFields: common(date+1, model.EventTypeViewUpdate, "view-update-1"), View: model.View{ViewContext: model.ViewContext{ID: "view-1"}}},
+		&model.ActionEvent{CommonFields: common(date+2, model.EventTypeAction, "action-1"), Action: model.Action{ID: "action-1", Type: "click"}},
+		&model.ResourceEvent{CommonFields: common(date+3, model.EventTypeResource, "resource-1"), Resource: model.Resource{ID: "resource-1", Method: "get"}},
+		&model.ErrorEvent{CommonFields: common(date+4, model.EventTypeError, "error-1"), Error: model.Error{ID: "error-1", Message: "boom"}},
+		&model.LongTaskEvent{CommonFields: common(date+5, model.EventTypeLongTask, "long-task-1"), LongTask: model.LongTask{ID: "long-task-1"}},
+		&model.VitalEvent{CommonFields: common(date+6, model.EventTypeVital, "vital-1"), Vital: model.Vital{ID: "vital-1", Name: "fcp"}},
+	}}
+
+	traces := Convert(batch, "")
+	require.Equal(t, 7, traces.ResourceSpans().Len())
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		scopeSpans := traces.ResourceSpans().At(i).ScopeSpans()
+		require.Equal(t, 1, scopeSpans.Len())
+		require.Equal(t, "bk-rum", scopeSpans.At(0).Scope().Name())
+		require.Equal(t, defaultSDKVersion, scopeSpans.At(0).Scope().Version())
+		require.Equal(t, 1, scopeSpans.At(0).Spans().Len())
+		span := scopeSpans.At(0).Spans().At(0)
+		assert.False(t, span.TraceID().IsEmpty())
+		assert.False(t, span.SpanID().IsEmpty())
+		if i != 3 {
+			assert.Equal(t, ptrace.SpanKindInternal, span.Kind(), "event %d", i)
+		}
+		assert.Equal(t, "session-1", traces.ResourceSpans().At(i).Resource().Attributes().AsRaw()["session.id"])
+	}
+	assert.Equal(t, "page.view", traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, "ui.action", traces.ResourceSpans().At(2).ScopeSpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, ptrace.SpanKindClient, traces.ResourceSpans().At(3).ScopeSpans().At(0).Spans().At(0).Kind())
+	assert.Equal(t, "exception", traces.ResourceSpans().At(4).ScopeSpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, "browser.long_task", traces.ResourceSpans().At(5).ScopeSpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, "vital.fcp", traces.ResourceSpans().At(6).ScopeSpans().At(0).Spans().At(0).Name())
+}
+
+func TestConvertIDsAndResourceAttributes(t *testing.T) {
+	commonFields := common(1_700_000_000_000, model.EventTypeView, "view-1")
+	commonFields.Application = model.Application{ID: "app-id", Name: "shop"}
+	commonFields.Service = "fallback-service"
+	commonFields.Version = "1.2.3"
+	commonFields.Tags = "team:web,env:staging"
+	commonFields.User = &model.User{ID: "user-1", AnonymousID: "anon-1"}
+	commonFields.Internal = &model.InternalFields{
+		TraceID:           "00112233445566778899aabbccddeeff",
+		SpanID:            "0011223344556677",
+		BrowserSDKVersion: "5.0.0",
+		Configuration:     &model.Configuration{SessionSampleRate: float64Ptr(25)},
+	}
+	commonFields.Raw = json.RawMessage(`{"type":"view","unknown":{"kept":true}}`)
+
+	traces := Convert(&model.Batch{Events: []model.Event{&model.ViewEvent{
+		CommonFields: commonFields,
+		View:         model.View{ViewContext: model.ViewContext{ID: "view-1"}},
+	}}}, "Mozilla/5.0 (test)")
+	require.Equal(t, 1, traces.ResourceSpans().Len())
+	resource := traces.ResourceSpans().At(0)
+	attrs := resource.Resource().Attributes().AsRaw()
+	assert.Equal(t, "shop", attrs["service.name"])
+	assert.Equal(t, "1.2.3", attrs["service.version"])
+	assert.Equal(t, "Mozilla/5.0 (test)", attrs["http.user_agent"])
+	assert.Equal(t, "staging", attrs["deployment.environment.name"])
+	assert.InDelta(t, 0.25, attrs["session.sample_rate"], 0.0001)
+	assert.Equal(t, "5.0.0", resource.ScopeSpans().At(0).Scope().Version())
+
+	span := resource.ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, "00112233445566778899aabbccddeeff", span.TraceID().HexString())
+	assert.Equal(t, "0011223344556677", span.SpanID().HexString())
+
+	withoutIDs := commonFields
+	withoutIDs.Internal = &model.InternalFields{}
+	withoutIDs.Session = &model.Session{ID: "session-other"}
+	other := Convert(&model.Batch{Events: []model.Event{&model.ViewEvent{
+		CommonFields: withoutIDs,
+		View:         model.View{ViewContext: model.ViewContext{ID: "view-other"}},
+	}}}, "")
+	assert.NotEqual(t, span.TraceID().HexString(), other.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID().HexString())
+}
+
+func TestConvertViewResourceErrorAndLongTaskDetails(t *testing.T) {
+	fcp := int64(10 * time.Millisecond)
+	lcp := int64(20 * time.Millisecond)
+	timingStart := int64(5 * time.Millisecond)
+	duration := int64(30 * time.Millisecond)
+	loadingTime := int64(25 * time.Millisecond)
+	timeSpent := int64(35 * time.Millisecond)
+	status := 503
+	performance := &model.ViewPerformance{
+		FCP:       &model.FCPPerformance{Timestamp: &fcp},
+		LCP:       &model.LCPPerformance{Timestamp: &lcp, TargetSelector: "#hero"},
+		FirstByte: &duration,
+	}
+	resource := &model.ResourceEvent{CommonFields: common(1000, model.EventTypeResource, "resource"), Resource: model.Resource{
+		Method: "get", StatusCode: &status, Duration: &duration,
+		Timing: &model.ResourceTiming{DNS: &model.Timing{Start: &timingStart, Duration: &duration}},
+	}}
+	view := &model.ViewEvent{CommonFields: common(1000, model.EventTypeView, "view"), View: model.View{
+		ViewContext: model.ViewContext{ID: "view"}, Performance: performance,
+		LoadingTime: &loadingTime, TimeSpent: &timeSpent,
+	}}
+	errorEvent := &model.ErrorEvent{CommonFields: common(1000, model.EventTypeError, "error"), Error: model.Error{Message: "failed"}}
+	longTaskDuration := int64(40 * time.Millisecond)
+	longTask := &model.LongTaskEvent{CommonFields: common(1000, model.EventTypeLongTask, "long"), LongTask: model.LongTask{
+		Duration: &longTaskDuration,
+	}}
+
+	traces := Convert(&model.Batch{Events: []model.Event{view, resource, errorEvent, longTask}}, "")
+	start := pcommon.NewTimestampFromTime(time.UnixMilli(1000))
+	viewSpan := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, start, viewSpan.StartTimestamp())
+	assert.Equal(t, pcommonTimestamp(int64(35*time.Millisecond)), viewSpan.EndTimestamp()-viewSpan.StartTimestamp())
+	assert.Equal(t, pcommonTimestamp(int64(10*time.Millisecond)), viewSpan.Events().At(0).Timestamp()-viewSpan.StartTimestamp())
+	assert.Equal(t, 3, viewSpan.Events().Len())
+
+	resourceSpan := traces.ResourceSpans().At(1).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, pcommonTimestamp(int64(30*time.Millisecond)), resourceSpan.EndTimestamp()-resourceSpan.StartTimestamp())
+	assert.Equal(t, "GET", resourceSpan.Name())
+	assert.Equal(t, int64(503), resourceSpan.Attributes().AsRaw()["http.response.status_code"])
+	assert.Equal(t, ptrace.StatusCodeError, resourceSpan.Status().Code())
+	assert.Equal(t, 1, resourceSpan.Events().Len())
+	assert.Equal(t, "resource.dns", resourceSpan.Events().At(0).Name())
+	assert.Equal(t, pcommonTimestamp(int64(5*time.Millisecond)), resourceSpan.Events().At(0).Timestamp()-resourceSpan.StartTimestamp())
+	timingAttrs := resourceSpan.Events().At(0).Attributes().AsRaw()
+	assert.Equal(t, int64(5*time.Millisecond), timingAttrs["timing.start_ns"])
+	assert.Equal(t, int64(30*time.Millisecond), timingAttrs["timing.duration_ns"])
+	assert.Equal(t, int64(35*time.Millisecond), timingAttrs["timing.end_ns"])
+
+	errorSpan := traces.ResourceSpans().At(2).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, ptrace.StatusCodeError, errorSpan.Status().Code())
+	assert.Equal(t, "failed", errorSpan.Status().Message())
+	assert.Equal(t, pcommonTimestamp(int64(time.Millisecond)), errorSpan.EndTimestamp()-errorSpan.StartTimestamp())
+
+	longTaskSpan := traces.ResourceSpans().At(3).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, pcommonTimestamp(int64(40*time.Millisecond)), longTaskSpan.EndTimestamp()-longTaskSpan.StartTimestamp())
+}
+
+func TestConvertDurationsUseServerNanoseconds(t *testing.T) {
+	duration := int64(30 * time.Millisecond)
+	cases := []struct {
+		name  string
+		event model.Event
+		span  string
+	}{
+		{
+			name: "action loading time",
+			event: &model.ActionEvent{
+				CommonFields: common(1000, model.EventTypeAction, "action"),
+				Action:       model.Action{LoadingTime: &duration},
+			},
+			span: "ui.action",
+		},
+		{
+			name: "resource duration",
+			event: &model.ResourceEvent{
+				CommonFields: common(1000, model.EventTypeResource, "resource"),
+				Resource:     model.Resource{Duration: &duration},
+			},
+			span: "resource.load",
+		},
+		{
+			name: "long task duration",
+			event: &model.LongTaskEvent{
+				CommonFields: common(1000, model.EventTypeLongTask, "long-task"),
+				LongTask:     model.LongTask{Duration: &duration},
+			},
+			span: "browser.long_task",
+		},
+		{
+			name: "vital duration",
+			event: &model.VitalEvent{
+				CommonFields: common(1000, model.EventTypeVital, "vital"),
+				Vital:        model.Vital{Name: "fcp", Duration: &duration},
+			},
+			span: "vital.fcp",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			span := Convert(&model.Batch{Events: []model.Event{tc.event}}, "").
+				ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+			assert.Equal(t, tc.span, span.Name())
+			assert.Equal(t, pcommonTimestamp(duration), span.EndTimestamp()-span.StartTimestamp())
+		})
+	}
+}
+
+func TestConvertDurationFallbackUsesOneMillisecond(t *testing.T) {
+	zero := int64(0)
+	negative := int64(-1)
+	cases := []model.Event{
+		&model.ViewEvent{CommonFields: common(1000, model.EventTypeView, "view")},
+		&model.ActionEvent{CommonFields: common(1000, model.EventTypeAction, "action"), Action: model.Action{LoadingTime: &zero}},
+		&model.ResourceEvent{CommonFields: common(1000, model.EventTypeResource, "resource"), Resource: model.Resource{Duration: &negative}},
+		&model.LongTaskEvent{CommonFields: common(1000, model.EventTypeLongTask, "long-task")},
+		&model.VitalEvent{CommonFields: common(1000, model.EventTypeVital, "vital")},
+	}
+
+	for _, event := range cases {
+		span := Convert(&model.Batch{Events: []model.Event{event}}, "").
+			ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+		assert.Equal(t, pcommonTimestamp(int64(time.Millisecond)), span.EndTimestamp()-span.StartTimestamp())
+	}
+}
+func TestConvertErrorMapping(t *testing.T) {
+	line, column := int64(42), int64(7)
+	crossOrigin := true
+	cases := []struct {
+		name        string
+		err         model.Error
+		wantSource  string
+		wantType    string // "" 表示该字段不应输出
+		wantHandled bool
+	}{
+		{
+			name:        "js error from window.onerror",
+			err:         model.Error{Message: "boom", Source: "source", Type: "TypeError", Handling: "unhandled"},
+			wantSource:  "window.error",
+			wantType:    "JavaScriptError",
+			wantHandled: false,
+		},
+		{
+			name:        "unhandled promise rejection",
+			err:         model.Error{Message: "rejected", Source: "source", Type: "Unhandledrejection", Handling: "unhandled"},
+			wantSource:  "unhandledrejection",
+			wantType:    "PromiseRejection",
+			wantHandled: false,
+		},
+		{
+			name:        "handled error",
+			err:         model.Error{Message: "caught", Source: "source", Type: "RangeError", Handling: "handled"},
+			wantSource:  "window.error",
+			wantType:    "JavaScriptError",
+			wantHandled: true,
+		},
+		{
+			name:        "network resource error",
+			err:         model.Error{Message: "not found", Source: "network", Handling: "unhandled"},
+			wantSource:  "resource",
+			wantType:    "ResourceError",
+			wantHandled: false,
+		},
+		{
+			name:        "cross-origin maps to window.error",
+			err:         model.Error{Message: "Script error.", Source: "cross-origin", Handling: "unhandled"},
+			wantSource:  "window.error",
+			wantType:    "JavaScriptError",
+			wantHandled: false,
+		},
+		{
+			name:        "console passthrough no type",
+			err:         model.Error{Message: "logged", Source: "console", Handling: "handled"},
+			wantSource:  "console",
+			wantType:    "",
+			wantHandled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			traces := Convert(&model.Batch{Events: []model.Event{&model.ErrorEvent{
+				CommonFields: common(1000, model.EventTypeError, "error"),
+				Error:        tc.err,
+			}}}, "")
+			span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+			raw := span.Attributes().AsRaw()
+			assert.Equal(t, tc.wantSource, raw["error.source"], "error.source")
+			if tc.wantType == "" {
+				assert.NotContains(t, raw, "error.type", "error.type should be absent")
+			} else {
+				assert.Equal(t, tc.wantType, raw["error.type"], "error.type")
+			}
+			assert.Equal(t, tc.wantHandled, raw["error.handled"], "error.handled")
+			assert.Equal(t, tc.err.Message, raw["error.message"], "error.message")
+			for _, key := range []string{
+				"exception.type", "exception.message", "exception.stacktrace", "exception.source",
+				"exception.handling", "exception.component_stack", "exception.fingerprint",
+				"exception.causes", "exception.csp", "exception.debug_ids", "exception.resource.url",
+			} {
+				assert.NotContains(t, raw, key, "legacy %s should be dropped", key)
+			}
+			assert.Equal(t, ptrace.StatusCodeError, span.Status().Code())
+			assert.Equal(t, tc.err.Message, span.Status().Message())
+		})
+	}
+
+	t.Run("detail fields emitted", func(t *testing.T) {
+		traces := Convert(&model.Batch{Events: []model.Event{&model.ErrorEvent{
+			CommonFields: common(1000, model.EventTypeError, "error"),
+			Error: model.Error{
+				Message:      "boom",
+				Source:       "network",
+				Handling:     "unhandled",
+				Stack:        "Error: boom\n  at foo (app.js:42:7)",
+				File:         "app.js",
+				Line:         &line,
+				Column:       &column,
+				CrossOrigin:  &crossOrigin,
+				ResourceType: "SCRIPT",
+				Resource:     &model.ErrorResource{URL: "https://example.com/app.js"},
+			},
+		}}}, "")
+		raw := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().AsRaw()
+		assert.Equal(t, "resource", raw["error.source"])
+		assert.Equal(t, "ResourceError", raw["error.type"])
+		assert.Equal(t, "app.js", raw["code.filepath"])
+		assert.Equal(t, int64(42), raw["code.lineno"])
+		assert.Equal(t, int64(7), raw["code.column"])
+		assert.Equal(t, true, raw["error.cross_origin"])
+		assert.Equal(t, "https://example.com/app.js", raw["error.resource_url"])
+		assert.Equal(t, "SCRIPT", raw["error.resource_tag"])
+		assert.Equal(t, "Error: boom\n  at foo (app.js:42:7)", raw["error.stack"])
+	})
+
+	t.Run("resource fields only when source is resource", func(t *testing.T) {
+		traces := Convert(&model.Batch{Events: []model.Event{&model.ErrorEvent{
+			CommonFields: common(1000, model.EventTypeError, "error"),
+			Error: model.Error{
+				Message:      "boom",
+				Source:       "source",
+				Handling:     "unhandled",
+				ResourceType: "SCRIPT",
+				Resource:     &model.ErrorResource{URL: "https://example.com/app.js"},
+			},
+		}}}, "")
+		raw := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().AsRaw()
+		assert.NotContains(t, raw, "error.resource_url")
+		assert.NotContains(t, raw, "error.resource_tag")
+	})
+}
+
+func TestConvertResourceHTTPStatusClassification(t *testing.T) {
+	cases := []struct {
+		status      int
+		wantCode    ptrace.StatusCode
+		wantMessage string
+	}{
+		{100, ptrace.StatusCodeUnset, ""},                    // 1xx Informational
+		{200, ptrace.StatusCodeOk, ""},                       // 2xx Success
+		{302, ptrace.StatusCodeUnset, ""},                    // 3xx Redirection
+		{404, ptrace.StatusCodeError, "Not Found"},           // 4xx Client Error
+		{503, ptrace.StatusCodeError, "Service Unavailable"}, // 5xx Server Error
+		{419, ptrace.StatusCodeError, ""},                    // Non-standard 4xx status
+	}
+
+	for _, tc := range cases {
+		status := tc.status
+		resource := &model.ResourceEvent{
+			CommonFields: common(1000, model.EventTypeResource, "resource"),
+			Resource:     model.Resource{StatusCode: &status},
+		}
+		span := Convert(&model.Batch{Events: []model.Event{resource}}, "").
+			ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+		assert.Equal(t, tc.wantCode, span.Status().Code(), "status %d code", status)
+		assert.Equal(t, tc.wantMessage, span.Status().Message(), "status %d message", status)
+		assert.Equal(t, int64(status), span.Attributes().AsRaw()["http.response.status_code"], "status %d attr", status)
+		assert.NotContains(t, span.Attributes().AsRaw(), "http.status_text", "http.status_text dropped")
+	}
+
+	// 无状态码时不设置 HTTP 状态相关字段
+	noStatus := &model.ResourceEvent{CommonFields: common(1000, model.EventTypeResource, "resource")}
+	noStatusSpan := Convert(&model.Batch{Events: []model.Event{noStatus}}, "").
+		ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, ptrace.StatusCodeUnset, noStatusSpan.Status().Code())
+	assert.Equal(t, "", noStatusSpan.Status().Message())
+	assert.NotContains(t, noStatusSpan.Attributes().AsRaw(), "http.response.status_code")
+
+	// 状态码 <= 0 不输出 http.response.status_code
+	zeroStatus := 0
+	zeroSpan := Convert(&model.Batch{Events: []model.Event{&model.ResourceEvent{
+		CommonFields: common(1000, model.EventTypeResource, "resource"),
+		Resource:     model.Resource{StatusCode: &zeroStatus},
+	}}}, "").ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	assert.NotContains(t, zeroSpan.Attributes().AsRaw(), "http.response.status_code")
+}
+
+func TestConvertResourceProtocolFields(t *testing.T) {
+	decoded, encoded, transferZero := int64(2048), int64(512), int64(0)
+	status := 200
+	resource := &model.ResourceEvent{
+		CommonFields: common(1000, model.EventTypeResource, "resource"),
+		Resource: model.Resource{
+			Type:                 "xhr",
+			Method:               "post",
+			URL:                  "https://api.example.com:8443/orders/12345/items/550e8400-e29b-41d4-a716-446655440000?token=secret",
+			StatusCode:           &status,
+			Protocol:             "h2",
+			DeliveryType:         "",
+			DecodedBodySize:      &decoded,
+			EncodedBodySize:      &encoded,
+			TransferSize:         &transferZero,
+			RenderBlockingStatus: "non-blocking",
+		},
+	}
+	raw := Convert(&model.Batch{Events: []model.Event{resource}}, "").
+		ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().AsRaw()
+
+	// url.full: query 被脱敏
+	assert.Equal(t, "https://api.example.com:8443/orders/12345/items/550e8400-e29b-41d4-a716-446655440000", raw["url.full"])
+	// url.template: 数字 ID 与 UUID 折叠为 :id，只保留 path
+	assert.Equal(t, "/orders/:id/items/:id", raw["url.template"])
+	// server.address: hostname 不含端口
+	assert.Equal(t, "api.example.com", raw["server.address"])
+	// server.port: 仅显式端口
+	assert.Equal(t, int64(8443), raw["server.port"])
+	// http.request.method: 归一大写，仅 Fetch/XHR
+	assert.Equal(t, "POST", raw["http.request.method"])
+	assert.Equal(t, int64(200), raw["http.response.status_code"])
+	assert.Equal(t, "h2", raw["resource.protocol"])
+	// delivery_type 空 -> other
+	assert.Equal(t, "other", raw["resource.delivery_type"])
+	assert.Equal(t, "non-blocking", raw["resource.render_blocking_status"])
+	// resource.size 协议定义为 decodedBodySize
+	assert.Equal(t, int64(2048), raw["resource.size"])
+	assert.Equal(t, int64(2048), raw["resource.decoded_body_size"])
+	assert.Equal(t, int64(512), raw["resource.encoded_body_size"])
+	assert.Equal(t, int64(0), raw["resource.transfer_size"])
+	// cache.hit: transferSize=0 且 decodedBodySize>0
+	assert.Equal(t, true, raw["resource.cache.hit"])
+	// 已删除的旧字段不再输出
+	for _, key := range []string{
+		"resource.id", "http.method", "http.url", "http.host", "http.target",
+		"http.query", "http.scheme", "http.status_code", "http.protocol",
+		"http.status_text", "resource.duration", "resource.provider.type",
+		"resource.provider.name", "resource.provider.domain", "resource.request",
+		"resource.response", "dd.trace_id", "dd.span_id",
+	} {
+		assert.NotContains(t, raw, key, "legacy %s should be dropped", key)
+	}
+
+	// 静态资源：无 http.request.method / url.template；默认端口无 server.port
+	staticTransfer, staticDecoded := int64(600), int64(100)
+	static := &model.ResourceEvent{
+		CommonFields: common(1000, model.EventTypeResource, "resource"),
+		Resource: model.Resource{
+			Type:            "img",
+			URL:             "https://cdn.example.com/logo.png",
+			TransferSize:    &staticTransfer,
+			DecodedBodySize: &staticDecoded,
+		},
+	}
+	staticRaw := Convert(&model.Batch{Events: []model.Event{static}}, "").
+		ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().AsRaw()
+	assert.Equal(t, "img", staticRaw["resource.type"])
+	assert.NotContains(t, staticRaw, "http.request.method")
+	assert.NotContains(t, staticRaw, "url.template")
+	assert.Equal(t, "cdn.example.com", staticRaw["server.address"])
+	assert.NotContains(t, staticRaw, "server.port")        // 默认端口
+	assert.NotContains(t, staticRaw, "resource.cache.hit") // transferSize>0 且 deliveryType!=cache
+
+	// deliveryType=cache -> cache.hit=true
+	cache := &model.ResourceEvent{
+		CommonFields: common(1000, model.EventTypeResource, "resource"),
+		Resource:     model.Resource{Type: "script", URL: "https://cdn.example.com/a.js", DeliveryType: "cache"},
+	}
+	cacheRaw := Convert(&model.Batch{Events: []model.Event{cache}}, "").
+		ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().AsRaw()
+	assert.Equal(t, true, cacheRaw["resource.cache.hit"])
+}
+
+func common(date int64, eventType model.EventType, id string) model.CommonFields {
+	return model.CommonFields{
+		Date:        date,
+		Type:        eventType,
+		Application: model.Application{ID: "app-1"},
+		Session:     &model.Session{ID: "session-1", Type: "user"},
+		ViewContext: &model.ViewContext{ID: "view-1"},
+		Raw:         json.RawMessage(`{"type":"` + eventType.S() + `","id":"` + id + `"}`),
+	}
+}
+
+func float64Ptr(value float64) *float64 { return &value }
+
+func pcommonTimestamp(value int64) pcommon.Timestamp { return pcommon.Timestamp(value) }

--- a/pkg/collector/receiver/datadogrum/internal/decoder/compression.go
+++ b/pkg/collector/receiver/datadogrum/internal/decoder/compression.go
@@ -1,0 +1,61 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package decoder
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+const encodingGzip = "gzip"
+
+// ReadBody reads the request body, transparently decompressing gzip.
+// maxBytes applies to the decompressed body.
+func ReadBody(req *http.Request, maxBytes int64) (*bytes.Buffer, error) {
+	if maxBytes <= 0 {
+		return nil, ErrInvalidLimit
+	}
+	if req.Body == nil {
+		return nil, model.ErrEmptyBody
+	}
+
+	var bodyReader io.Reader = req.Body
+	if strings.EqualFold(strings.TrimSpace(req.Header.Get("Content-Encoding")), encodingGzip) {
+		gzipReader, err := gzip.NewReader(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		defer gzipReader.Close()
+		bodyReader = gzipReader
+	}
+
+	bodyBuffer := &bytes.Buffer{}
+	// Read one extra byte so we can detect whether the body exceeds maxBytes.
+	copyLimit := maxBytes + 1
+	if copyLimit <= maxBytes {
+		copyLimit = maxBytes
+	}
+	if _, err := io.Copy(bodyBuffer, io.LimitReader(bodyReader, copyLimit)); err != nil {
+		return nil, err
+	}
+	if bodyBuffer.Len() == 0 {
+		return nil, model.ErrEmptyBody
+	}
+	if int64(bodyBuffer.Len()) > maxBytes {
+		return nil, fmt.Errorf("%w: exceeds %d bytes", ErrBodyTooLarge, maxBytes)
+	}
+	return bodyBuffer, nil
+}

--- a/pkg/collector/receiver/datadogrum/internal/decoder/compression_test.go
+++ b/pkg/collector/receiver/datadogrum/internal/decoder/compression_test.go
@@ -1,0 +1,81 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package decoder
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+func TestReadBodyAtLimit(t *testing.T) {
+	req := httptestRequest(bytes.NewBufferString("12345"), "")
+	body, err := ReadBody(req, 5)
+	assert.NoError(t, err)
+	assert.Equal(t, "12345", body.String())
+}
+
+func TestReadBodyLimit(t *testing.T) {
+	req := httptestRequest(bytes.NewBufferString("12345"), "")
+	_, err := ReadBody(req, 4)
+	assert.ErrorIs(t, err, ErrBodyTooLarge)
+}
+
+func TestReadBodyGzipLimit(t *testing.T) {
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	_, _ = zw.Write([]byte("12345"))
+	assert.NoError(t, zw.Close())
+
+	req := httptestRequest(bytes.NewReader(compressed.Bytes()), encodingGzip)
+	_, err := ReadBody(req, 4)
+	assert.ErrorIs(t, err, ErrBodyTooLarge)
+}
+
+func TestReadBodyGzipEncodingIsCaseAndWhitespaceInsensitive(t *testing.T) {
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	_, _ = zw.Write([]byte("12345"))
+	assert.NoError(t, zw.Close())
+
+	for _, encoding := range []string{"GZIP", " gzip ", " GzIp "} {
+		req := httptestRequest(bytes.NewReader(compressed.Bytes()), encoding)
+		body, err := ReadBody(req, 5)
+		assert.NoError(t, err, encoding)
+		assert.Equal(t, "12345", body.String(), encoding)
+	}
+}
+
+func TestReadBodyInvalidLimit(t *testing.T) {
+	req := httptestRequest(bytes.NewBufferString("1"), "")
+	for _, limit := range []int64{0, -1} {
+		_, err := ReadBody(req, limit)
+		assert.ErrorIs(t, err, ErrInvalidLimit)
+	}
+}
+
+func TestReadBodyNilBody(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "/v1/rum", nil)
+	_, err := ReadBody(req, 1024)
+	assert.ErrorIs(t, err, model.ErrEmptyBody)
+}
+
+func httptestRequest(body io.Reader, encoding string) *http.Request {
+	req, _ := http.NewRequest(http.MethodPost, "/v1/rum", body)
+	if encoding != "" {
+		req.Header.Set("Content-Encoding", encoding)
+	}
+	return req
+}

--- a/pkg/collector/receiver/datadogrum/internal/decoder/request_decoder.go
+++ b/pkg/collector/receiver/datadogrum/internal/decoder/request_decoder.go
@@ -1,0 +1,308 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package decoder
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+var (
+	// ErrInvalidLimit indicates a non-positive decoder limit.
+	ErrInvalidLimit = errors.New("invalid decoder limit")
+	// ErrBodyTooLarge indicates that the decompressed request body exceeds its limit.
+	ErrBodyTooLarge = errors.New("request body too large")
+	// ErrDecodedEventsTooLarge indicates that retained event JSON exceeds its limit.
+	ErrDecodedEventsTooLarge = errors.New("decoded events too large")
+)
+
+// decodedSizeLimiter tracks the total size of events retained by the decoder.
+// It is not safe for concurrent use; each DecodeEvents call must use its own instance.
+type decodedSizeLimiter struct {
+	maxBytes  int64
+	usedBytes int64
+}
+
+// newDecodedSizeLimiter creates a limiter for retained event JSON.
+func newDecodedSizeLimiter(maxBytes int64) decodedSizeLimiter {
+	return decodedSizeLimiter{maxBytes: maxBytes}
+}
+
+func (l *decodedSizeLimiter) add(eventSize int) error {
+	if eventSize < 0 || int64(eventSize) > l.maxBytes-l.usedBytes {
+		return fmt.Errorf("%w: exceeds %d bytes", ErrDecodedEventsTooLarge, l.maxBytes)
+	}
+	l.usedBytes += int64(eventSize)
+	return nil
+}
+
+// DecodeEvents splits a request body into raw RUM event objects.
+// It accepts JSON arrays, wrapped events, single objects, NDJSON, and JSON streams.
+func DecodeEvents(data []byte, maxDecodedBytes int64) ([][]byte, error) {
+	if maxDecodedBytes <= 0 {
+		return nil, ErrInvalidLimit
+	}
+
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, model.ErrEmptyBody
+	}
+
+	if trimmed[0] == '[' {
+		return decodeArray(trimmed, maxDecodedBytes)
+	}
+	if events, ok, err := decodeNDJSON(trimmed, maxDecodedBytes); err != nil || ok {
+		return events, err
+	}
+	events, ok, err := decodeObject(trimmed, maxDecodedBytes)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return events, nil
+	}
+	return decodeStream(trimmed, maxDecodedBytes)
+}
+
+func decodeNDJSON(data []byte, maxDecodedBytes int64) ([][]byte, bool, error) {
+	if !bytes.ContainsAny(data, "\r\n") {
+		return nil, false, nil
+	}
+
+	events := make([][]byte, 0, bytes.Count(data, []byte{'\n'})+1)
+	limiter := newDecodedSizeLimiter(maxDecodedBytes)
+	for start := 0; start <= len(data); {
+		end := start
+		if idx := bytes.IndexByte(data[start:], '\n'); idx >= 0 {
+			end = start + idx
+		} else {
+			end = len(data)
+		}
+
+		line := bytes.TrimSpace(data[start:end])
+		if len(line) > 0 {
+			if line[0] != '{' || line[len(line)-1] != '}' {
+				return nil, false, nil
+			}
+			if !json.Valid(line) {
+				return nil, true, model.ErrInvalidPayload
+			}
+			if err := limiter.add(len(line)); err != nil {
+				return nil, true, err
+			}
+			events = append(events, line)
+		}
+
+		if end == len(data) {
+			break
+		}
+		start = end + 1
+	}
+
+	if len(events) <= 1 {
+		return nil, false, nil
+	}
+	return events, true, nil
+}
+
+func decodeArray(data []byte, maxDecodedBytes int64) ([][]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	events, err := decodeJSONArray(dec, maxDecodedBytes)
+	if err != nil {
+		return nil, err
+	}
+	if err := expectEOF(dec); err != nil {
+		return nil, model.ErrInvalidPayload
+	}
+	return events, nil
+}
+
+func decodeObject(data []byte, maxDecodedBytes int64) ([][]byte, bool, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if err := expectToken(dec, '{'); err != nil {
+		return nil, false, nil
+	}
+
+	var (
+		events    [][]byte
+		hasEvents bool
+		hasType   bool
+		typeRaw   json.RawMessage
+	)
+	for dec.More() {
+		key, err := decodeObjectKey(dec)
+		if err != nil {
+			return nil, true, model.ErrInvalidPayload
+		}
+
+		switch key {
+		case "events":
+			if hasEvents {
+				return nil, true, model.ErrInvalidPayload
+			}
+			hasEvents = true
+			events, err = decodeJSONArray(dec, maxDecodedBytes)
+			if err != nil {
+				return nil, true, err
+			}
+		case "type":
+			if hasType {
+				return nil, true, model.ErrInvalidPayload
+			}
+			hasType = true
+			if err := dec.Decode(&typeRaw); err != nil {
+				return nil, true, model.ErrInvalidPayload
+			}
+		default:
+			var ignored json.RawMessage
+			if err := dec.Decode(&ignored); err != nil {
+				return nil, true, model.ErrInvalidPayload
+			}
+		}
+	}
+	if err := expectToken(dec, '}'); err != nil {
+		return nil, true, model.ErrInvalidPayload
+	}
+	if err := expectEOF(dec); err != nil {
+		return nil, false, nil
+	}
+
+	if hasEvents {
+		return events, true, nil
+	}
+	if !hasType {
+		return nil, true, model.ErrInvalidPayload
+	}
+	if err := validateEventType(typeRaw); err != nil {
+		return nil, true, err
+	}
+	if err := ensureDecodedEventSize(len(data), maxDecodedBytes); err != nil {
+		return nil, true, err
+	}
+	return [][]byte{append([]byte(nil), data...)}, true, nil
+}
+
+func decodeStream(data []byte, maxDecodedBytes int64) ([][]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	events := make([][]byte, 0)
+	limiter := newDecodedSizeLimiter(maxDecodedBytes)
+	for {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, model.ErrInvalidPayload
+		}
+		if !isJSONObject(raw) {
+			return nil, model.ErrInvalidPayload
+		}
+		if err := limiter.add(len(raw)); err != nil {
+			return nil, err
+		}
+		events = append(events, append([]byte(nil), raw...))
+	}
+	if len(events) == 0 {
+		return nil, model.ErrEmptyBody
+	}
+	return events, nil
+}
+
+func decodeJSONArray(dec *json.Decoder, maxDecodedBytes int64) ([][]byte, error) {
+	if err := expectToken(dec, '['); err != nil {
+		return nil, model.ErrInvalidPayload
+	}
+
+	limiter := newDecodedSizeLimiter(maxDecodedBytes)
+	events := make([][]byte, 0)
+	for dec.More() {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return nil, model.ErrInvalidPayload
+		}
+		if !isJSONObject(raw) {
+			return nil, model.ErrInvalidPayload
+		}
+		if err := limiter.add(len(raw)); err != nil {
+			return nil, err
+		}
+		events = append(events, append([]byte(nil), raw...))
+	}
+	if err := expectToken(dec, ']'); err != nil {
+		return nil, model.ErrInvalidPayload
+	}
+	if len(events) == 0 {
+		return nil, model.ErrEmptyBody
+	}
+	return events, nil
+}
+
+func decodeObjectKey(dec *json.Decoder) (string, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return "", err
+	}
+	key, ok := tok.(string)
+	if !ok {
+		return "", errors.New("object key is not a string")
+	}
+	return key, nil
+}
+
+func expectToken(dec *json.Decoder, want json.Delim) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != want {
+		return fmt.Errorf("expected JSON delimiter %q", want)
+	}
+	return nil
+}
+
+func expectEOF(dec *json.Decoder) error {
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func isJSONObject(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}'
+}
+
+// validateEventType verifies that a single-event object has a string type field.
+func validateEventType(rawType json.RawMessage) error {
+	var eventType string
+	if err := json.Unmarshal(rawType, &eventType); err != nil {
+		return model.ErrInvalidPayload
+	}
+	return nil
+}
+
+func ensureDecodedEventSize(size int, max int64) error {
+	if max <= 0 {
+		return ErrInvalidLimit
+	}
+	if int64(size) > max {
+		return fmt.Errorf("%w: exceeds %d bytes", ErrDecodedEventsTooLarge, max)
+	}
+	return nil
+}

--- a/pkg/collector/receiver/datadogrum/internal/decoder/request_decoder_test.go
+++ b/pkg/collector/receiver/datadogrum/internal/decoder/request_decoder_test.go
@@ -1,0 +1,106 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package decoder
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const defaultMaxDecodedBytes = 10 << 20
+
+func TestDecodeEvents_Array(t *testing.T) {
+	events, err := DecodeEvents([]byte(`[{"type":"view"},{"type":"action"}]`), defaultMaxDecodedBytes)
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+}
+
+func TestDecodeEvents_Wrapped(t *testing.T) {
+	events, err := DecodeEvents([]byte(`{"events":[{"type":"view"},{"type":"action"}]}`), defaultMaxDecodedBytes)
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+}
+
+func TestDecodeEvents_NDJSON(t *testing.T) {
+	events, err := DecodeEvents([]byte("{\"type\":\"view\"}\n{\"type\":\"action\"}"), defaultMaxDecodedBytes)
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+}
+
+func TestDecodeEvents_NDJSON_CRLFAndBlankLines(t *testing.T) {
+	events, err := DecodeEvents([]byte("{\"type\":\"view\"}\r\n\r\n{\"type\":\"action\"}\r\n"), defaultMaxDecodedBytes)
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+}
+
+func TestDecodeEvents_Single(t *testing.T) {
+	events, err := DecodeEvents([]byte(`{"type":"view"}`), defaultMaxDecodedBytes)
+	assert.NoError(t, err)
+	assert.Len(t, events, 1)
+}
+
+func TestDecodeEvents_PrettySingle(t *testing.T) {
+	events, err := DecodeEvents([]byte(`{
+  "type": "view",
+  "application": {
+    "id": "app"
+  }
+}`), defaultMaxDecodedBytes)
+	assert.NoError(t, err)
+	assert.Len(t, events, 1)
+}
+
+func TestDecodeEvents_ExceedsMaxDecodedBytes(t *testing.T) {
+	payload := []byte(`{"type":"view"}`)
+	_, err := DecodeEvents(payload, 1)
+	assert.Error(t, err)
+}
+
+func TestDecodeEvents_InvalidEntries(t *testing.T) {
+	for _, payload := range [][]byte{
+		[]byte(`[null]`),
+		[]byte(`[1]`),
+		[]byte(`{"events":null}`),
+		[]byte(`{"events":[null]}`),
+	} {
+		_, err := DecodeEvents(payload, defaultMaxDecodedBytes)
+		assert.Error(t, err, string(payload))
+	}
+}
+
+func TestDecodeEvents_InvalidLimit(t *testing.T) {
+	for _, limit := range []int64{0, -1} {
+		_, err := DecodeEvents([]byte(`{"type":"view"}`), limit)
+		assert.ErrorIs(t, err, ErrInvalidLimit)
+	}
+}
+
+func BenchmarkDecodeEvents_NDJSON(b *testing.B) {
+	var builder strings.Builder
+	for i := 0; i < 1000; i++ {
+		_, _ = fmt.Fprintf(&builder, `{"type":"view","date":%d,"application":{"id":"app"},"view":{"id":"view-%d"}}`+"\n", i+1, i)
+	}
+	payload := []byte(builder.String())
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	for i := 0; i < b.N; i++ {
+		events, err := DecodeEvents(payload, defaultMaxDecodedBytes)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(events) != 1000 {
+			b.Fatalf("expected 1000 events, got %d", len(events))
+		}
+	}
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/action.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/action.go
@@ -1,0 +1,76 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+type ActionEvent struct {
+	CommonFields
+	Action Action `json:"action"`
+}
+
+func (e *ActionEvent) GetType() EventType { return EventTypeAction }
+func (e *ActionEvent) GetCommon() *CommonFields {
+	return &e.CommonFields
+}
+
+type Action struct {
+	Present       bool               `json:"-"`
+	ID            string             `json:"id,omitempty"`
+	Type          string             `json:"type,omitempty"`
+	Name          string             `json:"name,omitempty"`
+	Target        *ActionTarget      `json:"target,omitempty"`
+	Frustration   *ActionFrustration `json:"frustration,omitempty"`
+	EventCount    *ActionEventCount  `json:"event,omitempty"`
+	CrashCount    *ActionCount       `json:"crash,omitempty"`
+	Internal      *ActionInternal    `json:"_dd,omitempty"`
+	Position      *ActionPosition    `json:"position,omitempty"`
+	LoadingTime   *int64             `json:"loading_time,omitempty"`
+	LongTaskCount *int64             `json:"long_task_count,omitempty"`
+	ResourceCount *int64             `json:"resource_count,omitempty"`
+	ErrorCount    *int64             `json:"error_count,omitempty"`
+	ViewActive    *bool              `json:"in_foreground,omitempty"`
+}
+
+type ActionTarget struct {
+	Name     string   `json:"name,omitempty"`
+	Selector string   `json:"selector,omitempty"`
+	Width    *float64 `json:"width,omitempty"`
+	Height   *float64 `json:"height,omitempty"`
+}
+
+type ActionFrustration struct {
+	Type []string `json:"type,omitempty"`
+}
+
+type ActionEventCount struct {
+	Error    *int64 `json:"error_count,omitempty"`
+	Resource *int64 `json:"resource_count,omitempty"`
+	LongTask *int64 `json:"long_task_count,omitempty"`
+}
+
+type ActionCount struct {
+	Count *int64 `json:"count,omitempty"`
+}
+
+type ActionInternal struct {
+	TargetSelectorPath   string   `json:"target_selector_path,omitempty"`
+	Selector             string   `json:"selector,omitempty"`
+	ComposedPathSelector string   `json:"composed_path_selector,omitempty"`
+	Width                *float64 `json:"width,omitempty"`
+	Height               *float64 `json:"height,omitempty"`
+	PermanentID          string   `json:"permanent_id,omitempty"`
+	NameSource           string   `json:"name_source,omitempty"`
+	PositionX            *float64 `json:"position_x,omitempty"`
+	PositionY            *float64 `json:"position_y,omitempty"`
+}
+
+type ActionPosition struct {
+	X *float64 `json:"x,omitempty"`
+	Y *float64 `json:"y,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/application.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/application.go
@@ -1,0 +1,17 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+// Application 是 RUM 应用关联实体。
+type Application struct {
+	ID            string `json:"id,omitempty"`
+	Name          string `json:"name,omitempty"`
+	CurrentLocale string `json:"current_locale,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/batch.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/batch.go
@@ -1,0 +1,28 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+// Batch contains the parsed RUM events from one request.
+type Batch struct {
+	Events []Event
+}
+
+// Empty reports whether the batch has no events.
+func (b *Batch) Empty() bool {
+	return b == nil || len(b.Events) == 0
+}
+
+// Size returns the number of events in the batch.
+func (b *Batch) Size() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.Events)
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/common.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/common.go
@@ -1,0 +1,48 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+import "encoding/json"
+
+// CommonFields 是所有 RUM 事件共享的关联上下文。
+type CommonFields struct {
+	Date         int64           `json:"date"`
+	Timestamp    int64           `json:"-"`
+	Type         EventType       `json:"type"`
+	Source       string          `json:"source,omitempty"`
+	Service      string          `json:"service,omitempty"`
+	Version      string          `json:"version,omitempty"`
+	BuildVersion string          `json:"build_version,omitempty"`
+	BuildID      string          `json:"build_id,omitempty"`
+	Tags         string          `json:"ddtags,omitempty"`
+	Application  Application     `json:"application"`
+	Session      *Session        `json:"session,omitempty"`
+	ViewContext  *ViewContext    `json:"-"`
+	User         *User           `json:"usr,omitempty"`
+	Account      *Account        `json:"account,omitempty"`
+	Tab          *Tab            `json:"tab,omitempty"`
+	Connectivity *Connectivity   `json:"connectivity,omitempty"`
+	Display      *Display        `json:"display,omitempty"`
+	Device       *Device         `json:"device,omitempty"`
+	OS           *OS             `json:"os,omitempty"`
+	Context      map[string]any  `json:"context,omitempty"`
+	FeatureFlags map[string]any  `json:"feature_flags,omitempty"`
+	Privacy      map[string]any  `json:"privacy,omitempty"`
+	Container    map[string]any  `json:"container,omitempty"`
+	Stream       map[string]any  `json:"stream,omitempty"`
+	Internal     *InternalFields `json:"_dd,omitempty"`
+	Raw          json.RawMessage `json:"-"`
+}
+
+func (c *CommonFields) Normalize() {
+	if c.Date <= 0 && c.Timestamp > 0 {
+		c.Date = c.Timestamp
+	}
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/context.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/context.go
@@ -1,0 +1,79 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+type User struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Email       string `json:"email,omitempty"`
+	AnonymousID string `json:"anonymous_id,omitempty"`
+}
+
+type Account struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type Tab struct {
+	ID string `json:"id,omitempty"`
+}
+
+type Connectivity struct {
+	Status        string           `json:"status,omitempty"`
+	EffectiveType string           `json:"effective_type,omitempty"`
+	Interfaces    []string         `json:"interfaces,omitempty"`
+	Cellular      *CellularNetwork `json:"cellular,omitempty"`
+}
+
+type CellularNetwork struct {
+	Technology  string `json:"technology,omitempty"`
+	CarrierName string `json:"carrier_name,omitempty"`
+}
+
+type Display struct {
+	Viewport *Viewport      `json:"viewport,omitempty"`
+	Scroll   *DisplayScroll `json:"scroll,omitempty"`
+}
+
+type Viewport struct {
+	Width  *int64 `json:"width,omitempty"`
+	Height *int64 `json:"height,omitempty"`
+}
+
+type DisplayScroll struct {
+	MaxDepth            *int64 `json:"max_depth,omitempty"`
+	MaxDepthScrollTop   *int64 `json:"max_depth_scroll_top,omitempty"`
+	MaxScrollHeight     *int64 `json:"max_scroll_height,omitempty"`
+	MaxScrollHeightTime *int64 `json:"max_scroll_height_time,omitempty"`
+}
+
+type Device struct {
+	Type            string   `json:"type,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Brand           string   `json:"brand,omitempty"`
+	Model           string   `json:"model,omitempty"`
+	Architecture    string   `json:"architecture,omitempty"`
+	Locale          string   `json:"locale,omitempty"`
+	Locales         []string `json:"locales,omitempty"`
+	TimeZone        string   `json:"time_zone,omitempty"`
+	BatteryLevel    *float64 `json:"battery_level,omitempty"`
+	PowerSavingMode *bool    `json:"power_saving_mode,omitempty"`
+	BrightnessLevel *float64 `json:"brightness_level,omitempty"`
+	LogicalCPUCount *int64   `json:"logical_cpu_count,omitempty"`
+	TotalRAM        *int64   `json:"total_ram,omitempty"`
+	IsLowRAM        *bool    `json:"is_low_ram,omitempty"`
+}
+
+type OS struct {
+	Name         string `json:"name,omitempty"`
+	Version      string `json:"version,omitempty"`
+	VersionMajor string `json:"version_major,omitempty"`
+	Build        string `json:"build,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/error.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/error.go
@@ -1,0 +1,74 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+type ErrorEvent struct {
+	CommonFields
+	Error Error `json:"error"`
+}
+
+func (e *ErrorEvent) GetType() EventType { return EventTypeError }
+func (e *ErrorEvent) GetCommon() *CommonFields {
+	return &e.CommonFields
+}
+
+type Error struct {
+	Present        bool   `json:"-"`
+	ID             string `json:"id,omitempty"`
+	Type           string `json:"type,omitempty"`
+	Message        string `json:"message,omitempty"`
+	Stack          string `json:"stack,omitempty"`
+	ComponentStack string `json:"component_stack,omitempty"`
+	Fingerprint    string `json:"fingerprint,omitempty"`
+	Source         string `json:"source,omitempty"`
+	Handling       string `json:"handling,omitempty"`
+	// File/Line/Column 为错误源码定位信息，按 1-based 归一化后由 SDK 上报。
+	File   string `json:"file,omitempty"`
+	Line   *int64 `json:"line,omitempty"`
+	Column *int64 `json:"column,omitempty"`
+	// CrossOrigin 标识跨域脚本错误（Script error.）。
+	CrossOrigin *bool `json:"cross_origin,omitempty"`
+	// ResourceType 为加载失败的资源元素标签名（如 SCRIPT/IMG/LINK），仅 source=resource 时出现。
+	ResourceType string         `json:"resource_type,omitempty"`
+	Causes       []ErrorCause   `json:"causes,omitempty"`
+	CSP          *CSPReport     `json:"csp,omitempty"`
+	Resource     *ErrorResource `json:"resource,omitempty"`
+	DebugIDs     DebugIDs       `json:"debug_ids,omitempty"`
+}
+
+type ErrorCause struct {
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message,omitempty"`
+	Stack   string `json:"stack,omitempty"`
+	Source  string `json:"source,omitempty"`
+}
+
+type CSPReport struct {
+	BlockedURI         string `json:"blocked_uri,omitempty"`
+	ColumnNumber       *int64 `json:"column_number,omitempty"`
+	Disposition        string `json:"disposition,omitempty"`
+	DocumentURI        string `json:"document_uri,omitempty"`
+	EffectiveDirective string `json:"effective_directive,omitempty"`
+	LineNumber         *int64 `json:"line_number,omitempty"`
+	OriginalPolicy     string `json:"original_policy,omitempty"`
+	Referrer           string `json:"referrer,omitempty"`
+	SourceFile         string `json:"source_file,omitempty"`
+	StatusCode         *int   `json:"status_code,omitempty"`
+	ViolatedDirective  string `json:"violated_directive,omitempty"`
+}
+
+type ErrorResource struct {
+	Method     string            `json:"method,omitempty"`
+	StatusCode *int              `json:"status_code,omitempty"`
+	URL        string            `json:"url,omitempty"`
+	Provider   *ResourceProvider `json:"provider,omitempty"`
+}
+
+type DebugIDs map[string]string

--- a/pkg/collector/receiver/datadogrum/internal/model/errors.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/errors.go
@@ -1,0 +1,26 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+import "errors"
+
+var (
+	// ErrInvalidPayload 表示请求体无法解析为有效的 Datadog RUM 事件
+	ErrInvalidPayload = errors.New("invalid datadog rum payload")
+
+	// ErrEmptyBody 表示请求体为空
+	ErrEmptyBody = errors.New("empty request body")
+
+	// ErrUnsupportedEventType 表示遇到不支持的事件类型
+	ErrUnsupportedEventType = errors.New("unsupported event type")
+
+	// ErrMissingRequiredField 表示协议必要字段缺失
+	ErrMissingRequiredField = errors.New("missing required field")
+)

--- a/pkg/collector/receiver/datadogrum/internal/model/event.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/event.go
@@ -1,0 +1,101 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+)
+
+// Event is the common interface implemented by supported RUM event types.
+type Event interface {
+	GetType() EventType
+	GetCommon() *CommonFields
+}
+
+func (*ViewEvent) DatadogRumEvent()     {}
+func (*ActionEvent) DatadogRumEvent()   {}
+func (*ResourceEvent) DatadogRumEvent() {}
+func (*ErrorEvent) DatadogRumEvent()    {}
+func (*LongTaskEvent) DatadogRumEvent() {}
+func (*VitalEvent) DatadogRumEvent()    {}
+
+func (e *ViewEvent) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
+	type viewEvent ViewEvent
+	return marshalEvent((*viewEvent)(e), &e.CommonFields)
+}
+
+func (e *ActionEvent) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
+	type actionEvent ActionEvent
+	return marshalEvent((*actionEvent)(e), &e.CommonFields)
+}
+
+func (e *ResourceEvent) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
+	type resourceEvent ResourceEvent
+	return marshalEvent((*resourceEvent)(e), &e.CommonFields)
+}
+
+func (e *ErrorEvent) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
+	type errorEvent ErrorEvent
+	return marshalEvent((*errorEvent)(e), &e.CommonFields)
+}
+
+func (e *LongTaskEvent) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
+	type longTaskEvent LongTaskEvent
+	return marshalEvent((*longTaskEvent)(e), &e.CommonFields)
+}
+
+func (e *VitalEvent) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
+	type vitalEvent VitalEvent
+	return marshalEvent((*vitalEvent)(e), &e.CommonFields)
+}
+
+// marshalEvent preserves a parsed event's original JSON; manually built events
+// are marshaled from typed fields and receive the shared view context.
+func marshalEvent(event any, common *CommonFields) ([]byte, error) {
+	if len(common.Raw) > 0 {
+		return append([]byte(nil), common.Raw...), nil
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	if common.ViewContext == nil {
+		return data, nil
+	}
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+	view, err := json.Marshal(common.ViewContext)
+	if err != nil {
+		return nil, err
+	}
+	fields["view"] = view
+	return json.Marshal(fields)
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/event_type.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/event_type.go
@@ -1,0 +1,35 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+// EventType 表示稳定支持的 Datadog RUM 事件类型。
+type EventType string
+
+func (e EventType) S() string { return string(e) }
+
+const (
+	EventTypeView       EventType = "view"
+	EventTypeViewUpdate EventType = "view_update"
+	EventTypeAction     EventType = "action"
+	EventTypeResource   EventType = "resource"
+	EventTypeError      EventType = "error"
+	EventTypeLongTask   EventType = "long_task"
+	EventTypeVital      EventType = "vital"
+)
+
+// IsValid 判断事件类型是否在稳定事件范围内。
+func (e EventType) IsValid() bool {
+	switch e {
+	case EventTypeView, EventTypeViewUpdate, EventTypeAction, EventTypeResource, EventTypeError, EventTypeLongTask, EventTypeVital:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/internal.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/internal.go
@@ -1,0 +1,208 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+const (
+	internalFieldFormatVersion                    = "format_version"
+	internalFieldDocumentVersion                  = "document_version"
+	internalFieldTraceID                          = "trace_id"
+	internalFieldSpanID                           = "span_id"
+	internalFieldDrift                            = "drift"
+	internalFieldConfiguration                    = "configuration"
+	internalFieldPageStates                       = "page_states"
+	internalFieldReplayStats                      = "replay_stats"
+	internalFieldAction                           = "action"
+	internalFieldVital                            = "vital"
+	internalFieldDebugIDs                         = "debug_ids"
+	internalFieldBrowserSDKVersion                = "browser_sdk_version"
+	internalFieldSDKName                          = "sdk_name"
+	internalFieldProfilingSampleRate              = "profiling_sample_rate"
+	internalFieldTraceSampleRate                  = "trace_sample_rate"
+	internalFieldStartSessionReplayRecordManually = "start_session_replay_recording_manually"
+	internalFieldRemoteConfigurationID            = "remote_configuration_id"
+	internalFieldCLSDevicePixelRatio              = "cls_device_pixel_ratio"
+)
+
+var internalKnownFields = []string{
+	internalFieldFormatVersion,
+	internalFieldDocumentVersion,
+	internalFieldTraceID,
+	internalFieldSpanID,
+	internalFieldDrift,
+	internalFieldSDKName,
+	internalFieldBrowserSDKVersion,
+	internalFieldProfilingSampleRate,
+	internalFieldTraceSampleRate,
+	internalFieldStartSessionReplayRecordManually,
+	internalFieldRemoteConfigurationID,
+	internalFieldCLSDevicePixelRatio,
+	internalFieldConfiguration,
+	internalFieldPageStates,
+	internalFieldReplayStats,
+	internalFieldAction,
+	internalFieldVital,
+	internalFieldDebugIDs,
+}
+
+// InternalFields contains Datadog's internal _dd protocol fields.
+type InternalFields struct {
+	FormatVersion                       *int                       `json:"format_version,omitempty"`
+	DocumentVersion                     *int                       `json:"document_version,omitempty"`
+	TraceID                             string                     `json:"trace_id,omitempty"`
+	SpanID                              string                     `json:"span_id,omitempty"`
+	Drift                               *int64                     `json:"drift,omitempty"`
+	SDKName                             string                     `json:"sdk_name,omitempty"`
+	BrowserSDKVersion                   string                     `json:"browser_sdk_version,omitempty"`
+	ProfilingSampleRate                 *float64                   `json:"profiling_sample_rate,omitempty"`
+	TraceSampleRate                     *float64                   `json:"trace_sample_rate,omitempty"`
+	StartSessionReplayRecordingManually *bool                      `json:"start_session_replay_recording_manually,omitempty"`
+	RemoteConfigurationID               string                     `json:"remote_configuration_id,omitempty"`
+	CLSDevicePixelRatio                 *float64                   `json:"cls_device_pixel_ratio,omitempty"`
+	Configuration                       *Configuration             `json:"configuration,omitempty"`
+	PageStates                          []PageState                `json:"page_states,omitempty"`
+	ReplayStats                         *ReplayStats               `json:"replay_stats,omitempty"`
+	Action                              *ActionInternal            `json:"action,omitempty"`
+	Vital                               *VitalInternal             `json:"vital,omitempty"`
+	DebugIDs                            json.RawMessage            `json:"debug_ids,omitempty"`
+	Additional                          map[string]json.RawMessage `json:"-"`
+}
+
+type Configuration struct {
+	SessionSampleRate       *float64 `json:"session_sample_rate,omitempty"`
+	SessionReplaySampleRate *float64 `json:"session_replay_sample_rate,omitempty"`
+	TraceSampleRate         *float64 `json:"trace_sample_rate,omitempty"`
+	ProfilingSampleRate     *float64 `json:"profiling_sample_rate,omitempty"`
+}
+
+type ReplayStats struct {
+	RecordsCount         *int64 `json:"records_count,omitempty"`
+	SegmentsCount        *int64 `json:"segments_count,omitempty"`
+	SegmentsTotalRawSize *int64 `json:"segments_total_raw_size,omitempty"`
+}
+
+func (f InternalFields) MarshalJSON() ([]byte, error) {
+	type alias InternalFields
+	if len(f.Additional) == 0 {
+		return json.Marshal(alias(f))
+	}
+
+	fields := make(map[string]json.RawMessage, len(internalKnownFields)+len(f.Additional))
+	knownFields := []struct {
+		key     string
+		value   any
+		include bool
+	}{
+		{internalFieldFormatVersion, f.FormatVersion, f.FormatVersion != nil},
+		{internalFieldDocumentVersion, f.DocumentVersion, f.DocumentVersion != nil},
+		{internalFieldTraceID, f.TraceID, f.TraceID != ""},
+		{internalFieldSpanID, f.SpanID, f.SpanID != ""},
+		{internalFieldDrift, f.Drift, f.Drift != nil},
+		{internalFieldSDKName, f.SDKName, f.SDKName != ""},
+		{internalFieldBrowserSDKVersion, f.BrowserSDKVersion, f.BrowserSDKVersion != ""},
+		{internalFieldProfilingSampleRate, f.ProfilingSampleRate, f.ProfilingSampleRate != nil},
+		{internalFieldTraceSampleRate, f.TraceSampleRate, f.TraceSampleRate != nil},
+		{internalFieldStartSessionReplayRecordManually, f.StartSessionReplayRecordingManually, f.StartSessionReplayRecordingManually != nil},
+		{internalFieldRemoteConfigurationID, f.RemoteConfigurationID, f.RemoteConfigurationID != ""},
+		{internalFieldCLSDevicePixelRatio, f.CLSDevicePixelRatio, f.CLSDevicePixelRatio != nil},
+		{internalFieldConfiguration, f.Configuration, f.Configuration != nil},
+		{internalFieldPageStates, f.PageStates, len(f.PageStates) > 0},
+		{internalFieldReplayStats, f.ReplayStats, f.ReplayStats != nil},
+		{internalFieldAction, f.Action, f.Action != nil},
+		{internalFieldVital, f.Vital, f.Vital != nil},
+		{internalFieldDebugIDs, f.DebugIDs, len(f.DebugIDs) > 0},
+	}
+	for _, field := range knownFields {
+		if !field.include {
+			continue
+		}
+		value, err := json.Marshal(field.value)
+		if err != nil {
+			return nil, err
+		}
+		fields[field.key] = value
+	}
+	for key, value := range f.Additional {
+		fields[key] = value
+	}
+	return json.Marshal(fields)
+}
+
+func (f *InternalFields) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var dst InternalFields
+	fields := []internalRawField{
+		{key: internalFieldFormatVersion, dst: &dst.FormatVersion},
+		{key: internalFieldDocumentVersion, dst: &dst.DocumentVersion},
+		{key: internalFieldTraceID, dst: &dst.TraceID},
+		{key: internalFieldSpanID, dst: &dst.SpanID},
+		{key: internalFieldDrift, dst: &dst.Drift},
+		{key: internalFieldSDKName, dst: &dst.SDKName},
+		{key: internalFieldBrowserSDKVersion, dst: &dst.BrowserSDKVersion},
+		{key: internalFieldProfilingSampleRate, dst: &dst.ProfilingSampleRate},
+		{key: internalFieldTraceSampleRate, dst: &dst.TraceSampleRate},
+		{key: internalFieldStartSessionReplayRecordManually, dst: &dst.StartSessionReplayRecordingManually},
+		{key: internalFieldRemoteConfigurationID, dst: &dst.RemoteConfigurationID},
+		{key: internalFieldCLSDevicePixelRatio, dst: &dst.CLSDevicePixelRatio},
+		{key: internalFieldConfiguration, dst: &dst.Configuration},
+		{key: internalFieldPageStates, dst: &dst.PageStates},
+		{key: internalFieldReplayStats, dst: &dst.ReplayStats},
+		{key: internalFieldAction, dst: &dst.Action},
+		{key: internalFieldVital, dst: &dst.Vital},
+		{key: internalFieldDebugIDs, dst: &dst.DebugIDs},
+	}
+	if err := decodeInternalFields(raw, fields); err != nil {
+		return err
+	}
+	dst.Additional = collectUnknownFields(raw, internalKnownFields...)
+	*f = dst
+	return nil
+}
+
+type internalRawField struct {
+	key string
+	dst any
+}
+
+func decodeInternalFields(raw map[string]json.RawMessage, fields []internalRawField) error {
+	for _, field := range fields {
+		if err := decodeInternalField(raw, field.key, field.dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decodeInternalField(raw map[string]json.RawMessage, key string, dst any) error {
+	msg, ok := raw[key]
+	if !ok || bytes.Equal(bytes.TrimSpace(msg), []byte("null")) {
+		return nil
+	}
+	return json.Unmarshal(msg, dst)
+}
+
+// collectUnknownFields removes known _dd fields and returns the remaining raw fields.
+func collectUnknownFields(raw map[string]json.RawMessage, known ...string) map[string]json.RawMessage {
+	for _, key := range known {
+		delete(raw, key)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/long_task.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/long_task.go
@@ -1,0 +1,32 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+type LongTaskEvent struct {
+	CommonFields
+	LongTask LongTask `json:"long_task"`
+}
+
+func (e *LongTaskEvent) GetType() EventType { return EventTypeLongTask }
+func (e *LongTaskEvent) GetCommon() *CommonFields {
+	return &e.CommonFields
+}
+
+type LongTask struct {
+	Present               bool   `json:"-"`
+	ID                    string `json:"id,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	EntryType             string `json:"entry_type,omitempty"`
+	Duration              *int64 `json:"duration,omitempty"`
+	BlockingDuration      *int64 `json:"blocking_duration,omitempty"`
+	RenderStart           *int64 `json:"render_start,omitempty"`
+	StyleAndLayoutStart   *int64 `json:"style_and_layout_start,omitempty"`
+	FirstUIEventTimestamp *int64 `json:"first_ui_event_timestamp,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/model_test.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/model_test.go
@@ -1,0 +1,225 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventMarshalPreservesRawPayload(t *testing.T) {
+	raw := json.RawMessage(`{"type":"action","view":{"id":"view"},"action":{"type":"click"},"custom":{"value":1}}`)
+	event := &ActionEvent{}
+	event.CommonFields.Raw = raw
+
+	encoded, err := json.Marshal(event)
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(raw), string(encoded))
+}
+
+func TestEventMarshalIncludesViewContext(t *testing.T) {
+	event := &ActionEvent{
+		CommonFields: CommonFields{
+			Date:        1,
+			Type:        EventTypeAction,
+			Application: Application{ID: "app"},
+			ViewContext: &ViewContext{ID: "view", URL: "https://example.com"},
+		},
+		Action: Action{Present: true, Type: "click"},
+	}
+
+	encoded, err := json.Marshal(event)
+	assert.NoError(t, err)
+	var payload map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(encoded, &payload))
+	assert.Contains(t, payload, "view")
+}
+
+func TestInternalFieldsDebugIDsAcceptArray(t *testing.T) {
+	var fields InternalFields
+	err := json.Unmarshal([]byte(`{"debug_ids":[{"url":"https://example.com/a.js","id":"abc"}]}`), &fields)
+	assert.NoError(t, err)
+}
+
+func TestInternalFieldsMarshalPreservesAdditional(t *testing.T) {
+	traceID := "trace-1"
+	fields := InternalFields{
+		TraceID:    traceID,
+		Additional: map[string]json.RawMessage{"custom": json.RawMessage(`{"value":1}`)},
+	}
+
+	encoded, err := json.Marshal(fields)
+	assert.NoError(t, err)
+
+	var payload map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(encoded, &payload))
+	assert.Contains(t, payload, "trace_id")
+	assert.Contains(t, payload, "custom")
+	assert.NotContains(t, payload, "span_id")
+}
+
+func TestInternalFieldsMarshalAdditionalPreservesOmitEmpty(t *testing.T) {
+	zeroInt := 0
+	zeroFloat := 0.0
+	zeroBool := false
+	fields := InternalFields{
+		FormatVersion:                       &zeroInt,
+		ProfilingSampleRate:                 &zeroFloat,
+		StartSessionReplayRecordingManually: &zeroBool,
+		Configuration:                       &Configuration{},
+		ReplayStats:                         &ReplayStats{},
+		Action:                              &ActionInternal{},
+		Vital:                               &VitalInternal{},
+		PageStates:                          []PageState{},
+		DebugIDs:                            json.RawMessage(`{"id":1}`),
+		Additional: map[string]json.RawMessage{
+			"trace_id":   json.RawMessage(`"overridden"`),
+			"custom":     json.RawMessage(`{"value":1}`),
+			"null_value": nil,
+		},
+	}
+
+	encoded, err := json.Marshal(fields)
+	assert.NoError(t, err)
+	var payload map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(encoded, &payload))
+
+	assert.JSONEq(t, `0`, string(payload["format_version"]))
+	assert.JSONEq(t, `0`, string(payload["profiling_sample_rate"]))
+	assert.JSONEq(t, `false`, string(payload["start_session_replay_recording_manually"]))
+	assert.JSONEq(t, `{}`, string(payload["configuration"]))
+	assert.JSONEq(t, `{}`, string(payload["replay_stats"]))
+	assert.JSONEq(t, `{}`, string(payload["action"]))
+	assert.JSONEq(t, `{}`, string(payload["vital"]))
+	assert.JSONEq(t, `{"id":1}`, string(payload["debug_ids"]))
+	assert.Equal(t, `"overridden"`, string(payload["trace_id"]))
+	assert.JSONEq(t, `{"value":1}`, string(payload["custom"]))
+	assert.Equal(t, "null", string(payload["null_value"]))
+	assert.NotContains(t, payload, "document_version")
+	assert.NotContains(t, payload, "page_states")
+	assert.NotContains(t, payload, "span_id")
+}
+
+func TestInternalFieldsMarshalAdditionalReturnsRawMessageErrors(t *testing.T) {
+	invalidKnown := InternalFields{
+		DebugIDs:   json.RawMessage(`{`),
+		Additional: map[string]json.RawMessage{"debug_ids": json.RawMessage(`[]`)},
+	}
+	_, err := json.Marshal(invalidKnown)
+	assert.Error(t, err)
+
+	invalidAdditional := InternalFields{
+		Additional: map[string]json.RawMessage{"custom": json.RawMessage(`{`)},
+	}
+	_, err = json.Marshal(invalidAdditional)
+	assert.Error(t, err)
+}
+
+func TestInternalFieldsRoundTrip(t *testing.T) {
+	formatVersion := 2
+	documentVersion := 1
+	drift := int64(100)
+	sessionSampleRate := 50.0
+	traceSampleRate := 25.0
+	startManually := true
+	clsRatio := 2.0
+
+	original := InternalFields{
+		FormatVersion:                       &formatVersion,
+		DocumentVersion:                     &documentVersion,
+		TraceID:                             "trace-1",
+		SpanID:                              "span-1",
+		Drift:                               &drift,
+		SDKName:                             "browser-sdk",
+		BrowserSDKVersion:                   "5.0.0",
+		ProfilingSampleRate:                 &traceSampleRate,
+		TraceSampleRate:                     &sessionSampleRate,
+		StartSessionReplayRecordingManually: &startManually,
+		RemoteConfigurationID:               "remote-1",
+		CLSDevicePixelRatio:                 &clsRatio,
+		Configuration: &Configuration{
+			SessionSampleRate:       &sessionSampleRate,
+			SessionReplaySampleRate: &sessionSampleRate,
+			TraceSampleRate:         &traceSampleRate,
+			ProfilingSampleRate:     &traceSampleRate,
+		},
+	}
+
+	encoded, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	var decoded InternalFields
+	assert.NoError(t, json.Unmarshal(encoded, &decoded))
+
+	assert.Equal(t, *original.FormatVersion, *decoded.FormatVersion)
+	assert.Equal(t, *original.DocumentVersion, *decoded.DocumentVersion)
+	assert.Equal(t, original.TraceID, decoded.TraceID)
+	assert.Equal(t, original.SpanID, decoded.SpanID)
+	assert.Equal(t, *original.Drift, *decoded.Drift)
+	assert.Equal(t, original.SDKName, decoded.SDKName)
+	assert.Equal(t, original.BrowserSDKVersion, decoded.BrowserSDKVersion)
+	assert.Equal(t, *original.ProfilingSampleRate, *decoded.ProfilingSampleRate)
+	assert.Equal(t, *original.TraceSampleRate, *decoded.TraceSampleRate)
+	assert.Equal(t, *original.StartSessionReplayRecordingManually, *decoded.StartSessionReplayRecordingManually)
+	assert.Equal(t, original.RemoteConfigurationID, decoded.RemoteConfigurationID)
+	assert.Equal(t, *original.CLSDevicePixelRatio, *decoded.CLSDevicePixelRatio)
+	assert.NotNil(t, decoded.Configuration)
+	assert.Equal(t, *original.Configuration.SessionSampleRate, *decoded.Configuration.SessionSampleRate)
+}
+
+func TestInternalFieldsUnknownFields(t *testing.T) {
+	payload := `{"trace_id":"trace-1","unknown_field":{"nested":true},"another_unknown":123}`
+	var fields InternalFields
+	assert.NoError(t, json.Unmarshal([]byte(payload), &fields))
+
+	assert.Equal(t, "trace-1", fields.TraceID)
+	assert.Contains(t, fields.Additional, "unknown_field")
+	assert.Contains(t, fields.Additional, "another_unknown")
+	assert.JSONEq(t, `{"nested":true}`, string(fields.Additional["unknown_field"]))
+	assert.JSONEq(t, `123`, string(fields.Additional["another_unknown"]))
+
+	encoded, err := json.Marshal(fields)
+	assert.NoError(t, err)
+	var roundTrip map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(encoded, &roundTrip))
+	assert.Contains(t, roundTrip, "unknown_field")
+	assert.Contains(t, roundTrip, "another_unknown")
+}
+
+func TestInternalFieldsNullHandling(t *testing.T) {
+	payload := `{"trace_id":"trace-1","format_version":null,"drift":null,"configuration":null}`
+	var fields InternalFields
+	assert.NoError(t, json.Unmarshal([]byte(payload), &fields))
+
+	assert.Equal(t, "trace-1", fields.TraceID)
+	assert.Nil(t, fields.FormatVersion)
+	assert.Nil(t, fields.Drift)
+	assert.Nil(t, fields.Configuration)
+}
+
+func TestInternalFieldsNumericFields(t *testing.T) {
+	payload := `{"format_version":2,"document_version":1,"drift":-50,"profiling_sample_rate":12.5,"trace_sample_rate":37.5,"cls_device_pixel_ratio":1.5}`
+	var fields InternalFields
+	assert.NoError(t, json.Unmarshal([]byte(payload), &fields))
+
+	assert.NotNil(t, fields.FormatVersion)
+	assert.Equal(t, 2, *fields.FormatVersion)
+	assert.NotNil(t, fields.DocumentVersion)
+	assert.Equal(t, 1, *fields.DocumentVersion)
+	assert.NotNil(t, fields.Drift)
+	assert.Equal(t, int64(-50), *fields.Drift)
+	assert.NotNil(t, fields.ProfilingSampleRate)
+	assert.InDelta(t, 12.5, *fields.ProfilingSampleRate, 0.0001)
+	assert.NotNil(t, fields.TraceSampleRate)
+	assert.InDelta(t, 37.5, *fields.TraceSampleRate, 0.0001)
+	assert.NotNil(t, fields.CLSDevicePixelRatio)
+	assert.InDelta(t, 1.5, *fields.CLSDevicePixelRatio, 0.0001)
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/resource.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/resource.go
@@ -1,0 +1,66 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+type ResourceEvent struct {
+	CommonFields
+	Resource Resource `json:"resource"`
+}
+
+func (e *ResourceEvent) GetType() EventType { return EventTypeResource }
+func (e *ResourceEvent) GetCommon() *CommonFields {
+	return &e.CommonFields
+}
+
+type Resource struct {
+	Present              bool              `json:"-"`
+	ID                   string            `json:"id,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	URL                  string            `json:"url,omitempty"`
+	URLHost              string            `json:"url_host,omitempty"`
+	URLPath              string            `json:"url_path,omitempty"`
+	URLQuery             string            `json:"url_query,omitempty"`
+	URLScheme            string            `json:"url_scheme,omitempty"`
+	Method               string            `json:"method,omitempty"`
+	StatusCode           *int              `json:"status_code,omitempty"`
+	Duration             *int64            `json:"duration,omitempty"`
+	Size                 *int64            `json:"size,omitempty"`
+	EncodedBodySize      *int64            `json:"encoded_body_size,omitempty"`
+	DecodedBodySize      *int64            `json:"decoded_body_size,omitempty"`
+	TransferSize         *int64            `json:"transfer_size,omitempty"`
+	Protocol             string            `json:"protocol,omitempty"`
+	DeliveryType         string            `json:"delivery_type,omitempty"`
+	RenderBlockingStatus string            `json:"render_blocking_status,omitempty"`
+	Timing               *ResourceTiming   `json:"timing,omitempty"`
+	Provider             *ResourceProvider `json:"provider,omitempty"`
+	Request              map[string]any    `json:"request,omitempty"`
+	Response             map[string]any    `json:"response,omitempty"`
+}
+
+type ResourceTiming struct {
+	Redirect  *Timing `json:"redirect,omitempty"`
+	Worker    *Timing `json:"worker,omitempty"`
+	DNS       *Timing `json:"dns,omitempty"`
+	Connect   *Timing `json:"connect,omitempty"`
+	SSL       *Timing `json:"ssl,omitempty"`
+	FirstByte *Timing `json:"first_byte,omitempty"`
+	Download  *Timing `json:"download,omitempty"`
+}
+
+type ResourceProvider struct {
+	Type   string `json:"type,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Domain string `json:"domain,omitempty"`
+}
+
+type Timing struct {
+	Start    *int64 `json:"start,omitempty"`
+	Duration *int64 `json:"duration,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/session.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/session.go
@@ -1,0 +1,42 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+// Session 是 RUM 事件的会话关联实体，不作为独立事件类型。
+// 字段语义与出现时机参考 Datadog RUM 文档，注释括号内标注出现时机：
+// 常见 / 开启回放后 / View 事件中条件出现 / 查询或聚合结果。
+type Session struct {
+	// ID 会话 ID（常见）。
+	ID string `json:"id,omitempty"`
+	// Type 会话类型（常见），常见值为 user，也可能出现 synthetics、ci_test。
+	Type string `json:"type,omitempty"`
+	// InitialViewID 会话首个 View 的 ID。
+	InitialViewID string `json:"initial_view_id,omitempty"`
+	// HasReplay 当前会话是否包含 Session Replay（开启回放后）。
+	HasReplay *bool `json:"has_replay,omitempty"`
+	// SampledForReplay 当前会话是否被回放采样（View 事件中条件出现）。
+	SampledForReplay *bool `json:"sampled_for_replay,omitempty"`
+	// IsActive 会话是否仍处于活动状态（View 事件中条件出现）。
+	IsActive *bool `json:"is_active,omitempty"`
+	// TimeSpent 会话持续时间，单位为纳秒（查询或聚合结果）。
+	TimeSpent *int64 `json:"time_spent,omitempty"`
+	// ViewCount 会话内 View 数量（查询或聚合结果）。
+	ViewCount *int64 `json:"view_count,omitempty"`
+	// ActionCount 会话内 Action 数量（查询或聚合结果）。
+	ActionCount *int64 `json:"action_count,omitempty"`
+	// ResourceCount 会话内 Resource 数量（查询或聚合结果）。
+	ResourceCount *int64 `json:"resource_count,omitempty"`
+	// ErrorCount 会话内 Error 数量（查询或聚合结果）。
+	ErrorCount *int64 `json:"error_count,omitempty"`
+	// LongTaskCount 会话内 Long Task 数量（查询或聚合结果）。
+	LongTaskCount *int64 `json:"long_task_count,omitempty"`
+	// Frustrated 当前会话是否被标记为受挫。
+	Frustrated *bool `json:"frustrated,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/view.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/view.go
@@ -1,0 +1,163 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+type ViewEvent struct {
+	CommonFields
+	View View `json:"view"`
+}
+
+// GetType returns the explicit event type when present; otherwise it defaults to EventTypeView.
+// View events may carry a more specific subtype in CommonFields.Type, unlike other event types.
+func (e *ViewEvent) GetType() EventType {
+	if e.CommonFields.Type == "" {
+		return EventTypeView
+	}
+	return e.CommonFields.Type
+}
+func (e *ViewEvent) GetCommon() *CommonFields {
+	return &e.CommonFields
+}
+
+type View struct {
+	Present bool `json:"-"`
+	ViewContext
+	IsActive                             *bool            `json:"is_active,omitempty"`
+	LoadingType                          string           `json:"loading_type,omitempty"`
+	LoadingTime                          *int64           `json:"loading_time,omitempty"`
+	NetworkSettledTime                   *int64           `json:"network_settled_time,omitempty"`
+	InteractionToNextViewTime            *int64           `json:"interaction_to_next_view_time,omitempty"`
+	TimeSpent                            *int64           `json:"time_spent,omitempty"`
+	FirstContentfulPaint                 *int64           `json:"first_contentful_paint,omitempty"`
+	LargestContentfulPaint               *int64           `json:"largest_contentful_paint,omitempty"`
+	LargestContentfulPaintTargetSelector string           `json:"largest_contentful_paint_target_selector,omitempty"`
+	FirstInputDelay                      *int64           `json:"first_input_delay,omitempty"`
+	FirstInputTime                       *int64           `json:"first_input_time,omitempty"`
+	FirstInputTargetSelector             string           `json:"first_input_target_selector,omitempty"`
+	InteractionToNextPaint               *int64           `json:"interaction_to_next_paint,omitempty"`
+	InteractionToNextPaintTime           *int64           `json:"interaction_to_next_paint_time,omitempty"`
+	InteractionToNextPaintTargetSelector string           `json:"interaction_to_next_paint_target_selector,omitempty"`
+	CumulativeLayoutShift                *float64         `json:"cumulative_layout_shift,omitempty"`
+	CumulativeLayoutShiftTime            *int64           `json:"cumulative_layout_shift_time,omitempty"`
+	CumulativeLayoutShiftTargetSelector  string           `json:"cumulative_layout_shift_target_selector,omitempty"`
+	Performance                          *ViewPerformance `json:"performance,omitempty"`
+	EventCount                           *ViewEventCount  `json:"event,omitempty"`
+	CustomTimings                        CustomTimings    `json:"custom_timings,omitempty"`
+	PageState                            *PageState       `json:"page_state,omitempty"`
+	Action                               *ViewCount       `json:"action,omitempty"`
+	Error                                *ViewCount       `json:"error,omitempty"`
+	Crash                                *ViewCount       `json:"crash,omitempty"`
+	Resource                             *ViewCount       `json:"resource,omitempty"`
+	LongTask                             *ViewCount       `json:"long_task,omitempty"`
+	Frustration                          *ViewCount       `json:"frustration,omitempty"`
+	InForegroundPeriods                  []Period         `json:"in_foreground_periods,omitempty"`
+}
+
+type ViewContext struct {
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Referrer string `json:"referrer,omitempty"`
+}
+
+type ViewPerformance struct {
+	NavigationStart  *int64          `json:"navigation_start,omitempty"`
+	FirstByte        *int64          `json:"first_byte,omitempty"`
+	DOMInteractive   *int64          `json:"dom_interactive,omitempty"`
+	DOMContentLoaded *int64          `json:"dom_content_loaded,omitempty"`
+	DOMComplete      *int64          `json:"dom_complete,omitempty"`
+	LoadEvent        *int64          `json:"load_event,omitempty"`
+	FCP              *FCPPerformance `json:"fcp,omitempty"`
+	LCP              *LCPPerformance `json:"lcp,omitempty"`
+	CLS              *CLSPerformance `json:"cls,omitempty"`
+	FID              *FIDPerformance `json:"fid,omitempty"`
+	INP              *INPPerformance `json:"inp,omitempty"`
+}
+
+type FCPPerformance struct {
+	Timestamp *int64 `json:"timestamp,omitempty"`
+}
+
+type LCPPerformance struct {
+	Timestamp      *int64       `json:"timestamp,omitempty"`
+	Target         string       `json:"target,omitempty"`
+	TargetSelector string       `json:"target_selector,omitempty"`
+	ResourceURL    string       `json:"resource_url,omitempty"`
+	Element        string       `json:"element,omitempty"`
+	SubParts       *LCPSubParts `json:"sub_parts,omitempty"`
+}
+
+type LCPSubParts struct {
+	LoadDelay   *int64 `json:"load_delay,omitempty"`
+	LoadTime    *int64 `json:"load_time,omitempty"`
+	RenderDelay *int64 `json:"render_delay,omitempty"`
+}
+
+type CLSPerformance struct {
+	Score          *float64 `json:"score,omitempty"`
+	Value          *float64 `json:"value,omitempty"`
+	Timestamp      *int64   `json:"timestamp,omitempty"`
+	TargetSelector string   `json:"target_selector,omitempty"`
+	PreviousRect   *Rect    `json:"previous_rect,omitempty"`
+	CurrentRect    *Rect    `json:"current_rect,omitempty"`
+}
+
+type FIDPerformance struct {
+	Duration       *int64 `json:"duration,omitempty"`
+	Timestamp      *int64 `json:"timestamp,omitempty"`
+	TargetSelector string `json:"target_selector,omitempty"`
+}
+
+type INPPerformance struct {
+	Duration       *int64       `json:"duration,omitempty"`
+	Value          *float64     `json:"value,omitempty"`
+	Timestamp      *int64       `json:"timestamp,omitempty"`
+	TargetSelector string       `json:"target_selector,omitempty"`
+	Target         string       `json:"target,omitempty"`
+	SubParts       *INPSubParts `json:"sub_parts,omitempty"`
+}
+
+type INPSubParts struct {
+	InputDelay         *int64 `json:"input_delay,omitempty"`
+	ProcessingDuration *int64 `json:"processing_duration,omitempty"`
+	PresentationDelay  *int64 `json:"presentation_delay,omitempty"`
+}
+
+type Rect struct {
+	X      *float64 `json:"x,omitempty"`
+	Y      *float64 `json:"y,omitempty"`
+	Width  *float64 `json:"width,omitempty"`
+	Height *float64 `json:"height,omitempty"`
+}
+
+type ViewCount struct {
+	Count *int64 `json:"count,omitempty"`
+}
+
+type ViewEventCount struct {
+	Action   *int64 `json:"action_count,omitempty"`
+	Error    *int64 `json:"error_count,omitempty"`
+	Resource *int64 `json:"resource_count,omitempty"`
+	LongTask *int64 `json:"long_task_count,omitempty"`
+}
+
+type CustomTimings map[string]int64
+
+type Period struct {
+	Start    *int64 `json:"start,omitempty"`
+	Duration *int64 `json:"duration,omitempty"`
+	End      *int64 `json:"end,omitempty"`
+}
+
+type PageState struct {
+	State    string `json:"state,omitempty"`
+	Start    *int64 `json:"start,omitempty"`
+	Duration *int64 `json:"duration,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/model/vital.go
+++ b/pkg/collector/receiver/datadogrum/internal/model/vital.go
@@ -1,0 +1,41 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package model
+
+type VitalEvent struct {
+	CommonFields
+	Vital Vital `json:"vital"`
+}
+
+func (e *VitalEvent) GetType() EventType { return EventTypeVital }
+func (e *VitalEvent) GetCommon() *CommonFields {
+	return &e.CommonFields
+}
+
+type Vital struct {
+	Present       bool               `json:"-"`
+	ID            string             `json:"id,omitempty"`
+	Type          VitalType          `json:"type,omitempty"`
+	Name          string             `json:"name,omitempty"`
+	Description   string             `json:"description,omitempty"`
+	StepType      VitalStepType      `json:"step_type,omitempty"`
+	OperationKey  string             `json:"operation_key,omitempty"`
+	Duration      *int64             `json:"duration,omitempty"`
+	FailureReason VitalFailureReason `json:"failure_reason,omitempty"`
+	Internal      *VitalInternal     `json:"_dd,omitempty"`
+}
+
+type VitalType string
+type VitalStepType string
+type VitalFailureReason string
+
+type VitalInternal struct {
+	ComputedValue *float64 `json:"computed_value,omitempty"`
+}

--- a/pkg/collector/receiver/datadogrum/internal/parser/event_parser.go
+++ b/pkg/collector/receiver/datadogrum/internal/parser/event_parser.go
@@ -1,0 +1,138 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package parser
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+// Parse parses and validates one raw Datadog RUM event.
+func (p *Parser) Parse(data []byte) (model.Event, error) {
+	raw, err := decodeRawEvent(data)
+	if err != nil {
+		return nil, err
+	}
+	eventType, err := raw.eventType()
+	if err != nil {
+		return nil, err
+	}
+
+	event, err := p.parseByType(raw, eventType)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.validator().Validate(event); err != nil {
+		return nil, err
+	}
+	event.GetCommon().Normalize()
+	event.GetCommon().Raw = append(json.RawMessage(nil), bytes.TrimSpace(data)...)
+	return event, nil
+}
+
+func (p *Parser) parseByType(raw rawEvent, eventType model.EventType) (model.Event, error) {
+	switch eventType {
+	case model.EventTypeView, model.EventTypeViewUpdate:
+		return p.parseView(raw)
+	case model.EventTypeAction:
+		return p.parseAction(raw)
+	case model.EventTypeResource:
+		return p.parseResource(raw)
+	case model.EventTypeError:
+		return p.parseError(raw)
+	case model.EventTypeLongTask:
+		return p.parseLongTask(raw)
+	case model.EventTypeVital:
+		return p.parseVital(raw)
+	default:
+		return nil, model.ErrUnsupportedEventType
+	}
+}
+
+func (p *Parser) parseView(raw rawEvent) (*model.ViewEvent, error) {
+	var view model.View
+	common, present, err := decodeCommonAndSection(raw, sectionView, &view)
+	if err != nil {
+		return nil, err
+	}
+	view.Present = present
+	common.ViewContext = &view.ViewContext
+	return &model.ViewEvent{
+		CommonFields: common,
+		View:         view,
+	}, nil
+}
+
+func (p *Parser) parseAction(raw rawEvent) (*model.ActionEvent, error) {
+	var action model.Action
+	common, present, err := decodeCommonAndSection(raw, sectionAction, &action)
+	if err != nil {
+		return nil, err
+	}
+	action.Present = present
+	return &model.ActionEvent{
+		CommonFields: common,
+		Action:       action,
+	}, nil
+}
+
+func (p *Parser) parseResource(raw rawEvent) (*model.ResourceEvent, error) {
+	var resource model.Resource
+	common, present, err := decodeCommonAndSection(raw, sectionResource, &resource)
+	if err != nil {
+		return nil, err
+	}
+	resource.Present = present
+	return &model.ResourceEvent{
+		CommonFields: common,
+		Resource:     resource,
+	}, nil
+}
+
+func (p *Parser) parseError(raw rawEvent) (*model.ErrorEvent, error) {
+	var rumError model.Error
+	common, present, err := decodeCommonAndSection(raw, sectionError, &rumError)
+	if err != nil {
+		return nil, err
+	}
+	rumError.Present = present
+	return &model.ErrorEvent{
+		CommonFields: common,
+		Error:        rumError,
+	}, nil
+}
+
+func (p *Parser) parseLongTask(raw rawEvent) (*model.LongTaskEvent, error) {
+	var longTask model.LongTask
+	common, present, err := decodeCommonAndSection(raw, sectionLongTask, &longTask)
+	if err != nil {
+		return nil, err
+	}
+	longTask.Present = present
+	return &model.LongTaskEvent{
+		CommonFields: common,
+		LongTask:     longTask,
+	}, nil
+}
+
+func (p *Parser) parseVital(raw rawEvent) (*model.VitalEvent, error) {
+	var vital model.Vital
+	common, present, err := decodeCommonAndSection(raw, sectionVital, &vital)
+	if err != nil {
+		return nil, err
+	}
+	vital.Present = present
+	return &model.VitalEvent{
+		CommonFields: common,
+		Vital:        vital,
+	}, nil
+}

--- a/pkg/collector/receiver/datadogrum/internal/parser/event_parser_test.go
+++ b/pkg/collector/receiver/datadogrum/internal/parser/event_parser_test.go
@@ -1,0 +1,96 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+const validContext = `"application":{"id":"app"},"session":{"id":"session","type":"user"},"view":{"id":"view","url":"https://example.com"},"_dd":{"format_version":2}`
+
+func TestParser_ParseViewUpdate(t *testing.T) {
+	p := New(false)
+	event, err := p.Parse([]byte(`{"type":"view_update","date":1,"application":{"id":"app"},"session":{"id":"session"},"view":{"id":"view","url":"https://example.com","performance":{"lcp":{"timestamp":376000000,"sub_parts":{"load_delay":306900000}}}},"_dd":{"format_version":2},"unknown_field":{"kept":true}}`))
+	assert.NoError(t, err)
+	assert.Equal(t, model.EventTypeViewUpdate, event.GetType())
+	assert.Equal(t, int64(376000000), *event.(*model.ViewEvent).View.Performance.LCP.Timestamp)
+}
+
+func TestParser_ParseTimestampFallback(t *testing.T) {
+	p := New(false)
+	event, err := p.Parse([]byte(`{"type":"action","timestamp":42,"application":{"id":"app"},"session":{"id":"session"},"view":{"id":"view","url":"https://example.com"},"action":{"type":"click"}}`))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(42), event.GetCommon().Date)
+}
+
+func TestParser_ParseBatch(t *testing.T) {
+	p := New(false)
+	rawEvents := [][]byte{
+		[]byte(`{"type":"view","date":1,` + validContext + `,"view":{"id":"view","url":"https://example.com"}}`),
+		[]byte(`{"type":"action","date":2,"application":{"id":"app"},"session":{"id":"session","type":"user"},"view":{"id":"view","url":"https://example.com"},"_dd":{"format_version":2},"action":{"id":"action","type":"click"}}`),
+	}
+
+	batch, err := p.ParseBatch(rawEvents)
+	assert.NoError(t, err)
+	assert.Len(t, batch.Events, 2)
+	assert.Equal(t, model.EventTypeView, batch.Events[0].GetType())
+}
+
+func TestParser_Parse_Unsupported(t *testing.T) {
+	p := New(false)
+	_, err := p.Parse([]byte(`{"type":"unknown","date":1,"application":{"id":"app"}}`))
+	assert.ErrorIs(t, err, model.ErrUnsupportedEventType)
+}
+
+func TestParser_Parse_MissingType(t *testing.T) {
+	p := New(false)
+	_, err := p.Parse([]byte(`{"date":1,"application":{"id":"app"}}`))
+	assert.ErrorIs(t, err, model.ErrMissingRequiredField)
+}
+
+func TestParser_Parse_SkipInvalid(t *testing.T) {
+	p := New(true)
+	rawEvents := [][]byte{
+		[]byte(`{"type":"unknown","date":1,"application":{"id":"app"}}`),
+		[]byte(`{"type":"error","date":2,"application":{"id":"app"},"session":{"id":"session","type":"user"},"view":{"id":"view","url":"https://example.com"},"_dd":{"format_version":2},"error":{"id":"err","message":"failed","source":"source"}}`),
+	}
+
+	batch, err := p.ParseBatch(rawEvents)
+	assert.NoError(t, err)
+	assert.Len(t, batch.Events, 1)
+	assert.Equal(t, model.EventTypeError, batch.Events[0].GetType())
+}
+
+func TestParser_Parse_Empty(t *testing.T) {
+	p := New(false)
+	_, err := p.ParseBatch(nil)
+	assert.ErrorIs(t, err, model.ErrEmptyBody)
+}
+
+func TestParser_Parse_EmptyResourceObject(t *testing.T) {
+	p := New(false)
+	_, err := p.Parse([]byte(`{"type":"resource","date":1,"application":{"id":"app"},"session":{"id":"session","type":"user"},"view":{"id":"view","url":"https://example.com"},"_dd":{"format_version":2},"resource":{}}`))
+	assert.NoError(t, err)
+}
+
+func TestParser_ParseNull(t *testing.T) {
+	p := New(false)
+	_, err := p.Parse([]byte("null"))
+	assert.ErrorIs(t, err, model.ErrInvalidPayload)
+}
+
+func TestParser_ParseActionWithoutID(t *testing.T) {
+	p := New(false)
+	_, err := p.Parse([]byte(`{"type":"action","date":1,"application":{"id":"app"},"session":{"id":"session","type":"user"},"view":{"id":"view","url":"https://example.com"},"_dd":{"format_version":2},"action":{"type":"click"}}`))
+	assert.NoError(t, err)
+}

--- a/pkg/collector/receiver/datadogrum/internal/parser/parser.go
+++ b/pkg/collector/receiver/datadogrum/internal/parser/parser.go
@@ -1,0 +1,54 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package parser
+
+import (
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+	modelvalidator "github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/validator"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
+)
+
+// Parser converts raw Datadog RUM events into validated model events.
+type Parser struct {
+	SkipInvalid    bool
+	eventValidator modelvalidator.Validator
+}
+
+// New creates a parser with the requested invalid-event policy.
+func New(skipInvalid bool) *Parser {
+	return &Parser{SkipInvalid: skipInvalid}
+}
+
+// ParseBatch parses and validates all events in a request batch.
+func (p *Parser) ParseBatch(rawEvents [][]byte) (*model.Batch, error) {
+	if len(rawEvents) == 0 {
+		return nil, model.ErrEmptyBody
+	}
+
+	parsedEvents := make([]model.Event, 0, len(rawEvents))
+	for _, rawEvent := range rawEvents {
+		event, err := p.Parse(rawEvent)
+		if err != nil {
+			if p.SkipInvalid {
+				logger.Warnf("skip invalid datadog rum event: %s", err)
+				continue
+			}
+			return nil, err
+		}
+		parsedEvents = append(parsedEvents, event)
+	}
+	if len(parsedEvents) == 0 {
+		return nil, model.ErrEmptyBody
+	}
+	return &model.Batch{Events: parsedEvents}, nil
+}
+
+func (p *Parser) validator() *modelvalidator.Validator {
+	return &p.eventValidator
+}

--- a/pkg/collector/receiver/datadogrum/internal/parser/raw_event.go
+++ b/pkg/collector/receiver/datadogrum/internal/parser/raw_event.go
@@ -1,0 +1,176 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package parser
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+const (
+	// Common event fields.
+	fieldType         = "type"
+	fieldDate         = "date"
+	fieldTimestamp    = "timestamp"
+	fieldSource       = "source"
+	fieldService      = "service"
+	fieldVersion      = "version"
+	fieldBuildVersion = "build_version"
+	fieldBuildID      = "build_id"
+	fieldTags         = "ddtags"
+
+	fieldApplication  = "application"
+	fieldSession      = "session"
+	fieldUser         = "usr"
+	fieldAccount      = "account"
+	fieldTab          = "tab"
+	fieldConnectivity = "connectivity"
+	fieldDisplay      = "display"
+	fieldDevice       = "device"
+	fieldOS           = "os"
+	fieldContext      = "context"
+	fieldFeatureFlags = "feature_flags"
+	fieldPrivacy      = "privacy"
+	fieldContainer    = "container"
+	fieldStream       = "stream"
+	fieldInternal     = "_dd"
+
+	// Event-specific sections.
+	sectionView     = "view"
+	sectionAction   = "action"
+	sectionResource = "resource"
+	sectionError    = "error"
+	sectionLongTask = "long_task"
+	sectionVital    = "vital"
+)
+
+type rawEvent map[string]json.RawMessage
+
+func decodeRawEvent(data []byte) (rawEvent, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+		return nil, model.ErrInvalidPayload
+	}
+
+	var raw rawEvent
+	if err := json.Unmarshal(trimmed, &raw); err != nil {
+		return nil, model.ErrInvalidPayload
+	}
+	if raw == nil {
+		return nil, model.ErrInvalidPayload
+	}
+	return raw, nil
+}
+
+func (r rawEvent) eventType() (model.EventType, error) {
+	msg, ok := r[fieldType]
+	if !ok {
+		return "", model.ErrMissingRequiredField
+	}
+	if isJSONNull(msg) {
+		return "", model.ErrInvalidPayload
+	}
+
+	var eventType model.EventType
+	if err := json.Unmarshal(msg, &eventType); err != nil {
+		return "", model.ErrInvalidPayload
+	}
+	return eventType, nil
+}
+
+func decodeCommonAndSection(raw rawEvent, section string, dst any) (model.CommonFields, bool, error) {
+	common, err := decodeCommon(raw)
+	if err != nil {
+		return common, false, err
+	}
+
+	present, err := raw.decodeField(section, dst)
+	if err != nil {
+		return common, false, err
+	}
+	return common, present, nil
+}
+
+func decodeCommon(raw rawEvent) (model.CommonFields, error) {
+	var common model.CommonFields
+	var err error
+
+	decodeInto(&err, raw, fieldType, &common.Type)
+	decodeInto(&err, raw, fieldDate, &common.Date)
+	decodeInto(&err, raw, fieldTimestamp, &common.Timestamp)
+	decodeInto(&err, raw, fieldSource, &common.Source)
+	decodeInto(&err, raw, fieldService, &common.Service)
+	decodeInto(&err, raw, fieldVersion, &common.Version)
+	decodeInto(&err, raw, fieldBuildVersion, &common.BuildVersion)
+	decodeInto(&err, raw, fieldBuildID, &common.BuildID)
+	decodeInto(&err, raw, fieldTags, &common.Tags)
+	decodeInto(&err, raw, fieldApplication, &common.Application)
+	decodePtrInto(&err, raw, fieldSession, &common.Session)
+	decodePtrInto(&err, raw, sectionView, &common.ViewContext)
+	decodePtrInto(&err, raw, fieldUser, &common.User)
+	decodePtrInto(&err, raw, fieldAccount, &common.Account)
+	decodePtrInto(&err, raw, fieldTab, &common.Tab)
+	decodePtrInto(&err, raw, fieldConnectivity, &common.Connectivity)
+	decodePtrInto(&err, raw, fieldDisplay, &common.Display)
+	decodePtrInto(&err, raw, fieldDevice, &common.Device)
+	decodePtrInto(&err, raw, fieldOS, &common.OS)
+	decodeInto(&err, raw, fieldContext, &common.Context)
+	decodeInto(&err, raw, fieldFeatureFlags, &common.FeatureFlags)
+	decodeInto(&err, raw, fieldPrivacy, &common.Privacy)
+	decodeInto(&err, raw, fieldContainer, &common.Container)
+	decodeInto(&err, raw, fieldStream, &common.Stream)
+	decodePtrInto(&err, raw, fieldInternal, &common.Internal)
+
+	if err != nil {
+		return common, err
+	}
+	return common, nil
+}
+
+func decodeInto(err *error, raw rawEvent, key string, dst any) {
+	if *err != nil {
+		return
+	}
+	_, *err = raw.decodeField(key, dst)
+}
+
+func decodePtrInto[T any](err *error, raw rawEvent, key string, dst **T) {
+	if *err != nil {
+		return
+	}
+	*dst, *err = decodePtr[T](raw, key)
+}
+
+func decodePtr[T any](raw rawEvent, key string) (*T, error) {
+	var dst T
+	ok, err := raw.decodeField(key, &dst)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return &dst, nil
+}
+
+func (r rawEvent) decodeField(key string, dst any) (bool, error) {
+	msg, ok := r[key]
+	if !ok || isJSONNull(msg) {
+		return false, nil
+	}
+	if err := json.Unmarshal(msg, dst); err != nil {
+		return true, fmt.Errorf("%w: field %s: %v", model.ErrInvalidPayload, key, err)
+	}
+	return true, nil
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}

--- a/pkg/collector/receiver/datadogrum/internal/validator/common_validator.go
+++ b/pkg/collector/receiver/datadogrum/internal/validator/common_validator.go
@@ -1,0 +1,38 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package validator
+
+import (
+	"fmt"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+func (v *Validator) ValidateCommon(common *model.CommonFields) error {
+	if common == nil {
+		return missing("common")
+	}
+	if !common.Type.IsValid() {
+		return model.ErrUnsupportedEventType
+	}
+	if common.Date <= 0 && common.Timestamp <= 0 {
+		return missing("date")
+	}
+	if common.Application.ID == "" {
+		return missing("application.id")
+	}
+	if common.Session != nil && common.Session.ID == "" {
+		return missing("session.id")
+	}
+	return nil
+}
+
+func missing(field string) error {
+	return fmt.Errorf("%w: %s", model.ErrMissingRequiredField, field)
+}

--- a/pkg/collector/receiver/datadogrum/internal/validator/event_validator.go
+++ b/pkg/collector/receiver/datadogrum/internal/validator/event_validator.go
@@ -1,0 +1,71 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package validator
+
+import "github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+
+func (v *Validator) ValidateView(event *model.ViewEvent) error {
+	if event == nil {
+		return missing("view")
+	}
+	return validateRequiredSection("view", event.View.Present, event.View.ID)
+}
+
+func (v *Validator) ValidateAction(event *model.ActionEvent) error {
+	if event == nil {
+		return missing("action")
+	}
+	return validateSection("action", event.Action.Present)
+}
+
+func (v *Validator) ValidateResource(event *model.ResourceEvent) error {
+	if event == nil {
+		return missing("resource")
+	}
+	return validateSection("resource", event.Resource.Present)
+}
+
+func (v *Validator) ValidateError(event *model.ErrorEvent) error {
+	if event == nil {
+		return missing("error")
+	}
+	return validateSection("error", event.Error.Present)
+}
+
+func (v *Validator) ValidateLongTask(event *model.LongTaskEvent) error {
+	if event == nil {
+		return missing("long_task")
+	}
+	return validateSection("long_task", event.LongTask.Present)
+}
+
+func (v *Validator) ValidateVital(event *model.VitalEvent) error {
+	if event == nil {
+		return missing("vital")
+	}
+	return validateRequiredSection("vital", event.Vital.Present, event.Vital.ID)
+}
+
+func validateSection(section string, present bool) error {
+	if !present {
+		return missing(section)
+	}
+	return nil
+}
+
+func validateRequiredSection(section string, present bool, id string) error {
+	if err := validateSection(section, present); err != nil {
+		return err
+	}
+	if id == "" {
+		return missing(section + ".id")
+	}
+	return nil
+}

--- a/pkg/collector/receiver/datadogrum/internal/validator/validator.go
+++ b/pkg/collector/receiver/datadogrum/internal/validator/validator.go
@@ -1,0 +1,68 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package validator
+
+import (
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+// Validator checks common and event-specific RUM requirements.
+type Validator struct{}
+
+// New creates a RUM event validator.
+func New() *Validator {
+	return &Validator{}
+}
+
+// Validate checks an event's common fields and concrete event section.
+func (v *Validator) Validate(event model.Event) error {
+	if event == nil || isNilEvent(event) {
+		return model.ErrInvalidPayload
+	}
+	if err := v.ValidateCommon(event.GetCommon()); err != nil {
+		return err
+	}
+
+	switch ev := event.(type) {
+	case *model.ViewEvent:
+		// EventTypeViewUpdate shares the ViewEvent concrete type.
+		return v.ValidateView(ev)
+	case *model.ActionEvent:
+		return v.ValidateAction(ev)
+	case *model.ResourceEvent:
+		return v.ValidateResource(ev)
+	case *model.ErrorEvent:
+		return v.ValidateError(ev)
+	case *model.LongTaskEvent:
+		return v.ValidateLongTask(ev)
+	case *model.VitalEvent:
+		return v.ValidateVital(ev)
+	default:
+		return model.ErrUnsupportedEventType
+	}
+}
+
+func isNilEvent(event model.Event) bool {
+	switch v := event.(type) {
+	case *model.ViewEvent:
+		return v == nil
+	case *model.ActionEvent:
+		return v == nil
+	case *model.ResourceEvent:
+		return v == nil
+	case *model.ErrorEvent:
+		return v == nil
+	case *model.LongTaskEvent:
+		return v == nil
+	case *model.VitalEvent:
+		return v == nil
+	default:
+		return false
+	}
+}

--- a/pkg/collector/receiver/datadogrum/internal/validator/validator_test.go
+++ b/pkg/collector/receiver/datadogrum/internal/validator/validator_test.go
@@ -1,0 +1,30 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/collector/receiver/datadogrum/internal/model"
+)
+
+func TestValidateCommonRequiresSessionIDWhenPresent(t *testing.T) {
+	v := New()
+	event := &model.ActionEvent{CommonFields: model.CommonFields{
+		Date:        1,
+		Type:        model.EventTypeAction,
+		Application: model.Application{ID: "app"},
+		Session:     &model.Session{},
+	}, Action: model.Action{Present: true}}
+	assert.ErrorIs(t, v.Validate(event), model.ErrMissingRequiredField)
+}
+
+func TestValidateViewRequiresID(t *testing.T) {
+	v := New()
+	event := &model.ViewEvent{CommonFields: model.CommonFields{
+		Date:        1,
+		Type:        model.EventTypeView,
+		Application: model.Application{ID: "app"},
+	}, View: model.View{Present: true}}
+	assert.ErrorIs(t, v.Validate(event), model.ErrMissingRequiredField)
+}


### PR DESCRIPTION
新增 Datadog RUM Receiver，支持接收 Datadog RUM 数据并转换为 OTEL 格式。

主要变更：

新增 Datadog RUM HTTP 接收接口，支持 /api/v2/rum 和 /v1/rum。
支持请求体读取、压缩解码、事件解析和数据校验。
支持 View、Action、Resource、Error、Long Task、Vital 等 RUM 事件转换为 OTEL Trace。
新增请求 Token、用户信息及 User-Agent 处理。
新增 Session Replay 接口占位实现。
补充 Decoder、Parser、Converter、Validator 及 HTTP 接口相关测试。