### PR TITLE
fix(bkmonitorbeat): 修复多租户内置 DataID 晚到恢复 --story=136935353

### DIFF
--- a/pkg/bkmonitorbeat/beater/beater.go
+++ b/pkg/bkmonitorbeat/beater/beater.go
@@ -46,13 +46,14 @@ const (
 
 // beaterState beater运行状态
 type beaterState struct {
-	config          *configs.Config
-	name            string
-	version         string
-	ctx             context.Context
-	cancelFunc      context.CancelFunc
-	heartBeatTicker *time.Ticker
-	tcli            *tenant.Client
+	config               *configs.Config
+	name                 string
+	version              string
+	ctx                  context.Context
+	cancelFunc           context.CancelFunc
+	heartBeatTicker      *time.Ticker
+	tcli                 *tenant.Client
+	tenantDataIDRevision uint64
 
 	Scheduler        define.Scheduler
 	KeywordScheduler define.Scheduler
@@ -244,7 +245,8 @@ func (bt *MonitorBeater) ParseConfig(cfg *common.Config) error {
 	if baseConfig.EnableMultiTenant {
 		tenantTasks = baseConfig.MultiTenantTasks
 	}
-	tenantResolver := tenant.DefaultStorage().NewResolver(tenantTasks)
+	tenantResolver, tenantRevision := tenant.DefaultStorage().NewResolverSnapshot(tenantTasks)
+	bt.tenantDataIDRevision = tenantRevision
 	bt.configEngine = NewBaseConfigEngine(ctx)
 	bt.configEngine.(*BaseConfigEngine).SetTenantDataIDResolver(tenantResolver)
 	err = bt.configEngine.Init(cfg, bt)
@@ -289,6 +291,35 @@ func commitTenantDataIDConfig(config *configs.Config) {
 		tasks = config.MultiTenantTasks
 	}
 	tenant.DefaultStorage().SetExpectedTasks(tasks)
+}
+
+func sameTenantClientConfig(oldConfig, newConfig *configs.Config) bool {
+	if oldConfig.EnableMultiTenant != newConfig.EnableMultiTenant {
+		return false
+	}
+	if !oldConfig.EnableMultiTenant {
+		return true
+	}
+	if oldConfig.GseMessageEndpoint != newConfig.GseMessageEndpoint {
+		return false
+	}
+	oldTasks := make(map[string]struct{}, len(oldConfig.MultiTenantTasks))
+	for _, task := range oldConfig.MultiTenantTasks {
+		oldTasks[task] = struct{}{}
+	}
+	newTasks := make(map[string]struct{}, len(newConfig.MultiTenantTasks))
+	for _, task := range newConfig.MultiTenantTasks {
+		newTasks[task] = struct{}{}
+	}
+	if len(oldTasks) != len(newTasks) {
+		return false
+	}
+	for task := range oldTasks {
+		if _, ok := newTasks[task]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // GetTasks 生成任务对象
@@ -632,7 +663,15 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 	oldConfig := bt.config
 	oldConfigEngine := bt.configEngine
 	tenantStorage := tenant.DefaultStorage()
-	tenantStorageRevision := tenantStorage.Revision()
+	candidateConfig := configs.NewConfig()
+	if err := cfg.Unpack(candidateConfig); err != nil {
+		logger.Errorf("MonitorBeater reload error: %v", err)
+		return
+	}
+	if !sameTenantClientConfig(oldConfig, candidateConfig) {
+		logger.Errorf("tenant client config cannot be reloaded; restart bkmonitorbeat to apply the change")
+		return
+	}
 	restoreState := func() {
 		bt.beaterState = oldState
 		bt.config = oldConfig
@@ -645,6 +684,7 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 	state.Scheduler = oldState.Scheduler
 	state.KeywordScheduler = oldState.KeywordScheduler
 	state.ListenScheduler = oldState.ListenScheduler
+	state.tcli = oldState.tcli
 
 	bt.beaterState = state
 	err := bt.ParseConfig(cfg)
@@ -653,7 +693,6 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 		restoreState()
 		return
 	}
-
 	tasks := bt.GetTasks()
 	updateRunningTasks(tasks)
 	bt.loadedTasks += int32(len(tasks))
@@ -696,7 +735,7 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 	}
 	if !reloadFailed {
 		commitTenantDataIDConfig(bt.config)
-		tenantStorage.MarkApplied(tenantStorageRevision)
+		tenantStorage.MarkApplied(bt.tenantDataIDRevision)
 	}
 	metricsReloaded := false
 	if bt.config.BizID != oldConfig.BizID || bt.config.CloudID != oldConfig.CloudID || bt.config.IP != oldConfig.IP {

--- a/pkg/bkmonitorbeat/beater/beater.go
+++ b/pkg/bkmonitorbeat/beater/beater.go
@@ -234,6 +234,11 @@ func (bt *MonitorBeater) ParseConfig(cfg *common.Config) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", define.ErrUnpackCfg, err)
 	}
+	if baseConfig.EnableMultiTenant {
+		tenant.DefaultStorage().SetExpectedTasks(baseConfig.MultiTenantTasks)
+	} else {
+		tenant.DefaultStorage().SetExpectedTasks(nil)
+	}
 	err = bt.initHostIDWatcher(baseConfig)
 	if err != nil {
 		return fmt.Errorf("init hostid failed,error:%s", err)

--- a/pkg/bkmonitorbeat/beater/beater.go
+++ b/pkg/bkmonitorbeat/beater/beater.go
@@ -621,6 +621,15 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 	oldState := bt.beaterState
 	oldConfig := bt.config
 	oldConfigEngine := bt.configEngine
+	tenantStorage := tenant.DefaultStorage()
+	tenantStorageSnapshot := tenantStorage.Snapshot()
+	tenantStorageRevision := tenantStorage.Revision()
+	restoreState := func() {
+		bt.beaterState = oldState
+		bt.config = oldConfig
+		bt.configEngine = oldConfigEngine
+		tenantStorage.Restore(tenantStorageSnapshot)
+	}
 	state := newBeaterState()
 	state.ctx = oldState.ctx
 	state.cancelFunc = oldState.cancelFunc
@@ -633,9 +642,7 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 	err := bt.ParseConfig(cfg)
 	if err != nil {
 		logger.Errorf("MonitorBeater reload error: %v", err)
-		bt.beaterState = oldState
-		bt.config = oldConfig
-		bt.configEngine = oldConfigEngine
+		restoreState()
 		return
 	}
 
@@ -663,24 +670,24 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 	err = bt.Scheduler.Reload(bt.ctx, state.config, beatTasks)
 	if err != nil {
 		logger.Errorf("Scheduler reload error: %v", err)
-		bt.beaterState = oldState
-		bt.config = oldConfig
-		bt.configEngine = oldConfigEngine
+		restoreState()
 		return
 	}
+	reloadFailed := false
 	err = bt.KeywordScheduler.Reload(bt.ctx, state.config, keywordTasks)
 	if err != nil {
 		logger.Errorf("keywordScheduler reload error: %v", err)
-		bt.beaterState = oldState
-		bt.config = oldConfig
-		bt.configEngine = oldConfigEngine
+		restoreState()
+		reloadFailed = true
 	}
 	err = bt.ListenScheduler.Reload(bt.ctx, state.config, listenTasks)
 	if err != nil {
 		logger.Errorf("listenScheduler reload error: %v", err)
-		bt.beaterState = oldState
-		bt.config = oldConfig
-		bt.configEngine = oldConfigEngine
+		restoreState()
+		reloadFailed = true
+	}
+	if !reloadFailed {
+		tenantStorage.MarkApplied(tenantStorageRevision)
 	}
 	metricsReloaded := false
 	if bt.config.BizID != oldConfig.BizID || bt.config.CloudID != oldConfig.CloudID || bt.config.IP != oldConfig.IP {

--- a/pkg/bkmonitorbeat/beater/beater.go
+++ b/pkg/bkmonitorbeat/beater/beater.go
@@ -158,6 +158,7 @@ func New(cfg *common.Config, name, version string) (*MonitorBeater, error) {
 	if err != nil {
 		return nil, err
 	}
+	commitTenantDataIDConfig(bt.config)
 	bt.rawConfig = cfg
 	configs.SetContainerMode(beat.IsContainerMode())
 	state.heartBeatTicker = time.NewTicker(bt.config.HeartBeat.Period)
@@ -234,17 +235,18 @@ func (bt *MonitorBeater) ParseConfig(cfg *common.Config) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", define.ErrUnpackCfg, err)
 	}
-	if baseConfig.EnableMultiTenant {
-		tenant.DefaultStorage().SetExpectedTasks(baseConfig.MultiTenantTasks)
-	} else {
-		tenant.DefaultStorage().SetExpectedTasks(nil)
-	}
 	err = bt.initHostIDWatcher(baseConfig)
 	if err != nil {
 		return fmt.Errorf("init hostid failed,error:%s", err)
 	}
 
+	var tenantTasks []string
+	if baseConfig.EnableMultiTenant {
+		tenantTasks = baseConfig.MultiTenantTasks
+	}
+	tenantResolver := tenant.DefaultStorage().NewResolver(tenantTasks)
 	bt.configEngine = NewBaseConfigEngine(ctx)
+	bt.configEngine.(*BaseConfigEngine).SetTenantDataIDResolver(tenantResolver)
 	err = bt.configEngine.Init(cfg, bt)
 	if err != nil {
 		return fmt.Errorf("init configEngine failed: %v", err)
@@ -279,6 +281,14 @@ func (bt *MonitorBeater) ParseConfig(cfg *common.Config) error {
 	}
 
 	return nil
+}
+
+func commitTenantDataIDConfig(config *configs.Config) {
+	var tasks []string
+	if config.EnableMultiTenant {
+		tasks = config.MultiTenantTasks
+	}
+	tenant.DefaultStorage().SetExpectedTasks(tasks)
 }
 
 // GetTasks 生成任务对象
@@ -622,13 +632,11 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 	oldConfig := bt.config
 	oldConfigEngine := bt.configEngine
 	tenantStorage := tenant.DefaultStorage()
-	tenantStorageSnapshot := tenantStorage.Snapshot()
 	tenantStorageRevision := tenantStorage.Revision()
 	restoreState := func() {
 		bt.beaterState = oldState
 		bt.config = oldConfig
 		bt.configEngine = oldConfigEngine
-		tenantStorage.Restore(tenantStorageSnapshot)
 	}
 	state := newBeaterState()
 	state.ctx = oldState.ctx
@@ -687,6 +695,7 @@ func (bt *MonitorBeater) Reload(cfg *common.Config) {
 		reloadFailed = true
 	}
 	if !reloadFailed {
+		commitTenantDataIDConfig(bt.config)
 		tenantStorage.MarkApplied(tenantStorageRevision)
 	}
 	metricsReloaded := false

--- a/pkg/bkmonitorbeat/beater/configengine.go
+++ b/pkg/bkmonitorbeat/beater/configengine.go
@@ -254,6 +254,9 @@ func (ce *BaseConfigEngine) GetBasicMetaConfig(ucfgConfig *ucfg.Config) (define.
 		logger.Errorf("get task by type failed,error:%v", err)
 		return nil, err
 	}
+	if setter, ok := taskMetaConfig.(configs.TenantDataIDResolverSetter); ok {
+		setter.SetTenantDataIDResolver(ce.tenantDataIDResolver)
+	}
 	return taskMetaConfig, nil
 }
 

--- a/pkg/bkmonitorbeat/beater/configengine.go
+++ b/pkg/bkmonitorbeat/beater/configengine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/beater/taskfactory"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/configs"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tenant"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/libgse/beat"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
@@ -43,9 +44,15 @@ type BaseConfigEngine struct {
 	repeatChildMetaTasks  []*configs.ChildTaskMetaConfig // 重复的子任务列表，子配置心跳会用到
 	wrongChildMetaTasks   []*configs.ChildTaskMetaConfig // 错误的子任务列表,子配置心跳会用到
 	errorChildMetaTasks   []*configs.ChildTaskMetaConfig // 读取失败的子任务列表,子配置心跳会用到
+	tenantDataIDResolver  tenant.DataIDResolver
 
 	heartbeatLock sync.Mutex   // 心跳数据读写锁
 	heartbeatInfo define.Event // 用于上传的心跳数据,全局配置部分
+}
+
+// SetTenantDataIDResolver sets the tenant DataID view used during config initialization.
+func (ce *BaseConfigEngine) SetTenantDataIDResolver(resolver tenant.DataIDResolver) {
+	ce.tenantDataIDResolver = resolver
 }
 
 // NewBaseConfigEngine 获取configEngine
@@ -73,6 +80,7 @@ func (ce *BaseConfigEngine) Init(cfg *common.Config, bt define.Beater) error {
 
 	// 获取全局config
 	baseConfig := configs.NewConfig()
+	baseConfig.SetTenantDataIDResolver(ce.tenantDataIDResolver)
 	err = cfg.Unpack(baseConfig)
 	if err != nil {
 		return fmt.Errorf("%s: %w", define.ErrUnpackCfg, err)

--- a/pkg/bkmonitorbeat/beater/configengine_test.go
+++ b/pkg/bkmonitorbeat/beater/configengine_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/beater"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/beater/taskfactory"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/configs"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tenant"
 )
 
 // yaml文件格式
@@ -77,4 +80,29 @@ func TestParseConfig(t *testing.T) {
 	assert.Equal(t, "test", childTaskMetaConfig.Name)
 	assert.Equal(t, "ping", childTaskMetaConfig.Type)
 	assert.Equal(t, "1.2.3", childTaskMetaConfig.Version)
+}
+
+func TestGetBasicMetaConfigInjectsTenantDataIDResolver(t *testing.T) {
+	const configType = "tenant-test-basereport"
+	taskfactory.SetTaskConfigByName(configType, func() define.TaskMetaConfig {
+		return &configs.BasereportConfig{}
+	})
+	storage := tenant.NewStorage()
+	resolver := storage.NewResolver([]string{define.ModuleBasereport})
+	ce := beater.NewBaseConfigEngine(context.Background()).(*beater.BaseConfigEngine)
+	ce.SetTenantDataIDResolver(resolver)
+	cfg, err := ce.ParseToUcfg([]byte("type: " + configType))
+	if err != nil {
+		t.Fatalf("create child config: %v", err)
+	}
+
+	meta, err := ce.GetBasicMetaConfig(cfg)
+	if err != nil {
+		t.Fatalf("get child meta config: %v", err)
+	}
+	baseReport := meta.(*configs.BasereportConfig)
+	baseReport.DataID = 1001
+	if got := len(baseReport.GetTaskConfigList()); got != 0 {
+		t.Fatalf("child basereport task count = %d, want 0 without tenant data ID", got)
+	}
 }

--- a/pkg/bkmonitorbeat/beater/reload_test.go
+++ b/pkg/bkmonitorbeat/beater/reload_test.go
@@ -1,0 +1,75 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package beater
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/go-ucfg"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/configs/validator"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tenant"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/host"
+)
+
+var (
+	registerRegexpValidatorOnce sync.Once
+	registerRegexpValidatorErr  error
+)
+
+func TestReloadRestoresTenantStorageOnParseFailure(t *testing.T) {
+	registerRegexpValidatorOnce.Do(func() {
+		registerRegexpValidatorErr = ucfg.RegisterValidator("regexp", validator.ValidateRegex)
+	})
+	if registerRegexpValidatorErr != nil {
+		t.Fatalf("register regexp validator: %v", registerRegexpValidatorErr)
+	}
+
+	storage := tenant.DefaultStorage()
+	storage.SetExpectedTasks([]string{define.ModuleBasereport})
+	storage.UpdateTaskDataIDs(map[string]int32{define.ModuleBasereport: 2001})
+	t.Cleanup(func() { storage.SetExpectedTasks(nil) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	state := newBeaterState()
+	state.ctx = ctx
+	state.cancelFunc = cancel
+	monitorBeater := &MonitorBeater{
+		beaterState:   state,
+		beaterStatus:  newBeaterStatus(),
+		hostIDWatcher: host.NewEmptyWatcher(),
+		configEngine:  NewBaseConfigEngine(ctx),
+	}
+
+	invalidConfig, err := common.NewConfigFrom(map[string]interface{}{
+		"enable_multi_tenant": false,
+		"mode":                "daemon",
+		"node_id":             "local-test",
+		"ip":                  "localhost",
+		"bk_biz_id":           1,
+		"bk_cloud_id":         0,
+	})
+	if err != nil {
+		t.Fatalf("create invalid reload config: %v", err)
+	}
+	monitorBeater.Reload(invalidConfig)
+
+	if got := storage.ResolveTaskDataID(define.ModuleBasereport, 1001); got != 2001 {
+		t.Fatalf("basereport data ID after failed reload = %d, want 2001", got)
+	}
+	if updated := storage.UpdateTaskDataIDs(map[string]int32{define.ModuleBasereport: 2001}); !updated {
+		t.Fatal("expected failed reload to keep tenant data ID pending for retry")
+	}
+}

--- a/pkg/bkmonitorbeat/beater/reload_test.go
+++ b/pkg/bkmonitorbeat/beater/reload_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/go-ucfg"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/configs"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/configs/validator"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tenant"
@@ -74,5 +75,61 @@ func TestReloadKeepsTenantStorageOnParseFailure(t *testing.T) {
 	}
 	if updated := storage.UpdateTaskDataIDs(map[string]int32{define.ModuleBasereport: 2001}); !updated {
 		t.Fatal("expected failed reload to keep tenant data ID pending for retry")
+	}
+}
+
+func TestSameTenantClientConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		old  *configs.Config
+		new  *configs.Config
+		want bool
+	}{
+		{
+			name: "unchanged multi-tenant client",
+			old: &configs.Config{
+				EnableMultiTenant:  true,
+				GseMessageEndpoint: "/var/run/gse.sock",
+				MultiTenantTasks:   []string{"basereport", "exceptionbeat"},
+			},
+			new: &configs.Config{
+				EnableMultiTenant:  true,
+				GseMessageEndpoint: "/var/run/gse.sock",
+				MultiTenantTasks:   []string{"exceptionbeat", "basereport"},
+			},
+			want: true,
+		},
+		{
+			name: "enable changed",
+			old:  &configs.Config{EnableMultiTenant: false},
+			new:  &configs.Config{EnableMultiTenant: true},
+			want: false,
+		},
+		{
+			name: "endpoint changed",
+			old:  &configs.Config{EnableMultiTenant: true, GseMessageEndpoint: "/old"},
+			new:  &configs.Config{EnableMultiTenant: true, GseMessageEndpoint: "/new"},
+			want: false,
+		},
+		{
+			name: "tasks changed",
+			old:  &configs.Config{EnableMultiTenant: true, MultiTenantTasks: []string{"basereport"}},
+			new:  &configs.Config{EnableMultiTenant: true, MultiTenantTasks: []string{"exceptionbeat"}},
+			want: false,
+		},
+		{
+			name: "disabled client ignores inactive options",
+			old:  &configs.Config{EnableMultiTenant: false, GseMessageEndpoint: "/old"},
+			new:  &configs.Config{EnableMultiTenant: false, GseMessageEndpoint: "/new"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameTenantClientConfig(tt.old, tt.new); got != tt.want {
+				t.Fatalf("sameTenantClientConfig() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/bkmonitorbeat/beater/reload_test.go
+++ b/pkg/bkmonitorbeat/beater/reload_test.go
@@ -39,7 +39,10 @@ func TestReloadRestoresTenantStorageOnParseFailure(t *testing.T) {
 	storage := tenant.DefaultStorage()
 	storage.SetExpectedTasks([]string{define.ModuleBasereport})
 	storage.UpdateTaskDataIDs(map[string]int32{define.ModuleBasereport: 2001})
-	t.Cleanup(func() { storage.SetExpectedTasks(nil) })
+	t.Cleanup(func() {
+		storage.SetExpectedTasks(nil)
+		storage.MarkApplied(storage.Revision())
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/pkg/bkmonitorbeat/beater/reload_test.go
+++ b/pkg/bkmonitorbeat/beater/reload_test.go
@@ -28,7 +28,7 @@ var (
 	registerRegexpValidatorErr  error
 )
 
-func TestReloadRestoresTenantStorageOnParseFailure(t *testing.T) {
+func TestReloadKeepsTenantStorageOnParseFailure(t *testing.T) {
 	registerRegexpValidatorOnce.Do(func() {
 		registerRegexpValidatorErr = ucfg.RegisterValidator("regexp", validator.ValidateRegex)
 	})

--- a/pkg/bkmonitorbeat/configs/basereport.go
+++ b/pkg/bkmonitorbeat/configs/basereport.go
@@ -93,6 +93,10 @@ type BasereportConfig struct {
 	ReportRoute   bool `config:"report_route"`
 }
 
+func (c *BasereportConfig) SetTenantDataIDResolver(resolver tenant.DataIDResolver) {
+	c.tenantDataIDResolver = resolver
+}
+
 func (c *BasereportConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
 	c.DataID = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleBasereport, c.DataID)

--- a/pkg/bkmonitorbeat/configs/basereport.go
+++ b/pkg/bkmonitorbeat/configs/basereport.go
@@ -94,14 +94,12 @@ type BasereportConfig struct {
 
 func (c *BasereportConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
+	storage := tenant.DefaultStorage()
+	c.DataID = storage.ResolveTaskDataID(define.ModuleBasereport, c.DataID)
+
 	// 说明没有任务 有且仅有一个任务
 	if c.DataID == 0 {
 		return tasks
-	}
-
-	storage := tenant.DefaultStorage()
-	if v, ok := storage.GetTaskDataID(define.ModuleBasereport); ok {
-		c.DataID = v
 	}
 
 	tasks = append(tasks, c)

--- a/pkg/bkmonitorbeat/configs/basereport.go
+++ b/pkg/bkmonitorbeat/configs/basereport.go
@@ -99,6 +99,10 @@ func (c *BasereportConfig) SetTenantDataIDResolver(resolver tenant.DataIDResolve
 
 func (c *BasereportConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
+	if c.DataID == 0 {
+		return tasks
+	}
+
 	c.DataID = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleBasereport, c.DataID)
 
 	// 说明没有任务 有且仅有一个任务

--- a/pkg/bkmonitorbeat/configs/basereport.go
+++ b/pkg/bkmonitorbeat/configs/basereport.go
@@ -77,8 +77,9 @@ type NetConfig struct {
 
 // BasereportConfig
 type BasereportConfig struct {
-	BaseTaskParam `config:"_,inline"`
-	TimeTolerate  int64 `config:"time_tolerate"`
+	BaseTaskParam        `config:"_,inline"`
+	TimeTolerate         int64 `config:"time_tolerate"`
+	tenantDataIDResolver tenant.DataIDResolver
 
 	// module detail configs
 	Cpu  CpuConfig  `config:"cpu"`
@@ -94,8 +95,7 @@ type BasereportConfig struct {
 
 func (c *BasereportConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
-	storage := tenant.DefaultStorage()
-	c.DataID = storage.ResolveTaskDataID(define.ModuleBasereport, c.DataID)
+	c.DataID = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleBasereport, c.DataID)
 
 	// 说明没有任务 有且仅有一个任务
 	if c.DataID == 0 {

--- a/pkg/bkmonitorbeat/configs/config.go
+++ b/pkg/bkmonitorbeat/configs/config.go
@@ -133,6 +133,11 @@ type Config struct {
 	SelfStatsTask      *SelfStatsConfig       `config:"selfstats_task"`
 }
 
+// TenantDataIDResolverSetter is implemented by task configs using tenant DataIDs.
+type TenantDataIDResolverSetter interface {
+	SetTenantDataIDResolver(tenant.DataIDResolver)
+}
+
 // NewConfig : new config struct
 func NewConfig() *Config {
 	config := &Config{
@@ -178,9 +183,9 @@ func NewConfig() *Config {
 // SetTenantDataIDResolver sets the tenant DataID view used by this config.
 func (c *Config) SetTenantDataIDResolver(resolver tenant.DataIDResolver) {
 	c.tenantDataIDResolver = resolver
-	c.BaseReportTask.tenantDataIDResolver = resolver
-	c.ExceptionBeatTask.tenantDataIDResolver = resolver
-	c.ProcessBeatTask.tenantDataIDResolver = resolver
+	c.BaseReportTask.SetTenantDataIDResolver(resolver)
+	c.ExceptionBeatTask.SetTenantDataIDResolver(resolver)
+	c.ProcessBeatTask.SetTenantDataIDResolver(resolver)
 }
 
 func resolveTenantDataID(resolver tenant.DataIDResolver, task string, fallback int32) int32 {

--- a/pkg/bkmonitorbeat/configs/config.go
+++ b/pkg/bkmonitorbeat/configs/config.go
@@ -227,8 +227,5 @@ func (c *Config) GetTaskConfigList() []define.TaskConfig {
 
 func (c *Config) GetGatherUpDataID() int32 {
 	storage := tenant.DefaultStorage()
-	if v, ok := storage.GetTaskDataID(define.ModuleGatherUpBeat); ok {
-		return v
-	}
-	return c.GatherUpBeat.DataID
+	return storage.ResolveTaskDataID(define.ModuleGatherUpBeat, c.GatherUpBeat.DataID)
 }

--- a/pkg/bkmonitorbeat/configs/config.go
+++ b/pkg/bkmonitorbeat/configs/config.go
@@ -69,7 +69,8 @@ func (cc *ConcurrencyLimitConfig) Clean() {
 
 // Config : global config
 type Config struct {
-	TaskTypeMapping map[string]define.TaskMetaConfig `config:"_"`
+	TaskTypeMapping      map[string]define.TaskMetaConfig `config:"_"`
+	tenantDataIDResolver tenant.DataIDResolver
 
 	CheckInterval    time.Duration `config:"check_interval" validate:"positive"`
 	CleanUpTimeout   time.Duration `config:"clean_up_timeout" validate:"min=1s"`
@@ -174,6 +175,21 @@ func NewConfig() *Config {
 	return config
 }
 
+// SetTenantDataIDResolver sets the tenant DataID view used by this config.
+func (c *Config) SetTenantDataIDResolver(resolver tenant.DataIDResolver) {
+	c.tenantDataIDResolver = resolver
+	c.BaseReportTask.tenantDataIDResolver = resolver
+	c.ExceptionBeatTask.tenantDataIDResolver = resolver
+	c.ProcessBeatTask.tenantDataIDResolver = resolver
+}
+
+func resolveTenantDataID(resolver tenant.DataIDResolver, task string, fallback int32) int32 {
+	if resolver == nil {
+		resolver = tenant.DefaultStorage()
+	}
+	return resolver.ResolveTaskDataID(task, fallback)
+}
+
 // GetTaskTypeMapping :
 func (c *Config) GetTaskTypeMapping() map[string]define.TaskMetaConfig {
 	return c.TaskTypeMapping
@@ -226,6 +242,5 @@ func (c *Config) GetTaskConfigList() []define.TaskConfig {
 }
 
 func (c *Config) GetGatherUpDataID() int32 {
-	storage := tenant.DefaultStorage()
-	return storage.ResolveTaskDataID(define.ModuleGatherUpBeat, c.GatherUpBeat.DataID)
+	return resolveTenantDataID(c.tenantDataIDResolver, define.ModuleGatherUpBeat, c.GatherUpBeat.DataID)
 }

--- a/pkg/bkmonitorbeat/configs/exceptionbeat.go
+++ b/pkg/bkmonitorbeat/configs/exceptionbeat.go
@@ -25,7 +25,8 @@ const (
 )
 
 type ExceptionBeatConfig struct {
-	BaseTaskParam `config:"_,inline"`
+	BaseTaskParam        `config:"_,inline"`
+	tenantDataIDResolver tenant.DataIDResolver
 
 	CheckBit               int           `config:",ignore"`
 	CheckMethod            string        `config:"check_bit"`
@@ -57,8 +58,7 @@ var DefaultExceptionBeatConfig = ExceptionBeatConfig{
 
 func (c *ExceptionBeatConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
-	storage := tenant.DefaultStorage()
-	c.DataID = storage.ResolveTaskDataID(define.ModuleExceptionbeat, c.DataID)
+	c.DataID = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleExceptionbeat, c.DataID)
 
 	// 说明没有任务 有且仅有一个任务
 	if c.DataID == 0 {

--- a/pkg/bkmonitorbeat/configs/exceptionbeat.go
+++ b/pkg/bkmonitorbeat/configs/exceptionbeat.go
@@ -43,6 +43,10 @@ type ExceptionBeatConfig struct {
 	CoreFileMatchRegex     string        `config:"corefile_match_regex"`
 }
 
+func (c *ExceptionBeatConfig) SetTenantDataIDResolver(resolver tenant.DataIDResolver) {
+	c.tenantDataIDResolver = resolver
+}
+
 var DefaultExceptionBeatConfig = ExceptionBeatConfig{
 	CheckBit:               0,
 	CheckMethod:            "",

--- a/pkg/bkmonitorbeat/configs/exceptionbeat.go
+++ b/pkg/bkmonitorbeat/configs/exceptionbeat.go
@@ -57,14 +57,12 @@ var DefaultExceptionBeatConfig = ExceptionBeatConfig{
 
 func (c *ExceptionBeatConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
+	storage := tenant.DefaultStorage()
+	c.DataID = storage.ResolveTaskDataID(define.ModuleExceptionbeat, c.DataID)
+
 	// 说明没有任务 有且仅有一个任务
 	if c.DataID == 0 {
 		return tasks
-	}
-
-	storage := tenant.DefaultStorage()
-	if v, ok := storage.GetTaskDataID(define.ModuleExceptionbeat); ok {
-		c.DataID = v
 	}
 
 	tasks = append(tasks, c)

--- a/pkg/bkmonitorbeat/configs/exceptionbeat.go
+++ b/pkg/bkmonitorbeat/configs/exceptionbeat.go
@@ -62,6 +62,10 @@ var DefaultExceptionBeatConfig = ExceptionBeatConfig{
 
 func (c *ExceptionBeatConfig) GetTaskConfigList() []define.TaskConfig {
 	tasks := make([]define.TaskConfig, 0)
+	if c.DataID == 0 {
+		return tasks
+	}
+
 	c.DataID = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleExceptionbeat, c.DataID)
 
 	// 说明没有任务 有且仅有一个任务

--- a/pkg/bkmonitorbeat/configs/processbeat.go
+++ b/pkg/bkmonitorbeat/configs/processbeat.go
@@ -81,19 +81,13 @@ func (c *ProcessbeatConfig) InitIdent() error {
 
 	storage := tenant.DefaultStorage()
 	if c.PortDataId != 0 {
-		if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_port"); ok {
-			c.PortDataId = v
-		}
+		c.PortDataId = storage.ResolveTaskDataID(define.ModuleProcessbeat+"_port", c.PortDataId)
 	}
 	if c.TopDataId != 0 {
-		if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_top"); ok {
-			c.TopDataId = v
-		}
+		c.TopDataId = storage.ResolveTaskDataID(define.ModuleProcessbeat+"_top", c.TopDataId)
 	}
 	if c.PerfDataId != 0 {
-		if v, ok := storage.GetTaskDataID(define.ModuleProcessbeat + "_perf"); ok {
-			c.PerfDataId = v
-		}
+		c.PerfDataId = storage.ResolveTaskDataID(define.ModuleProcessbeat+"_perf", c.PerfDataId)
 	}
 
 	return c.initIdent(c)

--- a/pkg/bkmonitorbeat/configs/processbeat.go
+++ b/pkg/bkmonitorbeat/configs/processbeat.go
@@ -50,6 +50,10 @@ type ProcessbeatConfig struct {
 	confs     map[string]ProcessbeatPortConfig   // id -> config
 }
 
+func (c *ProcessbeatConfig) SetTenantDataIDResolver(resolver tenant.DataIDResolver) {
+	c.tenantDataIDResolver = resolver
+}
+
 func NewProcessbeatConfig(root *Config) *ProcessbeatConfig {
 	config := &ProcessbeatConfig{
 		BaseTaskParam: NewBaseTaskParam(),

--- a/pkg/bkmonitorbeat/configs/processbeat.go
+++ b/pkg/bkmonitorbeat/configs/processbeat.go
@@ -44,6 +44,7 @@ type ProcessbeatConfig struct {
 	ConvergePID          bool                    `config:"converge_pid" yaml:"converge_pid"`
 	MaxNoListenPorts     int                     `config:"max_nolisten_ports" yaml:"max_nolisten_ports`
 	Disable              bool                    `config:"disable" yaml:"disable"`
+	tenantDataIDResolver tenant.DataIDResolver
 
 	namestore map[string][]ProcessbeatPortConfig // name -> configs
 	confs     map[string]ProcessbeatPortConfig   // id -> config
@@ -79,15 +80,14 @@ func (c *ProcessbeatConfig) GetPeriod() time.Duration { return c.Period }
 func (c *ProcessbeatConfig) InitIdent() error {
 	// 需要在计算 indent 之前进行 dataid 替换 否则 reload 不会生效
 
-	storage := tenant.DefaultStorage()
 	if c.PortDataId != 0 {
-		c.PortDataId = storage.ResolveTaskDataID(define.ModuleProcessbeat+"_port", c.PortDataId)
+		c.PortDataId = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleProcessbeat+"_port", c.PortDataId)
 	}
 	if c.TopDataId != 0 {
-		c.TopDataId = storage.ResolveTaskDataID(define.ModuleProcessbeat+"_top", c.TopDataId)
+		c.TopDataId = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleProcessbeat+"_top", c.TopDataId)
 	}
 	if c.PerfDataId != 0 {
-		c.PerfDataId = storage.ResolveTaskDataID(define.ModuleProcessbeat+"_perf", c.PerfDataId)
+		c.PerfDataId = resolveTenantDataID(c.tenantDataIDResolver, define.ModuleProcessbeat+"_perf", c.PerfDataId)
 	}
 
 	return c.initIdent(c)

--- a/pkg/bkmonitorbeat/configs/tenant_dataid_test.go
+++ b/pkg/bkmonitorbeat/configs/tenant_dataid_test.go
@@ -25,7 +25,10 @@ func TestExpectedTenantDataIDsDisableStaticFallback(t *testing.T) {
 		define.ModuleProcessbeat + "_port",
 		define.ModuleGatherUpBeat,
 	})
-	t.Cleanup(func() { storage.SetExpectedTasks(nil) })
+	t.Cleanup(func() {
+		storage.SetExpectedTasks(nil)
+		storage.MarkApplied(storage.Revision())
+	})
 
 	baseReport := &BasereportConfig{BaseTaskParam: NewBaseTaskParam()}
 	baseReport.DataID = 1001

--- a/pkg/bkmonitorbeat/configs/tenant_dataid_test.go
+++ b/pkg/bkmonitorbeat/configs/tenant_dataid_test.go
@@ -101,3 +101,24 @@ func TestExpectedTenantDataIDsDisableStaticFallback(t *testing.T) {
 		t.Fatalf("gather-up data ID = %d, want 2100017", got)
 	}
 }
+
+func TestTenantDataIDsDoNotEnableDisabledBuiltinTasks(t *testing.T) {
+	storage := tenant.NewStorage()
+	storage.UpdateTaskDataIDs(map[string]int32{
+		define.ModuleBasereport:    2001,
+		define.ModuleExceptionbeat: 2000,
+	})
+
+	globalConfig := NewConfig()
+	globalConfig.SetTenantDataIDResolver(storage.NewResolver([]string{
+		define.ModuleBasereport,
+		define.ModuleExceptionbeat,
+	}))
+
+	if got := len(globalConfig.BaseReportTask.GetTaskConfigList()); got != 0 {
+		t.Fatalf("basereport task count = %d, want 0 when static data ID disables the task", got)
+	}
+	if got := len(globalConfig.ExceptionBeatTask.GetTaskConfigList()); got != 0 {
+		t.Fatalf("exceptionbeat task count = %d, want 0 when static data ID disables the task", got)
+	}
+}

--- a/pkg/bkmonitorbeat/configs/tenant_dataid_test.go
+++ b/pkg/bkmonitorbeat/configs/tenant_dataid_test.go
@@ -1,0 +1,100 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package configs
+
+import (
+	"testing"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tenant"
+)
+
+func TestExpectedTenantDataIDsDisableStaticFallback(t *testing.T) {
+	storage := tenant.DefaultStorage()
+	storage.SetExpectedTasks([]string{
+		define.ModuleBasereport,
+		define.ModuleExceptionbeat,
+		define.ModuleProcessbeat + "_perf",
+		define.ModuleProcessbeat + "_port",
+		define.ModuleGatherUpBeat,
+	})
+	t.Cleanup(func() { storage.SetExpectedTasks(nil) })
+
+	baseReport := &BasereportConfig{BaseTaskParam: NewBaseTaskParam()}
+	baseReport.DataID = 1001
+	if got := len(baseReport.GetTaskConfigList()); got != 0 {
+		t.Fatalf("basereport task count = %d, want 0 before tenant data ID is available", got)
+	}
+
+	exceptionBeat := &ExceptionBeatConfig{BaseTaskParam: NewBaseTaskParam()}
+	exceptionBeat.DataID = 1000
+	if got := len(exceptionBeat.GetTaskConfigList()); got != 0 {
+		t.Fatalf("exceptionbeat task count = %d, want 0 before tenant data ID is available", got)
+	}
+
+	processBeat := &ProcessbeatConfig{
+		PortDataId: 1013,
+		PerfDataId: 1007,
+		Processes:  []ProcessbeatPortConfig{{Name: "example"}},
+	}
+	if err := processBeat.InitIdent(); err != nil {
+		t.Fatalf("initialize processbeat identity: %v", err)
+	}
+	if got := len(processBeat.GetTaskConfigList()); got != 0 {
+		t.Fatalf("processbeat task count = %d, want 0 before tenant data IDs are available", got)
+	}
+
+	globalConfig := NewConfig()
+	globalConfig.GatherUpBeat.DataID = 1100017
+	if got := globalConfig.GetGatherUpDataID(); got != 0 {
+		t.Fatalf("gather-up data ID = %d, want 0 before tenant data ID is available", got)
+	}
+
+	storage.UpdateTaskDataIDs(map[string]int32{
+		define.ModuleBasereport:            2001,
+		define.ModuleExceptionbeat:         2000,
+		define.ModuleProcessbeat + "_perf": 2007,
+		define.ModuleProcessbeat + "_port": 2013,
+		define.ModuleGatherUpBeat:          2100017,
+	})
+
+	baseReport = &BasereportConfig{BaseTaskParam: NewBaseTaskParam()}
+	baseReport.DataID = 1001
+	if got := len(baseReport.GetTaskConfigList()); got != 1 || baseReport.DataID != 2001 {
+		t.Fatalf("basereport task = (count %d, data ID %d), want (1, 2001)", got, baseReport.DataID)
+	}
+
+	exceptionBeat = &ExceptionBeatConfig{BaseTaskParam: NewBaseTaskParam()}
+	exceptionBeat.DataID = 1000
+	if got := len(exceptionBeat.GetTaskConfigList()); got != 1 || exceptionBeat.DataID != 2000 {
+		t.Fatalf("exceptionbeat task = (count %d, data ID %d), want (1, 2000)", got, exceptionBeat.DataID)
+	}
+
+	processBeat = &ProcessbeatConfig{
+		PortDataId: 1013,
+		PerfDataId: 1007,
+		Processes:  []ProcessbeatPortConfig{{Name: "example"}},
+	}
+	if err := processBeat.InitIdent(); err != nil {
+		t.Fatalf("initialize processbeat identity after data IDs are available: %v", err)
+	}
+	if got := len(processBeat.GetTaskConfigList()); got != 1 || processBeat.PortDataId != 2013 || processBeat.PerfDataId != 2007 {
+		t.Fatalf(
+			"processbeat task = (count %d, port data ID %d, perf data ID %d), want (1, 2013, 2007)",
+			got,
+			processBeat.PortDataId,
+			processBeat.PerfDataId,
+		)
+	}
+
+	if got := globalConfig.GetGatherUpDataID(); got != 2100017 {
+		t.Fatalf("gather-up data ID = %d, want 2100017", got)
+	}
+}

--- a/pkg/bkmonitorbeat/scheduler/listen/scheduler.go
+++ b/pkg/bkmonitorbeat/scheduler/listen/scheduler.go
@@ -112,35 +112,7 @@ func (s *Scheduler) Wait() {
 
 func (s *Scheduler) Reload(ctx context.Context, conf define.Config, newTasks []define.Task) error {
 	logger.Info("listen scheduler reload")
-	deleteList := make([]string, 0)
-	for key := range s.tasks {
-		exist := false
-		for _, newTask := range newTasks {
-			if newTask.GetConfig().GetIdent() == key {
-				exist = true
-				break
-			}
-		}
-		// 新任务里不存在该任务，则需要关闭
-		if !exist {
-			deleteList = append(deleteList, key)
-		}
-	}
-
-	addList := make([]define.Task, 0)
-	for _, newTask := range newTasks {
-		exist := false
-		for key := range s.tasks {
-			if newTask.GetConfig().GetIdent() == key {
-				exist = true
-				break
-			}
-		}
-		// 新增该任务
-		if !exist {
-			addList = append(addList, newTask)
-		}
-	}
+	deleteList, addList := planReloadTasks(s.tasks, newTasks)
 
 	// 由于涉及到端口占用，只能先删后增
 	logger.Infof("listen scheduler remove %d tasks", len(deleteList))
@@ -148,6 +120,35 @@ func (s *Scheduler) Reload(ctx context.Context, conf define.Config, newTasks []d
 	logger.Infof("listen scheduler start %d tasks", len(addList))
 	s.addTasks(addList)
 	return nil
+}
+
+func planReloadTasks(currentTasks map[string]define.Task, newTasks []define.Task) ([]string, []define.Task) {
+	newTasksByIdent := make(map[string]define.Task, len(newTasks))
+	for _, task := range newTasks {
+		newTasksByIdent[task.GetConfig().GetIdent()] = task
+	}
+
+	deleteList := make([]string, 0)
+	for ident, currentTask := range currentTasks {
+		newTask, exists := newTasksByIdent[ident]
+		if !exists || gatherUpDataIDChanged(currentTask, newTask) {
+			deleteList = append(deleteList, ident)
+		}
+	}
+
+	addList := make([]define.Task, 0)
+	for _, newTask := range newTasks {
+		currentTask, exists := currentTasks[newTask.GetConfig().GetIdent()]
+		if !exists || gatherUpDataIDChanged(currentTask, newTask) {
+			addList = append(addList, newTask)
+		}
+	}
+
+	return deleteList, addList
+}
+
+func gatherUpDataIDChanged(currentTask, newTask define.Task) bool {
+	return currentTask.GetGlobalConfig().GetGatherUpDataID() != newTask.GetGlobalConfig().GetGatherUpDataID()
 }
 
 func (s *Scheduler) removeTasks(taskIndents []string) {

--- a/pkg/bkmonitorbeat/scheduler/listen/scheduler.go
+++ b/pkg/bkmonitorbeat/scheduler/listen/scheduler.go
@@ -148,6 +148,12 @@ func planReloadTasks(currentTasks map[string]define.Task, newTasks []define.Task
 }
 
 func gatherUpDataIDChanged(currentTask, newTask define.Task) bool {
+	// Only metricbeat caches the global gather-up DataID. Other listen tasks
+	// must keep their listeners running when this mapping changes.
+	if currentTask.GetConfig().GetType() != define.ModuleMetricbeat ||
+		newTask.GetConfig().GetType() != define.ModuleMetricbeat {
+		return false
+	}
 	return currentTask.GetGlobalConfig().GetGatherUpDataID() != newTask.GetGlobalConfig().GetGatherUpDataID()
 }
 

--- a/pkg/bkmonitorbeat/scheduler/listen/scheduler_test.go
+++ b/pkg/bkmonitorbeat/scheduler/listen/scheduler_test.go
@@ -33,7 +33,21 @@ type reloadTestTask struct {
 func (t *reloadTestTask) Run(context.Context, chan<- define.Event) {}
 
 func newReloadTestTask(ident string, gatherUpDataID int32) define.Task {
-	taskConfig := configs.NewMetricBeatConfig()
+	return newReloadTestTaskWithType(ident, configs.ConfigTypeMetric, gatherUpDataID)
+}
+
+type reloadTestTaskConfig struct {
+	*configs.MetricBeatConfig
+	taskType string
+}
+
+func (c *reloadTestTaskConfig) GetType() string { return c.taskType }
+
+func newReloadTestTaskWithType(ident, taskType string, gatherUpDataID int32) define.Task {
+	taskConfig := &reloadTestTaskConfig{
+		MetricBeatConfig: configs.NewMetricBeatConfig(),
+		taskType:         taskType,
+	}
 	taskConfig.SetIdent(ident)
 	return &reloadTestTask{BaseTask: tasks.BaseTask{
 		GlobalConfig: &reloadTestConfig{gatherUpDataID: gatherUpDataID},
@@ -55,6 +69,33 @@ func TestPlanReloadReplacesTaskWhenGatherUpDataIDChanges(t *testing.T) {
 	}
 	if len(addList) != 1 || addList[0] != newTask {
 		t.Fatalf("add list = %v, want the task with the new gather-up data ID", addList)
+	}
+}
+
+func TestPlanReloadReplacesOnlyMetricbeatWhenGatherUpDataIDChanges(t *testing.T) {
+	taskTypes := []string{
+		configs.ConfigTypeMetric,
+		configs.ConfigTypeTrap,
+		configs.ConfigTypeKubeevent,
+		configs.ConfigTypeDmesg,
+	}
+	currentTasks := make(map[string]define.Task, len(taskTypes))
+	newTasks := make([]define.Task, 0, len(taskTypes))
+	for _, taskType := range taskTypes {
+		currentTasks[taskType] = newReloadTestTaskWithType(taskType, taskType, 100)
+		newTasks = append(newTasks, newReloadTestTaskWithType(taskType, taskType, 200))
+	}
+
+	deleteList, addList := planReloadTasks(currentTasks, newTasks)
+
+	if len(deleteList) != 1 || deleteList[0] != configs.ConfigTypeMetric {
+		t.Fatalf("delete list = %v, want [%s]", deleteList, configs.ConfigTypeMetric)
+	}
+	if len(addList) != 1 {
+		t.Fatalf("add list count = %d, want 1", len(addList))
+	}
+	if got := addList[0].GetConfig().GetType(); got != configs.ConfigTypeMetric {
+		t.Fatalf("added task type = %s, want %s", got, configs.ConfigTypeMetric)
 	}
 }
 

--- a/pkg/bkmonitorbeat/scheduler/listen/scheduler_test.go
+++ b/pkg/bkmonitorbeat/scheduler/listen/scheduler_test.go
@@ -1,0 +1,76 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package listen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/configs"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/tasks"
+)
+
+type reloadTestConfig struct {
+	gatherUpDataID int32
+}
+
+func (c *reloadTestConfig) GetTaskConfigListByType(string) []define.TaskConfig { return nil }
+func (c *reloadTestConfig) GetGatherUpDataID() int32                           { return c.gatherUpDataID }
+func (c *reloadTestConfig) Clean() error                                       { return nil }
+
+type reloadTestTask struct {
+	tasks.BaseTask
+}
+
+func (t *reloadTestTask) Run(context.Context, chan<- define.Event) {}
+
+func newReloadTestTask(ident string, gatherUpDataID int32) define.Task {
+	taskConfig := configs.NewMetricBeatConfig()
+	taskConfig.SetIdent(ident)
+	return &reloadTestTask{BaseTask: tasks.BaseTask{
+		GlobalConfig: &reloadTestConfig{gatherUpDataID: gatherUpDataID},
+		TaskConfig:   taskConfig,
+	}}
+}
+
+func TestPlanReloadReplacesTaskWhenGatherUpDataIDChanges(t *testing.T) {
+	currentTask := newReloadTestTask("metricbeat", 100)
+	newTask := newReloadTestTask("metricbeat", 200)
+
+	deleteList, addList := planReloadTasks(
+		map[string]define.Task{"metricbeat": currentTask},
+		[]define.Task{newTask},
+	)
+
+	if len(deleteList) != 1 || deleteList[0] != "metricbeat" {
+		t.Fatalf("delete list = %v, want [metricbeat]", deleteList)
+	}
+	if len(addList) != 1 || addList[0] != newTask {
+		t.Fatalf("add list = %v, want the task with the new gather-up data ID", addList)
+	}
+}
+
+func TestPlanReloadKeepsTaskWhenGatherUpDataIDIsUnchanged(t *testing.T) {
+	currentTask := newReloadTestTask("metricbeat", 100)
+	newTask := newReloadTestTask("metricbeat", 100)
+
+	deleteList, addList := planReloadTasks(
+		map[string]define.Task{"metricbeat": currentTask},
+		[]define.Task{newTask},
+	)
+
+	if len(deleteList) != 0 {
+		t.Fatalf("delete list = %v, want no replacement", deleteList)
+	}
+	if len(addList) != 0 {
+		t.Fatalf("add list = %v, want no replacement", addList)
+	}
+}

--- a/pkg/bkmonitorbeat/tenant/client.go
+++ b/pkg/bkmonitorbeat/tenant/client.go
@@ -199,21 +199,33 @@ func (c *Client) loop() {
 }
 
 type Pacer struct {
-	maxSeconds int
-	count      int
+	maxSeconds     int
+	nextMinSeconds int
 }
 
 func newPacer(maxSeconds int) *Pacer {
 	return &Pacer{
-		maxSeconds: maxSeconds,
+		maxSeconds:     maxSeconds,
+		nextMinSeconds: 2 * 60,
 	}
 }
 
 func (p *Pacer) Next() int {
-	p.count++
+	if p.maxSeconds <= 0 {
+		return 0
+	}
+	if p.nextMinSeconds >= p.maxSeconds {
+		return p.maxSeconds
+	}
 
-	n := 1 << p.count
-	seconds := (n * 60) + (rand.Int() % (n * 60))
+	minSeconds := p.nextMinSeconds
+	if minSeconds > p.maxSeconds/2 {
+		p.nextMinSeconds = p.maxSeconds
+	} else {
+		p.nextMinSeconds = minSeconds * 2
+	}
+
+	seconds := minSeconds + rand.Intn(minSeconds)
 	if seconds > p.maxSeconds {
 		return p.maxSeconds
 	}

--- a/pkg/bkmonitorbeat/tenant/client.go
+++ b/pkg/bkmonitorbeat/tenant/client.go
@@ -145,7 +145,7 @@ type AgentMsgRequest struct {
 }
 
 func newInstanceID() (string, error) {
-	buf := make([]byte, 16)
+	buf := make([]byte, 8)
 	if _, err := cryptorand.Read(buf); err != nil {
 		return "", err
 	}
@@ -158,7 +158,12 @@ func (c *Client) nextMessageID() string {
 
 	c.maxIssued++
 	// Metadata treats message IDs as opaque values and echoes them in responses.
-	return fmt.Sprintf("bkmonitorbeat.%s.%s.%d", TypeFetchHostDataID, c.instanceID, c.maxIssued)
+	return fmt.Sprintf(
+		"bkmonitorbeat.%s.%s.%s",
+		TypeFetchHostDataID,
+		c.instanceID,
+		strconv.FormatUint(c.maxIssued, 36),
+	)
 }
 
 func (c *Client) responseSequence(messageID string) (uint64, bool) {
@@ -170,7 +175,7 @@ func (c *Client) responseSequence(messageID string) (uint64, bool) {
 	if sequenceText == "" || strings.Contains(sequenceText, ".") {
 		return 0, false
 	}
-	sequence, err := strconv.ParseUint(sequenceText, 10, 64)
+	sequence, err := strconv.ParseUint(sequenceText, 36, 64)
 	if err != nil || sequence == 0 {
 		return 0, false
 	}

--- a/pkg/bkmonitorbeat/tenant/client.go
+++ b/pkg/bkmonitorbeat/tenant/client.go
@@ -11,9 +11,14 @@ package tenant
 
 import (
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	agentmessage "github.com/TencentBlueKing/bk-gse-sdk/go/service/agent-message"
@@ -37,6 +42,14 @@ type Client struct {
 	opt   Option
 	agent agentmessage.Client
 	pacer *Pacer
+
+	sequenceMu  sync.Mutex
+	instanceID  string
+	maxIssued   uint64
+	maxAccepted uint64
+	storage     *Storage
+	onUpdate    func(map[string]int32)
+	retrySoon   chan struct{}
 }
 
 // innerLogger 实现 gseagent 定义 Logger 接口
@@ -59,8 +72,31 @@ func (innerLogger) Error(format string, args ...interface{}) {
 }
 
 func NewClient(opt Option) (*Client, error) {
+	instanceID, err := newInstanceID()
+	if err != nil {
+		return nil, fmt.Errorf("generate tenant client instance ID: %w", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &Client{
+		ctx:        ctx,
+		cancel:     cancel,
+		opt:        opt,
+		pacer:      newPacer(3600), // 最大间隔 1 小时
+		instanceID: instanceID,
+		storage:    DefaultStorage(),
+		retrySoon:  make(chan struct{}, 1),
+	}
+	client.onUpdate = func(tasks map[string]int32) {
+		beat.ReloadChan <- true
+		define.RecordLog("update tenant dataid", []define.LogKV{{
+			K: "tasks",
+			V: tasks,
+		}})
+	}
+
 	socketOpts, err := agentMessageSocketOptions(opt.IPC)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -70,47 +106,17 @@ func NewClient(opt Option) (*Client, error) {
 	}
 	opts = append(opts, socketOpts...)
 	opts = append(opts,
-		agentmessage.WithRecvCallback(func(msgID string, content []byte) {
-			type R struct {
-				Data []FetchHostDataIDData `json:"data"`
-			}
-			var rsp R
-			if err := json.Unmarshal(content, &rsp); err != nil {
-				logger.Errorf("failed to unmarshal agent.msg (%s): %v", msgID, err)
-				return
-			}
-			logger.Debugf("handle agent.msg (%s)", msgID)
-
-			tasks := make(map[string]int32)
-			for _, pair := range rsp.Data {
-				tasks[pair.Task] = pair.DataID
-			}
-
-			// 如果触发了更新 则需要通知采集器进行 reload
-			updated := DefaultStorage().UpdateTaskDataIDs(tasks)
-			if updated {
-				beat.ReloadChan <- true
-				define.RecordLog("update tenant dataid", []define.LogKV{{
-					K: "tasks",
-					V: tasks,
-				}})
-			}
-		}),
+		agentmessage.WithRecvCallback(client.handleMessage),
 		agentmessage.WithLogger(innerLogger{}),
 	)
 	cli, err := agentmessage.New(opts...)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	return &Client{
-		ctx:    ctx,
-		cancel: cancel,
-		agent:  cli,
-		opt:    opt,
-		pacer:  newPacer(3600), // 最大间隔 1 小时
-	}, nil
+	client.agent = cli
+	return client, nil
 }
 
 const (
@@ -138,6 +144,97 @@ type AgentMsgRequest struct {
 	Params   interface{} `json:"params"`
 }
 
+func newInstanceID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := cryptorand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func (c *Client) nextMessageID() string {
+	c.sequenceMu.Lock()
+	defer c.sequenceMu.Unlock()
+
+	c.maxIssued++
+	// Metadata treats message IDs as opaque values and echoes them in responses.
+	return fmt.Sprintf("bkmonitorbeat.%s.%s.%d", TypeFetchHostDataID, c.instanceID, c.maxIssued)
+}
+
+func (c *Client) responseSequence(messageID string) (uint64, bool) {
+	prefix := fmt.Sprintf("bkmonitorbeat.%s.%s.", TypeFetchHostDataID, c.instanceID)
+	if !strings.HasPrefix(messageID, prefix) {
+		return 0, false
+	}
+	sequenceText := strings.TrimPrefix(messageID, prefix)
+	if sequenceText == "" || strings.Contains(sequenceText, ".") {
+		return 0, false
+	}
+	sequence, err := strconv.ParseUint(sequenceText, 10, 64)
+	if err != nil || sequence == 0 {
+		return 0, false
+	}
+	return sequence, true
+}
+
+func (c *Client) handleMessage(messageID string, content []byte) {
+	type response struct {
+		Code int                   `json:"code"`
+		Data []FetchHostDataIDData `json:"data"`
+	}
+	var rsp response
+	if err := json.Unmarshal(content, &rsp); err != nil {
+		logger.Errorf("failed to unmarshal agent.msg (%s): %v", messageID, err)
+		return
+	}
+	if rsp.Code != 0 {
+		logger.Errorf("failed tenant dataid response (%s), code=%d", messageID, rsp.Code)
+		return
+	}
+	sequence, ok := c.responseSequence(messageID)
+	if !ok {
+		logger.Warnf("ignore tenant dataid response with unknown message ID (%s)", messageID)
+		return
+	}
+
+	tasks := make(map[string]int32, len(rsp.Data))
+	for _, pair := range rsp.Data {
+		tasks[pair.Task] = pair.DataID
+	}
+
+	c.sequenceMu.Lock()
+	if sequence > c.maxIssued || sequence < c.maxAccepted {
+		c.sequenceMu.Unlock()
+		logger.Warnf("ignore stale tenant dataid response (%s)", messageID)
+		return
+	}
+	if sequence > c.maxAccepted {
+		c.maxAccepted = sequence
+	}
+	updated := c.storage.UpdateTaskDataIDs(tasks)
+	c.sequenceMu.Unlock()
+	if c.storage.NeedsRefresh() {
+		logger.Warnf("tenant dataid response remains incomplete or unapplied (%s)", messageID)
+		c.retryMissingDataIDs()
+	}
+
+	logger.Debugf("handle agent.msg (%s)", messageID)
+	if updated {
+		c.onUpdate(tasks)
+	}
+}
+
+func (c *Client) retryMissingDataIDs() {
+	if c.pacer == nil || c.retrySoon == nil {
+		return
+	}
+	c.pacer.Reset()
+	select {
+	case c.retrySoon <- struct{}{}:
+	default:
+	}
+}
+
 func (c *Client) SendMsg(messageID string, content []byte) error {
 	logger.Debugf("send agent.msg (%s), content=(%s)", messageID, content)
 	return c.agent.SendMessage(c.ctx, messageID, content)
@@ -160,8 +257,7 @@ func (c *Client) Start() error {
 func (c *Client) loop() {
 	send := func() {
 		info, _ := gse.GetAgentInfo()
-		// msgID 规则为 {插件名称}.{查询类型}.{UnixTimestamp}
-		messageID := fmt.Sprintf("bkmonitorbeat.%s.%d", TypeFetchHostDataID, time.Now().Unix())
+		messageID := c.nextMessageID()
 		content, _ := json.Marshal(AgentMsgRequest{
 			Type:     TypeFetchHostDataID,
 			CloudID:  int(info.Cloudid),
@@ -189,7 +285,20 @@ func (c *Client) loop() {
 	for {
 		select {
 		case <-timer.C:
+			if c.storage.NeedsRefresh() {
+				c.pacer.Reset()
+			}
 			send()
+			timer.Reset(time.Duration(c.pacer.Next()) * time.Second)
+
+		case <-c.retrySoon:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			c.pacer.Reset()
 			timer.Reset(time.Duration(c.pacer.Next()) * time.Second)
 
 		case <-c.ctx.Done():
@@ -199,6 +308,7 @@ func (c *Client) loop() {
 }
 
 type Pacer struct {
+	mut            sync.Mutex
 	maxSeconds     int
 	nextMinSeconds int
 }
@@ -211,6 +321,9 @@ func newPacer(maxSeconds int) *Pacer {
 }
 
 func (p *Pacer) Next() int {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
 	if p.maxSeconds <= 0 {
 		return 0
 	}
@@ -230,4 +343,11 @@ func (p *Pacer) Next() int {
 		return p.maxSeconds
 	}
 	return seconds
+}
+
+func (p *Pacer) Reset() {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	p.nextMinSeconds = 2 * 60
 }

--- a/pkg/bkmonitorbeat/tenant/client_test.go
+++ b/pkg/bkmonitorbeat/tenant/client_test.go
@@ -9,7 +9,10 @@
 
 package tenant
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestPacerNextStaysWithinMaximum(t *testing.T) {
 	pacer := newPacer(3600)
@@ -18,5 +21,100 @@ func TestPacerNextStaysWithinMaximum(t *testing.T) {
 		if got <= 0 || got > 3600 {
 			t.Fatalf("Next() = %d, want value in (0, 3600]", got)
 		}
+	}
+}
+
+func TestClientIgnoresOutOfOrderDataIDResponse(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+	reloads := 0
+	client := &Client{
+		instanceID: "test-instance",
+		storage:    storage,
+		onUpdate: func(map[string]int32) {
+			reloads++
+		},
+	}
+
+	oldMessageID := client.nextMessageID()
+	newMessageID := client.nextMessageID()
+	client.handleMessage(newMessageID, []byte(`{"code":0,"data":[{"task":"basereport","dataid":3001}]}`))
+	client.handleMessage(oldMessageID, []byte(`{"code":0,"data":[]}`))
+
+	if got, ok := storage.GetTaskDataID("basereport"); !ok || got != 3001 {
+		t.Fatalf("basereport data ID after out-of-order response = (%d, %v), want (3001, true)", got, ok)
+	}
+	if reloads != 1 {
+		t.Fatalf("reload count = %d, want 1", reloads)
+	}
+}
+
+func TestClientIgnoresResponseFromPreviousProcess(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+	client := &Client{
+		instanceID: "current-instance",
+		storage:    storage,
+		onUpdate:   func(map[string]int32) {},
+	}
+	client.nextMessageID()
+
+	client.handleMessage(
+		fmt.Sprintf("bkmonitorbeat.%s.previous-instance.1", TypeFetchHostDataID),
+		[]byte(`{"code":0,"data":[{"task":"basereport","dataid":2001}]}`),
+	)
+
+	if _, ok := storage.GetTaskDataID("basereport"); ok {
+		t.Fatal("response from previous process must not update storage")
+	}
+}
+
+func TestClientAllowsSameResponseToRetryPendingReload(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+	reloads := 0
+	client := &Client{
+		instanceID: "test-instance",
+		storage:    storage,
+		onUpdate: func(map[string]int32) {
+			reloads++
+		},
+	}
+	messageID := client.nextMessageID()
+	content := []byte(`{"code":0,"data":[{"task":"basereport","dataid":2001}]}`)
+
+	client.handleMessage(messageID, content)
+	client.handleMessage(messageID, content)
+
+	if reloads != 2 {
+		t.Fatalf("reload count = %d, want 2 while revision is pending", reloads)
+	}
+}
+
+func TestClientShortensPollWhenExpectedDataIDIsMissing(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+	pacer := newPacer(3600)
+	for i := 0; i < 10; i++ {
+		pacer.Next()
+	}
+	client := &Client{
+		instanceID: "test-instance",
+		storage:    storage,
+		pacer:      pacer,
+		retrySoon:  make(chan struct{}, 1),
+		onUpdate:   func(map[string]int32) {},
+	}
+	messageID := client.nextMessageID()
+
+	client.handleMessage(messageID, []byte(`{"code":0,"data":[]}`))
+
+	if got := pacer.Next(); got < 120 || got > 240 {
+		t.Fatalf("poll delay after missing response = %d, want [120, 240]", got)
+	}
+	select {
+	case <-client.retrySoon:
+	default:
+		t.Fatal("missing response must wake the polling loop")
 	}
 }

--- a/pkg/bkmonitorbeat/tenant/client_test.go
+++ b/pkg/bkmonitorbeat/tenant/client_test.go
@@ -1,0 +1,22 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package tenant
+
+import "testing"
+
+func TestPacerNextStaysWithinMaximum(t *testing.T) {
+	pacer := newPacer(3600)
+	for i := 0; i < 100; i++ {
+		got := pacer.Next()
+		if got <= 0 || got > 3600 {
+			t.Fatalf("Next() = %d, want value in (0, 3600]", got)
+		}
+	}
+}

--- a/pkg/bkmonitorbeat/tenant/client_test.go
+++ b/pkg/bkmonitorbeat/tenant/client_test.go
@@ -11,6 +11,8 @@ package tenant
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"testing"
 )
 
@@ -21,6 +23,31 @@ func TestPacerNextStaysWithinMaximum(t *testing.T) {
 		if got <= 0 || got > 3600 {
 			t.Fatalf("Next() = %d, want value in (0, 3600]", got)
 		}
+	}
+}
+
+func TestMessageIDFitsMetadataLimit(t *testing.T) {
+	client := &Client{
+		instanceID: strings.Repeat("f", 16),
+		maxIssued:  math.MaxUint64 - 1,
+	}
+
+	messageID := client.nextMessageID()
+	if got := len(messageID); got > 64 {
+		t.Fatalf("message ID length = %d, want <= 64: %s", got, messageID)
+	}
+	if sequence, ok := client.responseSequence(messageID); !ok || sequence != math.MaxUint64 {
+		t.Fatalf("parsed sequence = (%d, %v), want (%d, true)", sequence, ok, uint64(math.MaxUint64))
+	}
+}
+
+func TestInstanceIDUsesEightRandomBytes(t *testing.T) {
+	instanceID, err := newInstanceID()
+	if err != nil {
+		t.Fatalf("newInstanceID() error: %v", err)
+	}
+	if got := len(instanceID); got != 16 {
+		t.Fatalf("instance ID length = %d, want 16", got)
 	}
 }
 

--- a/pkg/bkmonitorbeat/tenant/storage.go
+++ b/pkg/bkmonitorbeat/tenant/storage.go
@@ -10,38 +10,84 @@
 package tenant
 
 import (
-	"reflect"
 	"sync"
 )
 
 type Storage struct {
-	mut   sync.Mutex
-	tasks map[string]int32 // 与 gse 通信获取
+	mut                sync.RWMutex
+	tasks              map[string]int32 // 与 gse 通信获取
+	expectedTasks      map[string]struct{}
+	expectedConfigured bool
 }
 
 func NewStorage() *Storage {
 	return &Storage{
-		tasks: make(map[string]int32),
+		tasks:         make(map[string]int32),
+		expectedTasks: make(map[string]struct{}),
 	}
 }
 
 func (s *Storage) GetTaskDataID(task string) (int32, bool) {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 
 	dst, ok := s.tasks[task]
 	return dst, ok
+}
+
+// SetExpectedTasks records tasks that must use tenant DataIDs. Existing mappings
+// are retained only when the task remains configured.
+func (s *Storage) SetExpectedTasks(tasks []string) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	expectedTasks := make(map[string]struct{}, len(tasks))
+	for _, task := range tasks {
+		expectedTasks[task] = struct{}{}
+	}
+	for task := range s.tasks {
+		if _, ok := expectedTasks[task]; !ok {
+			delete(s.tasks, task)
+		}
+	}
+
+	s.expectedTasks = expectedTasks
+	s.expectedConfigured = true
+}
+
+// ResolveTaskDataID returns a fetched tenant DataID when present. An expected
+// task without a mapping is disabled instead of falling back to a static ID.
+func (s *Storage) ResolveTaskDataID(task string, fallback int32) int32 {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	if dataID, ok := s.tasks[task]; ok {
+		return dataID
+	}
+	if _, ok := s.expectedTasks[task]; ok {
+		return 0
+	}
+	return fallback
 }
 
 func (s *Storage) UpdateTaskDataIDs(tasks map[string]int32) bool {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	if reflect.DeepEqual(tasks, s.tasks) {
-		return false
+	updated := false
+	for task, dataID := range tasks {
+		if s.expectedConfigured {
+			if _, ok := s.expectedTasks[task]; !ok {
+				continue
+			}
+		}
+		if oldDataID, ok := s.tasks[task]; ok && oldDataID == dataID {
+			continue
+		}
+		s.tasks[task] = dataID
+		updated = true
 	}
-	s.tasks = tasks
-	return true
+	return updated
 }
 
 var defaultStorage = NewStorage()

--- a/pkg/bkmonitorbeat/tenant/storage.go
+++ b/pkg/bkmonitorbeat/tenant/storage.go
@@ -12,6 +12,8 @@ package tenant
 import (
 	"reflect"
 	"sync"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
 )
 
 type Storage struct {
@@ -33,6 +35,29 @@ type resolver struct {
 	tasks         map[string]int32
 }
 
+func isTenantDataIDTask(task string) bool {
+	switch task {
+	case define.ModuleBasereport,
+		define.ModuleExceptionbeat,
+		define.ModuleProcessbeat + "_perf",
+		define.ModuleProcessbeat + "_port",
+		define.ModuleGatherUpBeat:
+		return true
+	default:
+		return false
+	}
+}
+
+func newExpectedTaskSet(tasks []string) map[string]struct{} {
+	expectedTasks := make(map[string]struct{}, len(tasks))
+	for _, task := range tasks {
+		if isTenantDataIDTask(task) {
+			expectedTasks[task] = struct{}{}
+		}
+	}
+	return expectedTasks
+}
+
 func NewStorage() *Storage {
 	return &Storage{
 		tasks:         make(map[string]int32),
@@ -48,10 +73,7 @@ func (s *Storage) NewResolver(tasks []string) DataIDResolver {
 
 // NewResolverSnapshot returns an immutable resolver and its mapping revision.
 func (s *Storage) NewResolverSnapshot(tasks []string) (DataIDResolver, uint64) {
-	expectedTasks := make(map[string]struct{}, len(tasks))
-	for _, task := range tasks {
-		expectedTasks[task] = struct{}{}
-	}
+	expectedTasks := newExpectedTaskSet(tasks)
 
 	s.mut.RLock()
 	defer s.mut.RUnlock()
@@ -139,12 +161,7 @@ func (s *Storage) SetExpectedTasks(tasks []string) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	expectedTasks := make(map[string]struct{}, len(tasks))
-	for _, task := range tasks {
-		expectedTasks[task] = struct{}{}
-	}
-
-	s.expectedTasks = expectedTasks
+	s.expectedTasks = newExpectedTaskSet(tasks)
 	s.expectedConfigured = true
 }
 

--- a/pkg/bkmonitorbeat/tenant/storage.go
+++ b/pkg/bkmonitorbeat/tenant/storage.go
@@ -22,10 +22,14 @@ type Storage struct {
 	appliedRevision    uint64
 }
 
-// Snapshot is an immutable copy of Storage state used by config reload rollback.
-type Snapshot struct {
-	expectedTasks      map[string]struct{}
-	expectedConfigured bool
+// DataIDResolver resolves task DataIDs against a fixed expected-task view.
+type DataIDResolver interface {
+	ResolveTaskDataID(task string, fallback int32) int32
+}
+
+type resolver struct {
+	storage       *Storage
+	expectedTasks map[string]struct{}
 }
 
 func NewStorage() *Storage {
@@ -35,34 +39,30 @@ func NewStorage() *Storage {
 	}
 }
 
-// Snapshot returns a copy of the current storage state.
-func (s *Storage) Snapshot() Snapshot {
-	s.mut.RLock()
-	defer s.mut.RUnlock()
-
-	expectedTasks := make(map[string]struct{}, len(s.expectedTasks))
-	for task := range s.expectedTasks {
+// NewResolver returns an isolated expected-task view over fetched DataIDs.
+func (s *Storage) NewResolver(tasks []string) DataIDResolver {
+	expectedTasks := make(map[string]struct{}, len(tasks))
+	for _, task := range tasks {
 		expectedTasks[task] = struct{}{}
 	}
-
-	return Snapshot{
-		expectedTasks:      expectedTasks,
-		expectedConfigured: s.expectedConfigured,
+	return &resolver{
+		storage:       s,
+		expectedTasks: expectedTasks,
 	}
 }
 
-// Restore reverts expected tasks without overwriting concurrently fetched mappings.
-func (s *Storage) Restore(snapshot Snapshot) {
-	s.mut.Lock()
-	defer s.mut.Unlock()
-
-	expectedTasks := make(map[string]struct{}, len(snapshot.expectedTasks))
-	for task := range snapshot.expectedTasks {
-		expectedTasks[task] = struct{}{}
+func (r *resolver) ResolveTaskDataID(task string, fallback int32) int32 {
+	if _, ok := r.expectedTasks[task]; !ok {
+		return fallback
 	}
 
-	s.expectedTasks = expectedTasks
-	s.expectedConfigured = snapshot.expectedConfigured
+	r.storage.mut.RLock()
+	defer r.storage.mut.RUnlock()
+
+	if dataID, ok := r.storage.tasks[task]; ok {
+		return dataID
+	}
+	return 0
 }
 
 // Revision returns the current mapping revision.

--- a/pkg/bkmonitorbeat/tenant/storage.go
+++ b/pkg/bkmonitorbeat/tenant/storage.go
@@ -10,6 +10,7 @@
 package tenant
 
 import (
+	"reflect"
 	"sync"
 )
 
@@ -138,27 +139,26 @@ func (s *Storage) ResolveTaskDataID(task string, fallback int32) int32 {
 	return fallback
 }
 
+// UpdateTaskDataIDs replaces mappings with the latest Metadata response.
 func (s *Storage) UpdateTaskDataIDs(tasks map[string]int32) bool {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	updated := false
+	nextTasks := make(map[string]int32, len(tasks))
 	for task, dataID := range tasks {
 		if s.expectedConfigured {
 			if _, ok := s.expectedTasks[task]; !ok {
 				continue
 			}
 		}
-		if oldDataID, ok := s.tasks[task]; ok && oldDataID == dataID {
-			continue
-		}
-		s.tasks[task] = dataID
-		updated = true
+		nextTasks[task] = dataID
 	}
-	if updated {
+	if !reflect.DeepEqual(s.tasks, nextTasks) {
+		s.tasks = nextTasks
 		s.revision++
+		return true
 	}
-	return updated || s.revision != s.appliedRevision
+	return s.revision != s.appliedRevision
 }
 
 var defaultStorage = NewStorage()

--- a/pkg/bkmonitorbeat/tenant/storage.go
+++ b/pkg/bkmonitorbeat/tenant/storage.go
@@ -29,8 +29,8 @@ type DataIDResolver interface {
 }
 
 type resolver struct {
-	storage       *Storage
 	expectedTasks map[string]struct{}
+	tasks         map[string]int32
 }
 
 func NewStorage() *Storage {
@@ -40,16 +40,30 @@ func NewStorage() *Storage {
 	}
 }
 
-// NewResolver returns an isolated expected-task view over fetched DataIDs.
+// NewResolver returns an immutable view over expected tasks and fetched DataIDs.
 func (s *Storage) NewResolver(tasks []string) DataIDResolver {
+	resolver, _ := s.NewResolverSnapshot(tasks)
+	return resolver
+}
+
+// NewResolverSnapshot returns an immutable resolver and its mapping revision.
+func (s *Storage) NewResolverSnapshot(tasks []string) (DataIDResolver, uint64) {
 	expectedTasks := make(map[string]struct{}, len(tasks))
 	for _, task := range tasks {
 		expectedTasks[task] = struct{}{}
 	}
-	return &resolver{
-		storage:       s,
-		expectedTasks: expectedTasks,
+
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+	fetchedTasks := make(map[string]int32, len(s.tasks))
+	for task, dataID := range s.tasks {
+		fetchedTasks[task] = dataID
 	}
+
+	return &resolver{
+		expectedTasks: expectedTasks,
+		tasks:         fetchedTasks,
+	}, s.revision
 }
 
 func (r *resolver) ResolveTaskDataID(task string, fallback int32) int32 {
@@ -57,10 +71,7 @@ func (r *resolver) ResolveTaskDataID(task string, fallback int32) int32 {
 		return fallback
 	}
 
-	r.storage.mut.RLock()
-	defer r.storage.mut.RUnlock()
-
-	if dataID, ok := r.storage.tasks[task]; ok {
+	if dataID, ok := r.tasks[task]; ok {
 		return dataID
 	}
 	return 0
@@ -72,6 +83,25 @@ func (s *Storage) Revision() uint64 {
 	defer s.mut.RUnlock()
 
 	return s.revision
+}
+
+// NeedsRefresh reports whether expected DataIDs are missing or not yet applied.
+func (s *Storage) NeedsRefresh() bool {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	if !s.expectedConfigured || len(s.expectedTasks) == 0 {
+		return false
+	}
+	if s.revision != s.appliedRevision {
+		return true
+	}
+	for task := range s.expectedTasks {
+		if _, ok := s.tasks[task]; !ok {
+			return true
+		}
+	}
+	return false
 }
 
 // MarkApplied records the newest mapping revision used by a successful reload.

--- a/pkg/bkmonitorbeat/tenant/storage.go
+++ b/pkg/bkmonitorbeat/tenant/storage.go
@@ -24,11 +24,8 @@ type Storage struct {
 
 // Snapshot is an immutable copy of Storage state used by config reload rollback.
 type Snapshot struct {
-	tasks              map[string]int32
 	expectedTasks      map[string]struct{}
 	expectedConfigured bool
-	revision           uint64
-	appliedRevision    uint64
 }
 
 func NewStorage() *Storage {
@@ -43,43 +40,29 @@ func (s *Storage) Snapshot() Snapshot {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
-	tasks := make(map[string]int32, len(s.tasks))
-	for task, dataID := range s.tasks {
-		tasks[task] = dataID
-	}
 	expectedTasks := make(map[string]struct{}, len(s.expectedTasks))
 	for task := range s.expectedTasks {
 		expectedTasks[task] = struct{}{}
 	}
 
 	return Snapshot{
-		tasks:              tasks,
 		expectedTasks:      expectedTasks,
 		expectedConfigured: s.expectedConfigured,
-		revision:           s.revision,
-		appliedRevision:    s.appliedRevision,
 	}
 }
 
-// Restore replaces storage state with a previous snapshot.
+// Restore reverts expected tasks without overwriting concurrently fetched mappings.
 func (s *Storage) Restore(snapshot Snapshot) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	tasks := make(map[string]int32, len(snapshot.tasks))
-	for task, dataID := range snapshot.tasks {
-		tasks[task] = dataID
-	}
 	expectedTasks := make(map[string]struct{}, len(snapshot.expectedTasks))
 	for task := range snapshot.expectedTasks {
 		expectedTasks[task] = struct{}{}
 	}
 
-	s.tasks = tasks
 	s.expectedTasks = expectedTasks
 	s.expectedConfigured = snapshot.expectedConfigured
-	s.revision = snapshot.revision
-	s.appliedRevision = snapshot.appliedRevision
 }
 
 // Revision returns the current mapping revision.
@@ -95,6 +78,13 @@ func (s *Storage) MarkApplied(revision uint64) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
+	if s.expectedConfigured {
+		for task := range s.tasks {
+			if _, ok := s.expectedTasks[task]; !ok {
+				delete(s.tasks, task)
+			}
+		}
+	}
 	if revision > s.appliedRevision && revision <= s.revision {
 		s.appliedRevision = revision
 	}
@@ -104,12 +94,16 @@ func (s *Storage) GetTaskDataID(task string) (int32, bool) {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
+	if s.expectedConfigured {
+		if _, ok := s.expectedTasks[task]; !ok {
+			return 0, false
+		}
+	}
 	dst, ok := s.tasks[task]
 	return dst, ok
 }
 
-// SetExpectedTasks records tasks that must use tenant DataIDs. Existing mappings
-// are retained only when the task remains configured.
+// SetExpectedTasks records tasks that must use tenant DataIDs.
 func (s *Storage) SetExpectedTasks(tasks []string) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
@@ -117,16 +111,6 @@ func (s *Storage) SetExpectedTasks(tasks []string) {
 	expectedTasks := make(map[string]struct{}, len(tasks))
 	for _, task := range tasks {
 		expectedTasks[task] = struct{}{}
-	}
-	mappingUpdated := false
-	for task := range s.tasks {
-		if _, ok := expectedTasks[task]; !ok {
-			delete(s.tasks, task)
-			mappingUpdated = true
-		}
-	}
-	if mappingUpdated {
-		s.revision++
 	}
 
 	s.expectedTasks = expectedTasks
@@ -139,11 +123,17 @@ func (s *Storage) ResolveTaskDataID(task string, fallback int32) int32 {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
+	if s.expectedConfigured {
+		if _, ok := s.expectedTasks[task]; !ok {
+			return fallback
+		}
+		if dataID, ok := s.tasks[task]; ok {
+			return dataID
+		}
+		return 0
+	}
 	if dataID, ok := s.tasks[task]; ok {
 		return dataID
-	}
-	if _, ok := s.expectedTasks[task]; ok {
-		return 0
 	}
 	return fallback
 }

--- a/pkg/bkmonitorbeat/tenant/storage.go
+++ b/pkg/bkmonitorbeat/tenant/storage.go
@@ -18,12 +18,85 @@ type Storage struct {
 	tasks              map[string]int32 // 与 gse 通信获取
 	expectedTasks      map[string]struct{}
 	expectedConfigured bool
+	revision           uint64
+	appliedRevision    uint64
+}
+
+// Snapshot is an immutable copy of Storage state used by config reload rollback.
+type Snapshot struct {
+	tasks              map[string]int32
+	expectedTasks      map[string]struct{}
+	expectedConfigured bool
+	revision           uint64
+	appliedRevision    uint64
 }
 
 func NewStorage() *Storage {
 	return &Storage{
 		tasks:         make(map[string]int32),
 		expectedTasks: make(map[string]struct{}),
+	}
+}
+
+// Snapshot returns a copy of the current storage state.
+func (s *Storage) Snapshot() Snapshot {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	tasks := make(map[string]int32, len(s.tasks))
+	for task, dataID := range s.tasks {
+		tasks[task] = dataID
+	}
+	expectedTasks := make(map[string]struct{}, len(s.expectedTasks))
+	for task := range s.expectedTasks {
+		expectedTasks[task] = struct{}{}
+	}
+
+	return Snapshot{
+		tasks:              tasks,
+		expectedTasks:      expectedTasks,
+		expectedConfigured: s.expectedConfigured,
+		revision:           s.revision,
+		appliedRevision:    s.appliedRevision,
+	}
+}
+
+// Restore replaces storage state with a previous snapshot.
+func (s *Storage) Restore(snapshot Snapshot) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	tasks := make(map[string]int32, len(snapshot.tasks))
+	for task, dataID := range snapshot.tasks {
+		tasks[task] = dataID
+	}
+	expectedTasks := make(map[string]struct{}, len(snapshot.expectedTasks))
+	for task := range snapshot.expectedTasks {
+		expectedTasks[task] = struct{}{}
+	}
+
+	s.tasks = tasks
+	s.expectedTasks = expectedTasks
+	s.expectedConfigured = snapshot.expectedConfigured
+	s.revision = snapshot.revision
+	s.appliedRevision = snapshot.appliedRevision
+}
+
+// Revision returns the current mapping revision.
+func (s *Storage) Revision() uint64 {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	return s.revision
+}
+
+// MarkApplied records the newest mapping revision used by a successful reload.
+func (s *Storage) MarkApplied(revision uint64) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	if revision > s.appliedRevision && revision <= s.revision {
+		s.appliedRevision = revision
 	}
 }
 
@@ -45,10 +118,15 @@ func (s *Storage) SetExpectedTasks(tasks []string) {
 	for _, task := range tasks {
 		expectedTasks[task] = struct{}{}
 	}
+	mappingUpdated := false
 	for task := range s.tasks {
 		if _, ok := expectedTasks[task]; !ok {
 			delete(s.tasks, task)
+			mappingUpdated = true
 		}
+	}
+	if mappingUpdated {
+		s.revision++
 	}
 
 	s.expectedTasks = expectedTasks
@@ -87,7 +165,10 @@ func (s *Storage) UpdateTaskDataIDs(tasks map[string]int32) bool {
 		s.tasks[task] = dataID
 		updated = true
 	}
-	return updated
+	if updated {
+		s.revision++
+	}
+	return updated || s.revision != s.appliedRevision
 }
 
 var defaultStorage = NewStorage()

--- a/pkg/bkmonitorbeat/tenant/storage_test.go
+++ b/pkg/bkmonitorbeat/tenant/storage_test.go
@@ -162,3 +162,32 @@ func TestStorageNeedsRefreshUntilExpectedSnapshotIsApplied(t *testing.T) {
 		t.Fatal("applied partial snapshot must still require refresh")
 	}
 }
+
+func TestStorageNeedsRefreshIgnoresStaticTemplateTasks(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{
+		"basereport",
+		"processbeat_perf",
+		"processbeat_port",
+		"global_heartbeat",
+		"gather_up_beat",
+		"timesync",
+		"dmesg",
+		"exceptionbeat",
+	})
+	storage.UpdateTaskDataIDs(map[string]int32{
+		"basereport":       2001,
+		"processbeat_perf": 2007,
+		"processbeat_port": 2013,
+		"gather_up_beat":   2100017,
+		"exceptionbeat":    2000,
+	})
+	storage.MarkApplied(storage.Revision())
+
+	if storage.NeedsRefresh() {
+		t.Fatal("static template tasks must not keep tenant DataID polling in short-retry mode")
+	}
+	if got := storage.ResolveTaskDataID("timesync", 1100030); got != 1100030 {
+		t.Fatalf("timesync data ID = %d, want static fallback 1100030", got)
+	}
+}

--- a/pkg/bkmonitorbeat/tenant/storage_test.go
+++ b/pkg/bkmonitorbeat/tenant/storage_test.go
@@ -1,0 +1,54 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package tenant
+
+import "testing"
+
+func TestStorageUpdateTaskDataIDsKeepsMissingTasks(t *testing.T) {
+	storage := NewStorage()
+	storage.UpdateTaskDataIDs(map[string]int32{
+		"basereport":    1001,
+		"exceptionbeat": 1000,
+	})
+
+	if updated := storage.UpdateTaskDataIDs(map[string]int32{"basereport": 2001}); !updated {
+		t.Fatal("expected changed data ID to update storage")
+	}
+
+	if got, ok := storage.GetTaskDataID("basereport"); !ok || got != 2001 {
+		t.Fatalf("basereport data ID = (%d, %v), want (2001, true)", got, ok)
+	}
+	if got, ok := storage.GetTaskDataID("exceptionbeat"); !ok || got != 1000 {
+		t.Fatalf("exceptionbeat data ID = (%d, %v), want (1000, true)", got, ok)
+	}
+}
+
+func TestStorageResolveTaskDataID(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+
+	if got := storage.ResolveTaskDataID("basereport", 1001); got != 0 {
+		t.Fatalf("missing expected task resolved to %d, want 0", got)
+	}
+	if got := storage.ResolveTaskDataID("exceptionbeat", 1000); got != 1000 {
+		t.Fatalf("unexpected task resolved to %d, want static data ID 1000", got)
+	}
+
+	storage.UpdateTaskDataIDs(map[string]int32{
+		"basereport": 2001,
+		"unexpected": 9999,
+	})
+	if got := storage.ResolveTaskDataID("basereport", 1001); got != 2001 {
+		t.Fatalf("mapped task resolved to %d, want dynamic data ID 2001", got)
+	}
+	if _, ok := storage.GetTaskDataID("unexpected"); ok {
+		t.Fatal("unexpected task should not be stored")
+	}
+}

--- a/pkg/bkmonitorbeat/tenant/storage_test.go
+++ b/pkg/bkmonitorbeat/tenant/storage_test.go
@@ -107,3 +107,58 @@ func TestStorageCandidateResolverDoesNotAffectCommittedTasks(t *testing.T) {
 		t.Fatalf("candidate exceptionbeat data ID after update = %d, want static data ID 1000", got)
 	}
 }
+
+func TestStorageCandidateResolverKeepsDataIDSnapshot(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 2001})
+	candidate := storage.NewResolver([]string{"basereport"})
+
+	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 3001})
+
+	if got := candidate.ResolveTaskDataID("basereport", 1001); got != 2001 {
+		t.Fatalf("candidate basereport data ID after storage update = %d, want immutable snapshot 2001", got)
+	}
+}
+
+func TestStorageResolverSnapshotCapturesRevision(t *testing.T) {
+	storage := NewStorage()
+	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 2001})
+
+	resolver, revision := storage.NewResolverSnapshot([]string{"basereport"})
+	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 3001})
+
+	if revision != 1 {
+		t.Fatalf("snapshot revision = %d, want 1", revision)
+	}
+	if got := resolver.ResolveTaskDataID("basereport", 1001); got != 2001 {
+		t.Fatalf("snapshot data ID = %d, want 2001", got)
+	}
+}
+
+func TestStorageNeedsRefreshUntilExpectedSnapshotIsApplied(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport", "exceptionbeat"})
+	if !storage.NeedsRefresh() {
+		t.Fatal("missing expected data IDs must require refresh")
+	}
+
+	storage.UpdateTaskDataIDs(map[string]int32{
+		"basereport":    2001,
+		"exceptionbeat": 2000,
+	})
+	if !storage.NeedsRefresh() {
+		t.Fatal("unapplied complete snapshot must require refresh")
+	}
+
+	storage.MarkApplied(storage.Revision())
+	if storage.NeedsRefresh() {
+		t.Fatal("applied complete snapshot must not require refresh")
+	}
+
+	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 2001})
+	storage.MarkApplied(storage.Revision())
+	if !storage.NeedsRefresh() {
+		t.Fatal("applied partial snapshot must still require refresh")
+	}
+}

--- a/pkg/bkmonitorbeat/tenant/storage_test.go
+++ b/pkg/bkmonitorbeat/tenant/storage_test.go
@@ -70,3 +70,22 @@ func TestStorageRetriesPendingUpdateUntilApplied(t *testing.T) {
 		t.Fatal("expected applied data ID response not to trigger reload")
 	}
 }
+
+func TestStorageRestorePreservesConcurrentUpdate(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 2001})
+	storage.MarkApplied(storage.Revision())
+	snapshot := storage.Snapshot()
+
+	storage.SetExpectedTasks([]string{"basereport", "exceptionbeat"})
+	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 3001})
+	storage.Restore(snapshot)
+
+	if got := storage.ResolveTaskDataID("basereport", 1001); got != 3001 {
+		t.Fatalf("concurrent basereport data ID after restore = %d, want 3001", got)
+	}
+	if updated := storage.UpdateTaskDataIDs(map[string]int32{"basereport": 3001}); !updated {
+		t.Fatal("expected concurrent update to remain pending after restore")
+	}
+}

--- a/pkg/bkmonitorbeat/tenant/storage_test.go
+++ b/pkg/bkmonitorbeat/tenant/storage_test.go
@@ -11,7 +11,7 @@ package tenant
 
 import "testing"
 
-func TestStorageUpdateTaskDataIDsKeepsMissingTasks(t *testing.T) {
+func TestStorageUpdateTaskDataIDsReplacesSnapshot(t *testing.T) {
 	storage := NewStorage()
 	storage.UpdateTaskDataIDs(map[string]int32{
 		"basereport":    1001,
@@ -25,8 +25,8 @@ func TestStorageUpdateTaskDataIDsKeepsMissingTasks(t *testing.T) {
 	if got, ok := storage.GetTaskDataID("basereport"); !ok || got != 2001 {
 		t.Fatalf("basereport data ID = (%d, %v), want (2001, true)", got, ok)
 	}
-	if got, ok := storage.GetTaskDataID("exceptionbeat"); !ok || got != 1000 {
-		t.Fatalf("exceptionbeat data ID = (%d, %v), want (1000, true)", got, ok)
+	if got, ok := storage.GetTaskDataID("exceptionbeat"); ok {
+		t.Fatalf("exceptionbeat data ID = (%d, %v), want missing after authoritative snapshot replacement", got, ok)
 	}
 }
 
@@ -94,7 +94,10 @@ func TestStorageCandidateResolverDoesNotAffectCommittedTasks(t *testing.T) {
 		t.Fatalf("committed exceptionbeat data ID = %d, want 2000", got)
 	}
 
-	if updated := storage.UpdateTaskDataIDs(map[string]int32{"exceptionbeat": 3000}); !updated {
+	if updated := storage.UpdateTaskDataIDs(map[string]int32{
+		"basereport":    2001,
+		"exceptionbeat": 3000,
+	}); !updated {
 		t.Fatal("expected committed exceptionbeat update to be accepted")
 	}
 	if got := storage.ResolveTaskDataID("exceptionbeat", 1000); got != 3000 {

--- a/pkg/bkmonitorbeat/tenant/storage_test.go
+++ b/pkg/bkmonitorbeat/tenant/storage_test.go
@@ -71,21 +71,36 @@ func TestStorageRetriesPendingUpdateUntilApplied(t *testing.T) {
 	}
 }
 
-func TestStorageRestorePreservesConcurrentUpdate(t *testing.T) {
+func TestStorageCandidateResolverDoesNotAffectCommittedTasks(t *testing.T) {
 	storage := NewStorage()
-	storage.SetExpectedTasks([]string{"basereport"})
-	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 2001})
-	storage.MarkApplied(storage.Revision())
-	snapshot := storage.Snapshot()
-
 	storage.SetExpectedTasks([]string{"basereport", "exceptionbeat"})
-	storage.UpdateTaskDataIDs(map[string]int32{"basereport": 3001})
-	storage.Restore(snapshot)
+	storage.UpdateTaskDataIDs(map[string]int32{
+		"basereport":    2001,
+		"exceptionbeat": 2000,
+	})
+	storage.MarkApplied(storage.Revision())
+	candidate := storage.NewResolver([]string{"basereport", "gather_up_beat"})
 
-	if got := storage.ResolveTaskDataID("basereport", 1001); got != 3001 {
-		t.Fatalf("concurrent basereport data ID after restore = %d, want 3001", got)
+	if got := candidate.ResolveTaskDataID("exceptionbeat", 1000); got != 1000 {
+		t.Fatalf("candidate exceptionbeat data ID = %d, want static data ID 1000", got)
 	}
-	if updated := storage.UpdateTaskDataIDs(map[string]int32{"basereport": 3001}); !updated {
-		t.Fatal("expected concurrent update to remain pending after restore")
+	if got := candidate.ResolveTaskDataID("basereport", 1001); got != 2001 {
+		t.Fatalf("candidate basereport data ID = %d, want 2001", got)
+	}
+	if got := candidate.ResolveTaskDataID("gather_up_beat", 1100017); got != 0 {
+		t.Fatalf("candidate gather-up data ID = %d, want 0 before mapping is available", got)
+	}
+	if got := storage.ResolveTaskDataID("exceptionbeat", 1000); got != 2000 {
+		t.Fatalf("committed exceptionbeat data ID = %d, want 2000", got)
+	}
+
+	if updated := storage.UpdateTaskDataIDs(map[string]int32{"exceptionbeat": 3000}); !updated {
+		t.Fatal("expected committed exceptionbeat update to be accepted")
+	}
+	if got := storage.ResolveTaskDataID("exceptionbeat", 1000); got != 3000 {
+		t.Fatalf("committed exceptionbeat data ID after update = %d, want 3000", got)
+	}
+	if got := candidate.ResolveTaskDataID("exceptionbeat", 1000); got != 1000 {
+		t.Fatalf("candidate exceptionbeat data ID after update = %d, want static data ID 1000", got)
 	}
 }

--- a/pkg/bkmonitorbeat/tenant/storage_test.go
+++ b/pkg/bkmonitorbeat/tenant/storage_test.go
@@ -52,3 +52,21 @@ func TestStorageResolveTaskDataID(t *testing.T) {
 		t.Fatal("unexpected task should not be stored")
 	}
 }
+
+func TestStorageRetriesPendingUpdateUntilApplied(t *testing.T) {
+	storage := NewStorage()
+	storage.SetExpectedTasks([]string{"basereport"})
+	tasks := map[string]int32{"basereport": 2001}
+
+	if updated := storage.UpdateTaskDataIDs(tasks); !updated {
+		t.Fatal("expected first data ID response to trigger reload")
+	}
+	if updated := storage.UpdateTaskDataIDs(tasks); !updated {
+		t.Fatal("expected unapplied data ID response to retry reload")
+	}
+
+	storage.MarkApplied(storage.Revision())
+	if updated := storage.UpdateTaskDataIDs(tasks); updated {
+		t.Fatal("expected applied data ID response not to trigger reload")
+	}
+}


### PR DESCRIPTION
## 背景

多租户模式下，Metadata 可能在 bkmonitorbeat 部署后才逐步返回内置 DataID。原逻辑在动态映射缺失时会回退静态 DataID；相同响应在 Reload 失败后也不能持续触发恢复，长期轮询退避还存在整数溢出风险。

## 修改

- Metadata 当前支持的五类动态任务在 DataID 缺失时 fail-closed，不再回退静态 DataID；非多租户任务及三类静态内置任务保持静态配置语义
- 为每次配置解析冻结 DataID 映射和 revision，旧运行配置、候选配置及并发回包互不污染；子配置使用同一候选 resolver
- 将 Metadata 成功响应作为权威快照，并通过进程实例 ID 与单调请求序号拒绝旧进程及乱序响应
- 请求 ID 使用 16 位实例标识和 base36 序号，最大 uint64 序号下总长度为 62，满足 Metadata 64 字符协议上限
- 动态 DataID 缺失或 revision 尚未成功应用时维持约 2–4 分钟轮询；五类动态映射完整应用后恢复有界倍增退避
- Reload 失败时不提交 DataID revision，相同快照后续仍可重试
- 当前租户客户端不支持运行期重建；enable、tasks 或 GSE endpoint 变更会拒绝热更新并保留旧配置，需重启进程应用
- 修正 tenant client 指针在普通 Reload 后丢失的问题，确保后续停止流程仍能关闭客户端
- gather-up DataID 晚到或变化时仅替换实际使用该全局映射的 metricbeat，保持 snmptrap、kubeevent、dmesg 监听连续运行

## 边界

- 本 PR 以 Metadata 返回的 DataSource/DataID 为协议基线，不把“DataID 已分配”等同于“DataLink 端到端已就绪”；链路 readiness 与失败重建由 Metadata 侧另行保证和验收
- `global_heartbeat`、`timesync`、`dmesg` 当前没有 Metadata 动态 DataID，继续使用静态配置，也不参与动态缺失重试判定
- Metadata 不回包且当前动态映射已完整应用时仍按最长 1 小时退避；缺失或待应用状态保持短轮询

## 验证

- `go test ./tenant ./configs ./beater -count=2`
- `go test -race ./tenant ./configs ./beater -count=1`
- `go test ./scheduler/listen -run 'TestPlanReload' -count=50`
- `go test -race ./scheduler/listen -count=1`
- `go test ./scheduler/... -count=1`
- Linux amd64 相关包编译通过，Linux 386 tenant 包编译通过
- `git diff --check`