### PR TITLE
fix: UQ 空 Mapping 查询规范化布尔运算符

### DIFF
--- a/pkg/unify-query/internal/lucene_parser/parser.go
+++ b/pkg/unify-query/internal/lucene_parser/parser.go
@@ -86,6 +86,65 @@ func ParseLuceneWithVisitor(ctx context.Context, q string, opt Option) Node {
 	return visitor
 }
 
+// NormalizeBooleanOperators uppercases case-insensitive boolean operators while
+// preserving identical words used as terms or quoted text.
+func NormalizeBooleanOperators(q string) string {
+	lexer := gen.NewLuceneLexer(antlr.NewInputStream(q))
+	lexerErrorListener := NewCustomErrorListener()
+	lexer.RemoveErrorListeners()
+	lexer.AddErrorListener(lexerErrorListener)
+
+	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	parser := gen.NewLuceneParser(tokens)
+	parserErrorListener := NewCustomErrorListener()
+	parser.RemoveErrorListeners()
+	parser.AddErrorListener(parserErrorListener)
+
+	query := parser.TopLevelQuery()
+	if lexerErrorListener.HasErrors() || parserErrorListener.HasErrors() || query == nil {
+		return q
+	}
+
+	normalizer := &booleanOperatorNormalizer{
+		BaseLuceneParserListener: &gen.BaseLuceneParserListener{},
+		query:                    []rune(q),
+	}
+	antlr.ParseTreeWalkerDefault.Walk(normalizer, query)
+	return string(normalizer.query)
+}
+
+type booleanOperatorNormalizer struct {
+	*gen.BaseLuceneParserListener
+	query []rune
+}
+
+func (n *booleanOperatorNormalizer) EnterDisjQuery(ctx *gen.DisjQueryContext) {
+	for _, operator := range ctx.AllOR() {
+		n.replace(operator.GetSymbol(), "OR")
+	}
+}
+
+func (n *booleanOperatorNormalizer) EnterConjQuery(ctx *gen.ConjQueryContext) {
+	for _, operator := range ctx.AllAND() {
+		n.replace(operator.GetSymbol(), "AND")
+	}
+}
+
+func (n *booleanOperatorNormalizer) EnterModifier(ctx *gen.ModifierContext) {
+	if operator := ctx.NOT(); operator != nil {
+		n.replace(operator.GetSymbol(), "NOT")
+	}
+}
+
+func (n *booleanOperatorNormalizer) replace(token antlr.Token, replacement string) {
+	start, stop := token.GetStart(), token.GetStop()
+	replacementRunes := []rune(replacement)
+	if start < 0 || stop >= len(n.query) || stop-start+1 != len(replacementRunes) {
+		return
+	}
+	copy(n.query[start:stop+1], replacementRunes)
+}
+
 // CustomErrorListener captures syntax errors during parsing
 type CustomErrorListener struct {
 	*antlr.DefaultErrorListener

--- a/pkg/unify-query/internal/lucene_parser/parser.go
+++ b/pkg/unify-query/internal/lucene_parser/parser.go
@@ -86,10 +86,11 @@ func ParseLuceneWithVisitor(ctx context.Context, q string, opt Option) Node {
 	return visitor
 }
 
-// NormalizeBooleanOperators uppercases case-insensitive boolean operators while
-// preserving identical words used as terms or quoted text.
-func NormalizeBooleanOperators(q string) string {
-	lexer := gen.NewLuceneLexer(antlr.NewInputStream(q))
+// NormalizeQueryStringSyntax adapts UQ-compatible query syntax before it is
+// delegated to a native query_string parser.
+func NormalizeQueryStringSyntax(q string) string {
+	normalizedQuery := convertSingleQuotes(q)
+	lexer := gen.NewLuceneLexer(antlr.NewInputStream(normalizedQuery))
 	lexerErrorListener := NewCustomErrorListener()
 	lexer.RemoveErrorListeners()
 	lexer.AddErrorListener(lexerErrorListener)
@@ -107,10 +108,10 @@ func NormalizeBooleanOperators(q string) string {
 
 	normalizer := &booleanOperatorNormalizer{
 		BaseLuceneParserListener: &gen.BaseLuceneParserListener{},
-		query:                    []rune(q),
+		query:                    []rune(normalizedQuery),
 	}
 	antlr.ParseTreeWalkerDefault.Walk(normalizer, query)
-	return string(normalizer.query)
+	return strings.TrimRight(string(normalizer.query), " \t\n\r\u3000")
 }
 
 type booleanOperatorNormalizer struct {
@@ -119,13 +120,23 @@ type booleanOperatorNormalizer struct {
 }
 
 func (n *booleanOperatorNormalizer) EnterDisjQuery(ctx *gen.DisjQueryContext) {
-	for _, operator := range ctx.AllOR() {
+	operators := ctx.AllOR()
+	for i, operator := range operators {
+		if i == len(operators)-1 && len(operators) == len(ctx.AllConjQuery()) {
+			n.remove(operator.GetSymbol())
+			continue
+		}
 		n.replace(operator.GetSymbol(), "OR")
 	}
 }
 
 func (n *booleanOperatorNormalizer) EnterConjQuery(ctx *gen.ConjQueryContext) {
-	for _, operator := range ctx.AllAND() {
+	operators := ctx.AllAND()
+	for i, operator := range operators {
+		if i == len(operators)-1 && len(operators) == len(ctx.AllModClause()) {
+			n.remove(operator.GetSymbol())
+			continue
+		}
 		n.replace(operator.GetSymbol(), "AND")
 	}
 }
@@ -143,6 +154,16 @@ func (n *booleanOperatorNormalizer) replace(token antlr.Token, replacement strin
 		return
 	}
 	copy(n.query[start:stop+1], replacementRunes)
+}
+
+func (n *booleanOperatorNormalizer) remove(token antlr.Token) {
+	start, stop := token.GetStart(), token.GetStop()
+	if start < 0 || stop >= len(n.query) {
+		return
+	}
+	for i := start; i <= stop; i++ {
+		n.query[i] = ' '
+	}
 }
 
 // CustomErrorListener captures syntax errors during parsing

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/README.md
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/README.md
@@ -17,12 +17,12 @@ sanitized request
 
 ## 当前覆盖
 
-数据集当前包含 43 个可执行 case。其中 17 个 case 的 input 与当前 expected outputs 均直接来自可关联的生产历史日志；24 个问题回归 case 的 expected outputs 由修复后的真实 handler 重新回放，其中 2 个 TSpider case 有生产 trace 证据，4 个 ES case 有生产日志或 trace 证据，另外 18 个 ES/Doris case 的问题形态与旧行为来自已合并 PR 的生产问题描述、测试和修复前 commit 回放，来源明确标记为 `merged_pr`；另有 2 个只有生产 input 形态的 provisional case，分别覆盖 ES 请求级批处理和 InfluxDB aggregate，outputs 由固定 fixture 经当前真实 handler 回放得到，不计入生产 output 采样收敛。
+数据集当前包含 45 个可执行 case。其中 17 个 case 的 input 与当前 expected outputs 均直接来自可关联的生产历史日志；26 个问题回归 case 的 expected outputs 由修复后的真实 handler 重新回放，其中 2 个 TSpider case 有生产 trace 证据，4 个 ES case 有生产日志或 trace 证据，另外 20 个 ES/Doris case 的问题形态与旧行为来自已合并 PR 的生产问题描述、测试和修复前 commit 回放，来源明确标记为 `merged_pr`；另有 2 个只有生产 input 形态的 provisional case，分别覆盖 ES 请求级批处理和 InfluxDB aggregate，outputs 由固定 fixture 经当前真实 handler 回放得到，不计入生产 output 采样收敛。
 
 | 分类 | Case 数 | 已覆盖形态 | Output 来源 |
 | --- | ---: | --- | --- |
 | VictoriaMetrics | 5 | PromQL range/instant、结构化 instant、复杂聚合/区间/二元表达式、多结果表合并 | 生产日志 |
-| Elasticsearch | 21 | aggregate/raw/reference、请求级开启的显式双 `query_list` 同连接批处理、query_string 语义、无引号保留字符转义与转义字符串区间、整份 mapping 缺失时回退原生 query_string 并规范化混合大小写布尔运算符、聚合枚举提取、字段元数据滞后、多 RT 无效索引跳过、缺排序字段 mapping 的空索引判定与重试、data source 别名、`table_id_conditions` 查询与 field_map | 生产日志 + 修复后 handler 回放 + 暂定 handler 回放 |
+| Elasticsearch | 23 | aggregate/raw/reference、请求级开启的显式双 `query_list` 同连接批处理、query_string 语义、无引号保留字符转义与转义字符串区间、整份 mapping 缺失时回退原生 query_string、规范化混合大小写布尔运算符、适配单引号短语并忽略尾部运算符、聚合枚举提取、字段元数据滞后、多 RT 无效索引跳过、缺排序字段 mapping 的空索引判定与重试、data source 别名、`table_id_conditions` 查询与 field_map | 生产日志 + 修复后 handler 回放 + 暂定 handler 回放 |
 | Doris | 11 | aggregate、raw、单 reference 七路由/十四 output、ES→Doris 时间分段路由、多表显式投影、`SELECT *` 类型交集、对象叶子大小写/精度、缺失字段 contains、平台分钟字段 UNION 依赖、raw 字段别名回退、缺失 `__shard_key__` 的时间桶回退 | 生产日志 + 修复后 handler 回放 |
 | TSpider | 3 | aggregate、raw、PromQL 8 reference/16 output | 生产日志 + 修复后 handler 回放 |
 | HDFS | 2 | aggregate、raw | 生产日志 |
@@ -42,11 +42,13 @@ sanitized request
 
 `tspider_promql_multi_reference_001` 来自后续问题修复：一个 PromQL input 解析出 8 个 reference，固定路由为每个 reference 选择同一个 BKSQL 结果表，每个 reference 再产生 schema + aggregate 两个请求，因此完整 output multiset 为 16 条。该 case 同时锁定 TSpider 时间桶必须按完整表达式分组，不能按 SELECT 别名 `_timestamp_` 分组。
 
-18 个合并 PR 回溯 case 锁定 ES query_string 的 regexp、wildcard、布尔词项和聚合枚举语义，显式路由字段元数据滞后、多 RT 空索引跳过、缺排序字段 mapping 的空索引判定与重试、data source 别名、`table_id_conditions` 与 field_map，以及 Doris 多物理表 UNION、平台分钟字段的内部时间字段依赖、raw 字段别名回退、缺失 `__shard_key__` 的时间桶回退和缺失字段 contains。它们没有保留原始 trace ID，均在修复前 commit 得到 RED、在当前代码得到 GREEN，因此只计入问题回归覆盖，不改写前述分类采样收敛统计。多数 ES case 为 `1 input × 1 reference × 1 route × 2 stages = 2 outputs`；field_map 只生成 index/mapping 请求，多 RT 跳过 case 只保留有效 RT 的 2 个 outputs。缺 mapping fallback case 生成 1 条 alias/index 元数据请求和首次查询、精确空检查、重试共 3 条 search 请求。平台分钟字段和部分物理表缺少 `__shard_key__` 两个 Doris UNION case 各生成 2 条 schema 请求和 1 条合并查询，raw 字段别名回退 case 生成 1 条 schema 请求和 1 条查询。
+20 个合并 PR 回溯 case 锁定 ES query_string 的 regexp、wildcard、布尔词项、单引号短语、尾部运算符和聚合枚举语义，显式路由字段元数据滞后、多 RT 空索引跳过、缺排序字段 mapping 的空索引判定与重试、data source 别名、`table_id_conditions` 与 field_map，以及 Doris 多物理表 UNION、平台分钟字段的内部时间字段依赖、raw 字段别名回退、缺失 `__shard_key__` 的时间桶回退和缺失字段 contains。它们没有保留原始 trace ID，均在修复前 commit 得到 RED、在当前代码得到 GREEN，因此只计入问题回归覆盖，不改写前述分类采样收敛统计。多数 ES case 为 `1 input × 1 reference × 1 route × 2 stages = 2 outputs`；field_map 只生成 index/mapping 请求，多 RT 跳过 case 只保留有效 RT 的 2 个 outputs。缺 mapping fallback case 生成 1 条 alias/index 元数据请求和首次查询、精确空检查、重试共 3 条 search 请求。平台分钟字段和部分物理表缺少 `__shard_key__` 两个 Doris UNION case 各生成 2 条 schema 请求和 1 条合并查询，raw 字段别名回退 case 生成 1 条 schema 请求和 1 条查询。
 
 `es_query_string_missing_mapping_phrase_001` 来自可关联的生产日志和 trace：ES mapping 元数据短暂为空，但同一索引的 search 已正常命中。修复前 handler 将否定短语生成 `term`；修复后在整份 mapping 缺失时回退原生 `query_string`，由实际搜索分片按真实 mapping 解析。该 case 使用同一份脱敏 input 和固定依赖完成 RED→GREEN，不把失败 DSL 固化为正确答案。
 
 `es_query_string_missing_mapping_mixed_case_boolean_001` 补齐同一空 mapping 回退路径中的混合大小写布尔语义。修复前 handler 把小写运算符原样下发；修复后只规范化语法树中实际承担布尔运算的 token，引号内容和字段值中的同名词保持不变。该 case 的 input 形态来自可关联生产日志，expected 由修复后真实 handler 回放生成。
+
+`es_query_string_missing_mapping_single_quote_001` 和 `es_query_string_missing_mapping_trailing_boolean_001` 回溯 #1420 空 mapping 分支绕过既有语法适配的两个兄弟缺口：前者先把单引号短语适配为双引号并保持短语内容，后者忽略尾部 `AND/OR`。两者没有关联生产日志或 trace，来源明确标记为 `merged_pr`，均使用固定 fixture 完成 handler RED→GREEN。
 
 生产采样过程、W1～W7 的形似分布和当前边界见 [SAMPLING.md](SAMPLING.md)。
 

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/README.md
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/README.md
@@ -17,12 +17,12 @@ sanitized request
 
 ## 当前覆盖
 
-数据集当前包含 42 个可执行 case。其中 17 个 case 的 input 与当前 expected outputs 均直接来自可关联的生产历史日志；23 个问题回归 case 的 expected outputs 由修复后的真实 handler 重新回放，其中 2 个 TSpider case 有生产 trace 证据，3 个 ES case 有生产日志或 trace 证据，另外 18 个 ES/Doris case 的问题形态与旧行为来自已合并 PR 的生产问题描述、测试和修复前 commit 回放，来源明确标记为 `merged_pr`；另有 2 个只有生产 input 形态的 provisional case，分别覆盖 ES 请求级批处理和 InfluxDB aggregate，outputs 由固定 fixture 经当前真实 handler 回放得到，不计入生产 output 采样收敛。
+数据集当前包含 43 个可执行 case。其中 17 个 case 的 input 与当前 expected outputs 均直接来自可关联的生产历史日志；24 个问题回归 case 的 expected outputs 由修复后的真实 handler 重新回放，其中 2 个 TSpider case 有生产 trace 证据，4 个 ES case 有生产日志或 trace 证据，另外 18 个 ES/Doris case 的问题形态与旧行为来自已合并 PR 的生产问题描述、测试和修复前 commit 回放，来源明确标记为 `merged_pr`；另有 2 个只有生产 input 形态的 provisional case，分别覆盖 ES 请求级批处理和 InfluxDB aggregate，outputs 由固定 fixture 经当前真实 handler 回放得到，不计入生产 output 采样收敛。
 
 | 分类 | Case 数 | 已覆盖形态 | Output 来源 |
 | --- | ---: | --- | --- |
 | VictoriaMetrics | 5 | PromQL range/instant、结构化 instant、复杂聚合/区间/二元表达式、多结果表合并 | 生产日志 |
-| Elasticsearch | 20 | aggregate/raw/reference、请求级开启的显式双 `query_list` 同连接批处理、query_string 语义、无引号保留字符转义与转义字符串区间、整份 mapping 缺失时回退原生 query_string、聚合枚举提取、字段元数据滞后、多 RT 无效索引跳过、缺排序字段 mapping 的空索引判定与重试、data source 别名、`table_id_conditions` 查询与 field_map | 生产日志 + 修复后 handler 回放 + 暂定 handler 回放 |
+| Elasticsearch | 21 | aggregate/raw/reference、请求级开启的显式双 `query_list` 同连接批处理、query_string 语义、无引号保留字符转义与转义字符串区间、整份 mapping 缺失时回退原生 query_string 并规范化混合大小写布尔运算符、聚合枚举提取、字段元数据滞后、多 RT 无效索引跳过、缺排序字段 mapping 的空索引判定与重试、data source 别名、`table_id_conditions` 查询与 field_map | 生产日志 + 修复后 handler 回放 + 暂定 handler 回放 |
 | Doris | 11 | aggregate、raw、单 reference 七路由/十四 output、ES→Doris 时间分段路由、多表显式投影、`SELECT *` 类型交集、对象叶子大小写/精度、缺失字段 contains、平台分钟字段 UNION 依赖、raw 字段别名回退、缺失 `__shard_key__` 的时间桶回退 | 生产日志 + 修复后 handler 回放 |
 | TSpider | 3 | aggregate、raw、PromQL 8 reference/16 output | 生产日志 + 修复后 handler 回放 |
 | HDFS | 2 | aggregate、raw | 生产日志 |
@@ -45,6 +45,8 @@ sanitized request
 18 个合并 PR 回溯 case 锁定 ES query_string 的 regexp、wildcard、布尔词项和聚合枚举语义，显式路由字段元数据滞后、多 RT 空索引跳过、缺排序字段 mapping 的空索引判定与重试、data source 别名、`table_id_conditions` 与 field_map，以及 Doris 多物理表 UNION、平台分钟字段的内部时间字段依赖、raw 字段别名回退、缺失 `__shard_key__` 的时间桶回退和缺失字段 contains。它们没有保留原始 trace ID，均在修复前 commit 得到 RED、在当前代码得到 GREEN，因此只计入问题回归覆盖，不改写前述分类采样收敛统计。多数 ES case 为 `1 input × 1 reference × 1 route × 2 stages = 2 outputs`；field_map 只生成 index/mapping 请求，多 RT 跳过 case 只保留有效 RT 的 2 个 outputs。缺 mapping fallback case 生成 1 条 alias/index 元数据请求和首次查询、精确空检查、重试共 3 条 search 请求。平台分钟字段和部分物理表缺少 `__shard_key__` 两个 Doris UNION case 各生成 2 条 schema 请求和 1 条合并查询，raw 字段别名回退 case 生成 1 条 schema 请求和 1 条查询。
 
 `es_query_string_missing_mapping_phrase_001` 来自可关联的生产日志和 trace：ES mapping 元数据短暂为空，但同一索引的 search 已正常命中。修复前 handler 将否定短语生成 `term`；修复后在整份 mapping 缺失时回退原生 `query_string`，由实际搜索分片按真实 mapping 解析。该 case 使用同一份脱敏 input 和固定依赖完成 RED→GREEN，不把失败 DSL 固化为正确答案。
+
+`es_query_string_missing_mapping_mixed_case_boolean_001` 补齐同一空 mapping 回退路径中的混合大小写布尔语义。修复前 handler 把小写运算符原样下发；修复后只规范化语法树中实际承担布尔运算的 token，引号内容和字段值中的同名词保持不变。该 case 的 input 形态来自可关联生产日志，expected 由修复后真实 handler 回放生成。
 
 生产采样过程、W1～W7 的形似分布和当前边界见 [SAMPLING.md](SAMPLING.md)。
 

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/SAMPLING.md
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/SAMPLING.md
@@ -129,6 +129,8 @@ W7 的 VM range 选取样本包含结构化和 PromQL 入口，VM instant 选取
 
 2026-07-27 又从一条可关联的生产问题请求中确认了 ES mapping 元数据暂时为空、search 数据面仍可用的形态。脱敏后的 `es_query_string_missing_mapping_phrase_001` 保留 aggregate query、否定引号短语、空 mapping 依赖和最终 search 两阶段输出。修复前相同 fixture 将短语生成 `term`，修复后回退原生 `query_string`，RED→GREEN 的唯一预期差异位于 search DSL；该问题驱动 case 不改变 W1～W7 分类采样收敛统计。
 
+2026-08-04 在同一空 mapping 回退路径中确认了混合大小写布尔运算符的语义缺口。新增 `es_query_string_missing_mapping_mixed_case_boolean_001`，保留脱敏后的复合否定、通配条件和小写 `and` 结构。修复前 handler 将小写运算符原样交给 ES 原生 `query_string`，修复后只把语法树中的布尔运算 token 规范化为大写，引号内容和字段值中的同名词保持不变；该问题驱动 case 同样不改变 W1～W7 分类采样收敛统计。
+
 ### 请求级 ES 批处理形态扩充
 
 2026-07-29 基于用户提供的生产 Trace 查询页面形态和当前 APM→UQ 源码调用链，新增 `es_raw_explicit_multi_rt_batch_001`。该 case 只保留两个显式 `query_list` RT、相同 TraceID 过滤条件、同一实际 ES 连接和顶层 `is_es_batch=true`；原始 TraceID、应用、空间、结果表、索引和集群均未进入正式数据集。
@@ -204,12 +206,13 @@ W7 的 VM range 选取样本包含结构化和 PromQL 入口，VM instant 选取
 
 2026-07-23 的 9 个新增 case，以及 2026-07-24 为 #1403、#1404、#1405、#1408 新增的 4 个 case，其问题形态均来自已合并 PR 的问题描述、回归测试和代码修复，不保留原始 trace ID。每个 case 均使用同一份脱敏 request、固定 route/dependencies，在对应修复 PR 的第一父提交先得到 RED，再在当前代码得到 GREEN；当前 expected 由真实 handler 生成并标记为 `post_fix_handler_replay`。它们的 `source.kind` 均为 `merged_pr`，不声称来自已关联的生产日志或 trace，也不计入 W1～W7 分类采样的 production output 收敛统计。
 
-#1420 的 input 形态来自可关联的生产日志和 trace，因此使用 `source.kind=production_log`；正确 expected 由修复后的真实 handler 回放生成并标记为 `post_fix_handler_replay`、`post_fix_expected`，不计入 W1～W7 分类采样窗口的新增形似统计。
+#1420 及本次空 mapping 小写布尔后续回归的 input 形态来自可关联的生产日志和 trace，因此使用 `source.kind=production_log`；正确 expected 由修复后的真实 handler 回放生成并标记为 `post_fix_handler_replay`、`post_fix_expected`，不计入 W1～W7 分类采样窗口的新增形似统计。
 
 历史 RED 的判定点如下：
 
 | PR | 修复前可观察差异 |
 | --- | --- |
+| #1420 后续 | 空 mapping 下小写布尔运算符原样进入原生 `query_string`，与 UQ 的大小写不敏感语义不一致 |
 | #1420 | 空 mapping 下否定短语被生成 `must_not term`，而不是交给原生 `query_string` 解析 |
 | #1408 | 两张物理表中一张缺少 `__shard_key__`，handler 以多表 UNION 字段缺失返回 HTTP 400；修复后整体回退到 `dtEventTimeStamp` 时间桶 |
 | #1405 | raw 查询生成 `NULL AS _value_` 和 `ORDER BY NULL DESC`，而不是回退使用别名前字段 `dtEventTimeStamp` |

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/SAMPLING.md
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/SAMPLING.md
@@ -131,6 +131,8 @@ W7 的 VM range 选取样本包含结构化和 PromQL 入口，VM instant 选取
 
 2026-08-04 在同一空 mapping 回退路径中确认了混合大小写布尔运算符的语义缺口。新增 `es_query_string_missing_mapping_mixed_case_boolean_001`，保留脱敏后的复合否定、通配条件和小写 `and` 结构。修复前 handler 将小写运算符原样交给 ES 原生 `query_string`，修复后只把语法树中的布尔运算 token 规范化为大写，引号内容和字段值中的同名词保持不变；该问题驱动 case 同样不改变 W1～W7 分类采样收敛统计。
 
+同日继续按 #1420 已合并代码和仓库既有 parser 契约回溯，补充 `es_query_string_missing_mapping_single_quote_001` 与 `es_query_string_missing_mapping_trailing_boolean_001`。前者在修复前把单引号短语内部 `and` 改写为运算符，后者把尾部 `AND` 原样交给严格的 ES 原生语法；修复后分别恢复短语适配和尾部运算符忽略。两条 case 没有关联生产日志或 trace，使用 `source.kind=merged_pr` 和修复后 handler expected，不计入 W1～W7 分类采样收敛。
+
 ### 请求级 ES 批处理形态扩充
 
 2026-07-29 基于用户提供的生产 Trace 查询页面形态和当前 APM→UQ 源码调用链，新增 `es_raw_explicit_multi_rt_batch_001`。该 case 只保留两个显式 `query_list` RT、相同 TraceID 过滤条件、同一实际 ES 连接和顶层 `is_es_batch=true`；原始 TraceID、应用、空间、结果表、索引和集群均未进入正式数据集。
@@ -156,7 +158,7 @@ W7 的 VM range 选取样本包含结构化和 PromQL 入口，VM instant 选取
 
 | PR | 查询处理影响 | Golden 处理 |
 | --- | --- | --- |
-| #1420 | 整份 ES mapping 为空时否定短语被错误构造成 `term` | 已合入 `es_query_string_missing_mapping_phrase_001` |
+| #1420 | 整份 ES mapping 为空时否定短语被错误构造成 `term`；回退原生语法后又绕过单引号短语和尾部运算符兼容契约 | 已有 `es_query_string_missing_mapping_phrase_001`，补充 `es_query_string_missing_mapping_single_quote_001`、`es_query_string_missing_mapping_trailing_boolean_001` |
 | #1413 | TSpider 时间桶错误按 `_timestamp_` 别名分组 | 既有 `tspider_promql_multi_reference_001` 精确覆盖 |
 | #1408 | 任一 Doris 物理表缺失 `__shard_key__` 时仍错误使用该字段构造时间桶 | 新增 `doris_missing_shard_key_time_bucket_001` |
 | #1407 | 分段路由切换时过滤 lookback 重复或越界样本 | 范围外；属于查询结果 series 合并与过滤，不改变下游请求构造 |
@@ -206,12 +208,13 @@ W7 的 VM range 选取样本包含结构化和 PromQL 入口，VM instant 选取
 
 2026-07-23 的 9 个新增 case，以及 2026-07-24 为 #1403、#1404、#1405、#1408 新增的 4 个 case，其问题形态均来自已合并 PR 的问题描述、回归测试和代码修复，不保留原始 trace ID。每个 case 均使用同一份脱敏 request、固定 route/dependencies，在对应修复 PR 的第一父提交先得到 RED，再在当前代码得到 GREEN；当前 expected 由真实 handler 生成并标记为 `post_fix_handler_replay`。它们的 `source.kind` 均为 `merged_pr`，不声称来自已关联的生产日志或 trace，也不计入 W1～W7 分类采样的 production output 收敛统计。
 
-#1420 及本次空 mapping 小写布尔后续回归的 input 形态来自可关联的生产日志和 trace，因此使用 `source.kind=production_log`；正确 expected 由修复后的真实 handler 回放生成并标记为 `post_fix_handler_replay`、`post_fix_expected`，不计入 W1～W7 分类采样窗口的新增形似统计。
+#1420 原始否定短语及本次空 mapping 小写布尔后续回归的 input 形态来自可关联的生产日志和 trace，因此使用 `source.kind=production_log`。单引号短语与尾部运算符两个兄弟缺口只由 #1420 已合并代码和既有测试契约确认，使用 `source.kind=merged_pr`，不声称存在对应生产 trace。四条正确 expected 均由修复后的真实 handler 回放生成并标记为 `post_fix_handler_replay`、`post_fix_expected`，不计入 W1～W7 分类采样窗口的新增形似统计。
 
 历史 RED 的判定点如下：
 
 | PR | 修复前可观察差异 |
 | --- | --- |
+| #1420 契约回溯 | 空 mapping 下单引号短语内部 `and` 被改写为运算符；尾部 `AND/OR` 没有被忽略 |
 | #1420 后续 | 空 mapping 下小写布尔运算符原样进入原生 `query_string`，与 UQ 的大小写不敏感语义不一致 |
 | #1420 | 空 mapping 下否定短语被生成 `must_not term`，而不是交给原生 `query_string` 解析 |
 | #1408 | 两张物理表中一张缺少 `__shard_key__`，handler 以多表 UNION 字段缺失返回 HTTP 400；修复后整体回退到 `dtEventTimeStamp` 时间桶 |

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/case.yaml
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/case.yaml
@@ -1,0 +1,26 @@
+id: es_query_string_missing_mapping_mixed_case_boolean_001
+storage: es
+enabled: true
+shape_signature: query_ts/range/es/aggregate/query_string/mixed_case_boolean/mapping_empty/output_index_search
+source:
+  kind: production_log
+  outputs_kind: post_fix_handler_replay
+  sampled_at: "2026-08-04"
+  fingerprint: sha256:9f7374bb2d8921598154a8c5469b4b398dfde16183960de35007be35f95a0c23
+tags:
+  - query_ts_api
+  - aggregation
+  - query_string
+  - missing_mapping
+  - case_insensitive_boolean
+  - post_fix_expected
+  - regression_fix
+  - production_shape
+notes:
+  - 生产问题形态仅保留 mapping 为空时混合大小写布尔查询的结构，所有标识和值均已不可逆替换。
+  - 正确 output 仅规范化布尔运算符，字段解析仍由实际搜索分片的原生 query_string 完成。
+files:
+  request: request.json
+  route: route.json
+  dependencies: dependencies.json
+  expect_outputs: expect.outputs.json

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/dependencies.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/dependencies.json
@@ -1,0 +1,14 @@
+{
+  "elasticsearch": {
+    "mapping": {},
+    "search": {
+      "took": 1,
+      "timed_out": false,
+      "hits": {
+        "total": {"value": 0, "relation": "eq"},
+        "hits": []
+      },
+      "aggregations": {}
+    }
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/expect.outputs.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/expect.outputs.json
@@ -1,0 +1,70 @@
+[
+  {
+    "backend": "elasticsearch",
+    "method": "GET",
+    "path": "/golden_mixed_case_boolean_logs"
+  },
+  {
+    "backend": "elasticsearch",
+    "method": "POST",
+    "path": "/golden_mixed_case_boolean_logs/_search",
+    "body": {
+      "aggregations": {
+        "service": {
+          "aggregations": {
+            "dtEventTimeStamp": {
+              "aggregations": {
+                "_value": {
+                  "value_count": {
+                    "field": "events_total"
+                  }
+                }
+              },
+              "date_histogram": {
+                "extended_bounds": {
+                  "max": 1784702135999,
+                  "min": 1784701739999
+                },
+                "field": "dtEventTimeStamp",
+                "interval": "1m",
+                "min_doc_count": 0,
+                "time_zone": "UTC"
+              }
+            }
+          },
+          "terms": {
+            "field": "service",
+            "missing": " ",
+            "size": 10000
+          }
+        }
+      },
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "range": {
+                "dtEventTimeStamp": {
+                  "format": "epoch_second",
+                  "from": 1784701739,
+                  "include_lower": true,
+                  "include_upper": true,
+                  "to": 1784702135
+                }
+              }
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "fields": ["*", "__*"],
+                "lenient": true,
+                "query": "(NOT client_id:\"demo-a\" AND NOT client_id:\"demo-b\") AND action:req-* AND endpoint:edge-*"
+              }
+            }
+          ]
+        }
+      },
+      "size": 0
+    }
+  }
+]

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/request.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/request.json
@@ -1,0 +1,42 @@
+{
+  "method": "POST",
+  "path": "/query/ts",
+  "headers": {
+    "Content-Type": "application/json",
+    "Bk-Query-Source": "golden",
+    "X-Bk-Scope-Space-Uid": "bkcc__golden_es_mixed_case_boolean",
+    "X-Bk-Tenant-Id": "tenant_golden"
+  },
+  "body": {
+    "space_uid": "bkcc__golden_es_mixed_case_boolean",
+    "query_list": [
+      {
+        "data_source": "bk_log",
+        "table_id": "demo_boolean_logs.partition_1",
+        "field_name": "events_total",
+        "function": [
+          {
+            "method": "sum",
+            "dimensions": ["service"]
+          }
+        ],
+        "time_aggregation": {
+          "function": "count_over_time",
+          "window": "1m"
+        },
+        "reference_name": "a",
+        "conditions": {
+          "field_list": [],
+          "condition_list": []
+        },
+        "query_string": "(NOT client_id:\"demo-a\" AND NOT client_id:\"demo-b\") and action:req-* and endpoint:edge-*"
+      }
+    ],
+    "metric_merge": "a",
+    "start_time": "1784701776",
+    "end_time": "1784702076",
+    "step": "60s",
+    "timezone": "UTC",
+    "instant": false
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/route.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_mixed_case_boolean_001/route.json
@@ -1,0 +1,27 @@
+{
+  "space_uid": "bkcc__golden_es_mixed_case_boolean",
+  "result_tables": [
+    {
+      "table_id": "demo_boolean_logs.partition_1"
+    }
+  ],
+  "result_table_details": {
+    "demo_boolean_logs.partition_1": {
+      "storage_id": 2003,
+      "storage_name": "es_cluster_mixed_case_boolean",
+      "storage_type": "elasticsearch",
+      "cluster_name": "es_cluster_mixed_case_boolean",
+      "db": "golden_mixed_case_boolean_logs",
+      "table_id": "demo_boolean_logs.partition_1",
+      "fields": ["events_total"],
+      "data_label": "demo_boolean_logs",
+      "tags_key": ["service"],
+      "source_type": "bklog"
+    }
+  },
+  "storages": {
+    "2003": {
+      "type": "elasticsearch"
+    }
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/case.yaml
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/case.yaml
@@ -1,0 +1,25 @@
+id: es_query_string_missing_mapping_single_quote_001
+storage: es
+enabled: true
+shape_signature: query_ts/range/es/aggregate/query_string/single_quote_phrase/mapping_empty/output_index_search
+source:
+  kind: merged_pr
+  outputs_kind: post_fix_handler_replay
+  sampled_at: "2026-07-27"
+  fingerprint: sha256:d4e4fe429db3a582a9e873e0debc38cadf4f3df0688eb686d24c78fdde0dfa8f
+tags:
+  - query_ts_api
+  - aggregation
+  - query_string
+  - missing_mapping
+  - single_quote_phrase
+  - post_fix_expected
+  - regression_fix
+notes:
+  - 问题形态来自已合并变更和既有单引号短语契约，没有关联生产日志或 trace，不计入生产采样收敛。
+  - 正确 output 先把单引号短语适配为双引号，再只规范化短语外的布尔运算符。
+files:
+  request: request.json
+  route: route.json
+  dependencies: dependencies.json
+  expect_outputs: expect.outputs.json

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/dependencies.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/dependencies.json
@@ -1,0 +1,14 @@
+{
+  "elasticsearch": {
+    "mapping": {},
+    "search": {
+      "took": 1,
+      "timed_out": false,
+      "hits": {
+        "total": {"value": 0, "relation": "eq"},
+        "hits": []
+      },
+      "aggregations": {}
+    }
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/expect.outputs.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/expect.outputs.json
@@ -1,0 +1,70 @@
+[
+  {
+    "backend": "elasticsearch",
+    "method": "GET",
+    "path": "/golden_single_quote_logs"
+  },
+  {
+    "backend": "elasticsearch",
+    "method": "POST",
+    "path": "/golden_single_quote_logs/_search",
+    "body": {
+      "aggregations": {
+        "service": {
+          "aggregations": {
+            "dtEventTimeStamp": {
+              "aggregations": {
+                "_value": {
+                  "value_count": {
+                    "field": "events_total"
+                  }
+                }
+              },
+              "date_histogram": {
+                "extended_bounds": {
+                  "max": 1784702135999,
+                  "min": 1784701739999
+                },
+                "field": "dtEventTimeStamp",
+                "interval": "1m",
+                "min_doc_count": 0,
+                "time_zone": "UTC"
+              }
+            }
+          },
+          "terms": {
+            "field": "service",
+            "missing": " ",
+            "size": 10000
+          }
+        }
+      },
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "range": {
+                "dtEventTimeStamp": {
+                  "format": "epoch_second",
+                  "from": 1784701739,
+                  "include_lower": true,
+                  "include_upper": true,
+                  "to": 1784702135
+                }
+              }
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "fields": ["*", "__*"],
+                "lenient": true,
+                "query": "log:\"error and warning\" AND status:ok"
+              }
+            }
+          ]
+        }
+      },
+      "size": 0
+    }
+  }
+]

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/request.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/request.json
@@ -1,0 +1,42 @@
+{
+  "method": "POST",
+  "path": "/query/ts",
+  "headers": {
+    "Content-Type": "application/json",
+    "Bk-Query-Source": "golden",
+    "X-Bk-Scope-Space-Uid": "bkcc__golden_es_single_quote",
+    "X-Bk-Tenant-Id": "tenant_golden"
+  },
+  "body": {
+    "space_uid": "bkcc__golden_es_single_quote",
+    "query_list": [
+      {
+        "data_source": "bk_log",
+        "table_id": "demo_single_quote_logs.partition_1",
+        "field_name": "events_total",
+        "function": [
+          {
+            "method": "sum",
+            "dimensions": ["service"]
+          }
+        ],
+        "time_aggregation": {
+          "function": "count_over_time",
+          "window": "1m"
+        },
+        "reference_name": "a",
+        "conditions": {
+          "field_list": [],
+          "condition_list": []
+        },
+        "query_string": "log:'error and warning' and status:ok"
+      }
+    ],
+    "metric_merge": "a",
+    "start_time": "1784701776",
+    "end_time": "1784702076",
+    "step": "60s",
+    "timezone": "UTC",
+    "instant": false
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/route.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_single_quote_001/route.json
@@ -1,0 +1,27 @@
+{
+  "space_uid": "bkcc__golden_es_single_quote",
+  "result_tables": [
+    {
+      "table_id": "demo_single_quote_logs.partition_1"
+    }
+  ],
+  "result_table_details": {
+    "demo_single_quote_logs.partition_1": {
+      "storage_id": 2004,
+      "storage_name": "es_cluster_single_quote",
+      "storage_type": "elasticsearch",
+      "cluster_name": "es_cluster_single_quote",
+      "db": "golden_single_quote_logs",
+      "table_id": "demo_single_quote_logs.partition_1",
+      "fields": ["events_total"],
+      "data_label": "demo_single_quote_logs",
+      "tags_key": ["service"],
+      "source_type": "bklog"
+    }
+  },
+  "storages": {
+    "2004": {
+      "type": "elasticsearch"
+    }
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/case.yaml
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/case.yaml
@@ -1,0 +1,25 @@
+id: es_query_string_missing_mapping_trailing_boolean_001
+storage: es
+enabled: true
+shape_signature: query_ts/range/es/aggregate/query_string/trailing_boolean/mapping_empty/output_index_search
+source:
+  kind: merged_pr
+  outputs_kind: post_fix_handler_replay
+  sampled_at: "2026-07-27"
+  fingerprint: sha256:3dead45f919c5666df67963ebec4b1778930ffd7df5b60493323921e04b51746
+tags:
+  - query_ts_api
+  - aggregation
+  - query_string
+  - missing_mapping
+  - trailing_boolean_operator
+  - post_fix_expected
+  - regression_fix
+notes:
+  - 问题形态来自已合并变更和既有尾部运算符兼容契约，没有关联生产日志或 trace，不计入生产采样收敛。
+  - 正确 output 忽略尾部布尔运算符，避免把不完整语法交给原生 query_string。
+files:
+  request: request.json
+  route: route.json
+  dependencies: dependencies.json
+  expect_outputs: expect.outputs.json

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/dependencies.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/dependencies.json
@@ -1,0 +1,14 @@
+{
+  "elasticsearch": {
+    "mapping": {},
+    "search": {
+      "took": 1,
+      "timed_out": false,
+      "hits": {
+        "total": {"value": 0, "relation": "eq"},
+        "hits": []
+      },
+      "aggregations": {}
+    }
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/expect.outputs.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/expect.outputs.json
@@ -1,0 +1,70 @@
+[
+  {
+    "backend": "elasticsearch",
+    "method": "GET",
+    "path": "/golden_trailing_boolean_logs"
+  },
+  {
+    "backend": "elasticsearch",
+    "method": "POST",
+    "path": "/golden_trailing_boolean_logs/_search",
+    "body": {
+      "aggregations": {
+        "service": {
+          "aggregations": {
+            "dtEventTimeStamp": {
+              "aggregations": {
+                "_value": {
+                  "value_count": {
+                    "field": "events_total"
+                  }
+                }
+              },
+              "date_histogram": {
+                "extended_bounds": {
+                  "max": 1784702135999,
+                  "min": 1784701739999
+                },
+                "field": "dtEventTimeStamp",
+                "interval": "1m",
+                "min_doc_count": 0,
+                "time_zone": "UTC"
+              }
+            }
+          },
+          "terms": {
+            "field": "service",
+            "missing": " ",
+            "size": 10000
+          }
+        }
+      },
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "range": {
+                "dtEventTimeStamp": {
+                  "format": "epoch_second",
+                  "from": 1784701739,
+                  "include_lower": true,
+                  "include_upper": true,
+                  "to": 1784702135
+                }
+              }
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "fields": ["*", "__*"],
+                "lenient": true,
+                "query": "log:error AND status:active"
+              }
+            }
+          ]
+        }
+      },
+      "size": 0
+    }
+  }
+]

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/request.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/request.json
@@ -1,0 +1,42 @@
+{
+  "method": "POST",
+  "path": "/query/ts",
+  "headers": {
+    "Content-Type": "application/json",
+    "Bk-Query-Source": "golden",
+    "X-Bk-Scope-Space-Uid": "bkcc__golden_es_trailing_boolean",
+    "X-Bk-Tenant-Id": "tenant_golden"
+  },
+  "body": {
+    "space_uid": "bkcc__golden_es_trailing_boolean",
+    "query_list": [
+      {
+        "data_source": "bk_log",
+        "table_id": "demo_trailing_boolean_logs.partition_1",
+        "field_name": "events_total",
+        "function": [
+          {
+            "method": "sum",
+            "dimensions": ["service"]
+          }
+        ],
+        "time_aggregation": {
+          "function": "count_over_time",
+          "window": "1m"
+        },
+        "reference_name": "a",
+        "conditions": {
+          "field_list": [],
+          "condition_list": []
+        },
+        "query_string": "log:error AND status:active AND"
+      }
+    ],
+    "metric_merge": "a",
+    "start_time": "1784701776",
+    "end_time": "1784702076",
+    "step": "60s",
+    "timezone": "UTC",
+    "instant": false
+  }
+}

--- a/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/route.json
+++ b/pkg/unify-query/internal/online_cases/query_golden_cases/testdata/cases/es/es_query_string_missing_mapping_trailing_boolean_001/route.json
@@ -1,0 +1,27 @@
+{
+  "space_uid": "bkcc__golden_es_trailing_boolean",
+  "result_tables": [
+    {
+      "table_id": "demo_trailing_boolean_logs.partition_1"
+    }
+  ],
+  "result_table_details": {
+    "demo_trailing_boolean_logs.partition_1": {
+      "storage_id": 2005,
+      "storage_name": "es_cluster_trailing_boolean",
+      "storage_type": "elasticsearch",
+      "cluster_name": "es_cluster_trailing_boolean",
+      "db": "golden_trailing_boolean_logs",
+      "table_id": "demo_trailing_boolean_logs.partition_1",
+      "fields": ["events_total"],
+      "data_label": "demo_trailing_boolean_logs",
+      "tags_key": ["service"],
+      "source_type": "bklog"
+    }
+  },
+  "storages": {
+    "2005": {
+      "type": "elasticsearch"
+    }
+  }
+}

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -353,7 +353,7 @@ func (s *FormatFactory) queryString(str string, isPrefix bool) elastic.Query {
 func (f *FormatFactory) ParserQueryString(ctx context.Context, q string, isPrefix bool) elastic.Query {
 	if len(f.fieldsMap) == 0 {
 		// 没有 mapping 时无法可靠区分 text 与 keyword，交由实际 ES 分片按真实 mapping 解析。
-		return f.queryString(lucene_parser.NormalizeBooleanOperators(q), isPrefix)
+		return f.queryString(lucene_parser.NormalizeQueryStringSyntax(q), isPrefix)
 	}
 
 	node := lucene_parser.ParseLuceneWithVisitor(ctx, q, lucene_parser.Option{

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -353,7 +353,7 @@ func (s *FormatFactory) queryString(str string, isPrefix bool) elastic.Query {
 func (f *FormatFactory) ParserQueryString(ctx context.Context, q string, isPrefix bool) elastic.Query {
 	if len(f.fieldsMap) == 0 {
 		// 没有 mapping 时无法可靠区分 text 与 keyword，交由实际 ES 分片按真实 mapping 解析。
-		return f.queryString(q, isPrefix)
+		return f.queryString(lucene_parser.NormalizeBooleanOperators(q), isPrefix)
 	}
 
 	node := lucene_parser.ParseLuceneWithVisitor(ctx, q, lucene_parser.Option{

--- a/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
@@ -277,6 +277,11 @@ func TestParserQueryStringMappingAvailability(t *testing.T) {
 			query:     `message:"告警 and 恢复" and level:error`,
 			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"message:\"告警 and 恢复\" AND level:error"}}`,
 		},
+		"missing mapping adapts single quoted phrases before normalizing operators": {
+			fieldsMap: metadata.FieldsMap{},
+			query:     `log:'error and warning' and status:ok`,
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"log:\"error and warning\" AND status:ok"}}`,
+		},
 		"missing mapping keeps boolean words used as terms": {
 			fieldsMap: metadata.FieldsMap{},
 			query:     `message:and and level:error`,
@@ -286,6 +291,16 @@ func TestParserQueryStringMappingAvailability(t *testing.T) {
 			fieldsMap: metadata.FieldsMap{},
 			query:     `not client_id:"demo-a" or status:ignored`,
 			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"NOT client_id:\"demo-a\" OR status:ignored"}}`,
+		},
+		"missing mapping drops trailing and": {
+			fieldsMap: metadata.FieldsMap{},
+			query:     `log:error AND status:active AND`,
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"log:error AND status:active"}}`,
+		},
+		"missing mapping drops trailing or": {
+			fieldsMap: metadata.FieldsMap{},
+			query:     `status:active or`,
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"status:active"}}`,
 		},
 		"known text field keeps match phrase": {
 			fieldsMap: metadata.FieldsMap{

--- a/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
@@ -259,11 +259,33 @@ func TestParserQueryStringMappingAvailability(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		fieldsMap metadata.FieldsMap
+		query     string
 		expected  string
 	}{
 		"missing mapping falls back to native query string": {
 			fieldsMap: metadata.FieldsMap{},
+			query:     `NOT (message:"ignored phrase")`,
 			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"NOT (message:\"ignored phrase\")"}}`,
+		},
+		"missing mapping normalizes case insensitive boolean operators": {
+			fieldsMap: metadata.FieldsMap{},
+			query:     `(NOT client_id:"demo-a" AND NOT client_id:"demo-b") and action:req-* and endpoint:edge-*`,
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"(NOT client_id:\"demo-a\" AND NOT client_id:\"demo-b\") AND action:req-* AND endpoint:edge-*"}}`,
+		},
+		"missing mapping keeps boolean words inside quoted text": {
+			fieldsMap: metadata.FieldsMap{},
+			query:     `message:"告警 and 恢复" and level:error`,
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"message:\"告警 and 恢复\" AND level:error"}}`,
+		},
+		"missing mapping keeps boolean words used as terms": {
+			fieldsMap: metadata.FieldsMap{},
+			query:     `message:and and level:error`,
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"message:and AND level:error"}}`,
+		},
+		"missing mapping normalizes lowercase not and or": {
+			fieldsMap: metadata.FieldsMap{},
+			query:     `not client_id:"demo-a" or status:ignored`,
+			expected:  `{"query_string":{"analyze_wildcard":true,"fields":["*","__*"],"lenient":true,"query":"NOT client_id:\"demo-a\" OR status:ignored"}}`,
 		},
 		"known text field keeps match phrase": {
 			fieldsMap: metadata.FieldsMap{
@@ -273,6 +295,7 @@ func TestParserQueryStringMappingAvailability(t *testing.T) {
 					IsAnalyzed: true,
 				},
 			},
+			query:    `NOT (message:"ignored phrase")`,
 			expected: `{"bool":{"must_not":{"match_phrase":{"message":{"query":"ignored phrase"}}}}}`,
 		},
 		"known keyword field keeps term": {
@@ -282,13 +305,14 @@ func TestParserQueryStringMappingAvailability(t *testing.T) {
 					FieldType: KeyWord,
 				},
 			},
+			query:    `NOT (message:"ignored phrase")`,
 			expected: `{"bool":{"must_not":{"term":{"message":"ignored phrase"}}}}`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			query := NewFormatFactory(ctx).
 				WithFieldMap(tc.fieldsMap).
-				ParserQueryString(ctx, `NOT (message:"ignored phrase")`, false)
+				ParserQueryString(ctx, tc.query, false)
 			require.NotNil(t, query)
 			body, err := query.Source()
 			require.NoError(t, err)


### PR DESCRIPTION
## 背景

#1420 在整份 ES Mapping 为空时回退原生 query_string，避免缺失字段类型导致错误 DSL。但该分支绕过了 UQ 已有的 query_string 语法兼容：布尔运算符大小写不敏感、单引号表示短语、尾部 AND/OR 可忽略。

## 修改

- 仅在空 Mapping 回退路径中复用单引号短语适配，再根据 Lucene 语法树规范化实际承担布尔运算的 AND、OR、NOT token。
- 忽略语法树中的尾部 AND/OR，避免把不完整语法交给 ES 原生 query_string。
- 保持引号内容及字段值中的同名词不变；解析失败和已有 Mapping 路径不改变。
- 新增 3 个脱敏问题回归 golden case，分别覆盖混合大小写布尔、单引号短语和尾部运算符；数据集增至 45 个 case。

## 验证

- 三类问题均保留修复前单元测试或 handler golden RED，当前代码 GREEN。
- go test ./... -count=1 通过。
- 数据集协议、敏感信息门禁及全量 handler golden 回放通过。