### PR TITLE
feat: 补齐 UQ Elasticsearch 批内查询可观测性 --story=136997142

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/raw_batch.go
+++ b/pkg/unify-query/tsdb/elasticsearch/raw_batch.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	elastic "github.com/olivere/elastic/v7"
 
@@ -29,7 +30,10 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
 )
 
-const rawBatchContentType = "application/x-ndjson"
+const (
+	rawBatchContentType            = "application/x-ndjson"
+	rawBatchTraceQueryBodyMaxBytes = 16 * 1024
+)
 
 // RawBatchMember keeps the stable request ordinal together with the one
 // prepared-query pointer that owns the member's formatter and decoder state.
@@ -273,6 +277,7 @@ func (i *Instance) ExecuteRawBatch(
 	if err != nil {
 		return nil, err
 	}
+	recordRawBatchRequestTrace(span, batch)
 	claimedMembers := make([]*PreparedRawQuery, 0, len(batch.members))
 	for _, member := range batch.members {
 		if !member.Prepared.claimed.CompareAndSwap(false, true) {
@@ -325,6 +330,7 @@ func (i *Instance) ExecuteRawBatch(
 			Kind:   "response_count_mismatch",
 		}
 	}
+	recordRawBatchResponseTrace(span, batch.members, multiSearchResult.Responses)
 
 	results = make([]RawBatchMemberResult, len(batch.members))
 	childErrors := 0
@@ -388,6 +394,92 @@ func (i *Instance) ExecuteRawBatch(
 	}
 
 	return results, nil
+}
+
+func recordRawBatchRequestTrace(span *trace.Span, batch *RawBatch) {
+	members := batch.members
+	ordinals := make([]int64, len(members))
+	tableIDs := make([]string, len(members))
+	indexCounts := make([]int64, len(members))
+	sharedQueryBody := members[0].Prepared.body
+	for index, member := range members {
+		ordinals[index] = int64(member.Ordinal)
+		tableIDs[index] = member.Prepared.query.TableID
+		indexCounts[index] = int64(len(member.Prepared.queryOption.indexes))
+		if member.Prepared.body != sharedQueryBody {
+			sharedQueryBody = ""
+		}
+	}
+
+	span.Set("es_batch_member_ordinals", ordinals)
+	span.Set("es_batch_member_table_ids", tableIDs)
+	span.Set("es_batch_member_index_counts", indexCounts)
+	span.Set("es_batch_shared_query_body", sharedQueryBody != "")
+	if sharedQueryBody == "" {
+		return
+	}
+	span.Set("query-body-size", len([]byte(sharedQueryBody)))
+	queryBody, truncated := truncateRawBatchTraceQueryBody(sharedQueryBody)
+	span.Set("query-body-truncated", truncated)
+	span.Set("query-body", queryBody)
+}
+
+func truncateRawBatchTraceQueryBody(body string) (string, bool) {
+	if len(body) <= rawBatchTraceQueryBodyMaxBytes {
+		return body, false
+	}
+	end := rawBatchTraceQueryBodyMaxBytes
+	for end > 0 && !utf8.ValidString(body[:end]) {
+		end--
+	}
+	return body[:end], true
+}
+
+func recordRawBatchResponseTrace(
+	span *trace.Span,
+	members []RawBatchMember,
+	children []*elastic.SearchResult,
+) {
+	tookMillis := make([]int64, len(children))
+	statuses := make([]int64, len(children))
+	totalHits := make([]int64, len(children))
+	shardsTotal := make([]int64, len(children))
+	shardsSuccessful := make([]int64, len(children))
+	shardsFailed := make([]int64, len(children))
+	errorTypes := make([]string, len(children))
+	timedOutOrdinals := make([]int64, 0)
+
+	for index, child := range children {
+		errorTypes[index] = "none"
+		if child == nil {
+			errorTypes[index] = "nil_response"
+			continue
+		}
+		tookMillis[index] = child.TookInMillis
+		statuses[index] = int64(child.Status)
+		totalHits[index] = child.TotalHits()
+		if child.TimedOut {
+			timedOutOrdinals = append(timedOutOrdinals, int64(members[index].Ordinal))
+		}
+		if child.Shards != nil {
+			shardsTotal[index] = int64(child.Shards.Total)
+			shardsSuccessful[index] = int64(child.Shards.Successful)
+			shardsFailed[index] = int64(child.Shards.Failed)
+		}
+		var childError *RawBatchChildError
+		if errors.As(rawBatchChildError(child), &childError) {
+			errorTypes[index] = childError.Type
+		}
+	}
+
+	span.Set("es_batch_child_took_millis", tookMillis)
+	span.Set("es_batch_child_timed_out_ordinals", timedOutOrdinals)
+	span.Set("es_batch_child_statuses", statuses)
+	span.Set("es_batch_child_total_hits", totalHits)
+	span.Set("es_batch_child_shards_total", shardsTotal)
+	span.Set("es_batch_child_shards_successful", shardsSuccessful)
+	span.Set("es_batch_child_shards_failed", shardsFailed)
+	span.Set("es_batch_child_error_types", errorTypes)
 }
 
 func (i *Instance) executeRawBatchMember(

--- a/pkg/unify-query/tsdb/elasticsearch/raw_batch_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/raw_batch_test.go
@@ -21,12 +21,14 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jarcoal/httpmock"
 	elastic "github.com/olivere/elastic/v7"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metric"
@@ -471,19 +473,26 @@ func TestRawBatchExecuteTransportStatusDoesNotFanOut(t *testing.T) {
 	}
 }
 
-func TestRawBatchSpanDoesNotExposeMemberDetails(t *testing.T) {
+func TestRawBatchSpanRecordsMemberDiagnosticsWithoutConnectionDetails(t *testing.T) {
 	recorder := setupESTraceRecorder(t)
 	const (
-		indexSentinel = "sensitive-index-sentinel"
-		querySentinel = "sensitive-query-sentinel"
-		userSentinel  = "sensitive-user-sentinel"
-		passSentinel  = "sensitive-password-sentinel"
+		firstIndexSentinel  = "sensitive-index-first"
+		secondIndexSentinel = "sensitive-index-second"
+		querySentinel       = "trace-query-sentinel"
+		firstTableID        = "trace.app.first"
+		secondTableID       = "trace.app.second"
+		userSentinel        = "sensitive-user-sentinel"
+		passSentinel        = "sensitive-password-sentinel"
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(
 			writer,
-			`{"responses":[{"status":200,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}]}`,
+			`{"responses":[`+
+				`{"took":932,"timed_out":true,"status":200,"_shards":{"total":8,"successful":7,"failed":1},`+
+				`"hits":{"total":{"value":23,"relation":"eq"},"hits":[]}},`+
+				`{"took":41,"timed_out":false,"status":404,"_shards":{"total":4,"successful":4,"failed":0},`+
+				`"error":{"type":"index_not_found_exception","reason":"must-not-leak"}}]}`,
 		)
 	}))
 	defer server.Close()
@@ -493,35 +502,192 @@ func TestRawBatchSpanDoesNotExposeMemberDetails(t *testing.T) {
 		UserName: userSentinel,
 		Password: passSentinel,
 	}
-	prepared := rawBatchPrepared(
+	queryBody := `{"query":{"term":{"message":"` + querySentinel + `"}}}`
+	first := rawBatchPrepared(
 		t,
 		connect,
-		[]string{indexSentinel},
-		`{"query":{"term":{"message":"`+querySentinel+`"}}}`,
+		[]string{firstIndexSentinel},
+		queryBody,
 		0,
 	)
-	batch := rawSingleBatch(t, prepared)
+	first.query.TableID = firstTableID
+	second := rawBatchPrepared(t, connect, []string{secondIndexSentinel}, queryBody, 0)
+	second.query.TableID = secondTableID
+	batch := rawBatchFromMembers(t, []RawBatchMember{
+		{Ordinal: 7, Prepared: first},
+		{Ordinal: 9, Prepared: second},
+	})
 	results, err := rawBatchInstance(t, connect).ExecuteRawBatch(context.Background(), batch, 4)
 	require.NoError(t, err)
-	require.Len(t, results, 1)
+	require.Len(t, results, 2)
 
 	attributes := endedSpanAttrs(t, recorder)
 	renderedAttributes := fmt.Sprint(attributes)
 	for _, sentinel := range []string{
 		server.URL,
-		indexSentinel,
-		querySentinel,
+		firstIndexSentinel,
+		secondIndexSentinel,
 		userSentinel,
 		passSentinel,
+		"must-not-leak",
 	} {
 		assert.NotContains(t, renderedAttributes, sentinel)
 	}
+	queryBodyAttribute, ok := esSpanAttrString(attributes, "query-body")
+	require.True(t, ok)
+	assert.Equal(t, queryBody, queryBodyAttribute)
+	queryBodySize, ok := esSpanAttrInt(attributes, "query-body-size")
+	require.True(t, ok)
+	assert.EqualValues(t, len([]byte(queryBody)), queryBodySize)
+	queryBodyTruncated, ok := esSpanAttrBool(attributes, "query-body-truncated")
+	require.True(t, ok)
+	assert.False(t, queryBodyTruncated)
+	sharedQueryBody, ok := esSpanAttrBool(attributes, "es_batch_shared_query_body")
+	require.True(t, ok)
+	assert.True(t, sharedQueryBody)
+
+	memberOrdinals, ok := esSpanAttrIntSlice(attributes, "es_batch_member_ordinals")
+	require.True(t, ok)
+	assert.Equal(t, []int64{7, 9}, memberOrdinals)
+	memberTableIDs, ok := esSpanAttrStringSlice(attributes, "es_batch_member_table_ids")
+	require.True(t, ok)
+	assert.Equal(t, []string{firstTableID, secondTableID}, memberTableIDs)
+	memberIndexCounts, ok := esSpanAttrIntSlice(attributes, "es_batch_member_index_counts")
+	require.True(t, ok)
+	assert.Equal(t, []int64{1, 1}, memberIndexCounts)
+
+	childTookMillis, ok := esSpanAttrIntSlice(attributes, "es_batch_child_took_millis")
+	require.True(t, ok)
+	assert.Equal(t, []int64{932, 41}, childTookMillis)
+	childTimedOutOrdinals, ok := esSpanAttrIntSlice(attributes, "es_batch_child_timed_out_ordinals")
+	require.True(t, ok)
+	assert.Equal(t, []int64{7}, childTimedOutOrdinals)
+	childStatuses, ok := esSpanAttrIntSlice(attributes, "es_batch_child_statuses")
+	require.True(t, ok)
+	assert.Equal(t, []int64{200, 404}, childStatuses)
+	childTotalHits, ok := esSpanAttrIntSlice(attributes, "es_batch_child_total_hits")
+	require.True(t, ok)
+	assert.Equal(t, []int64{23, 0}, childTotalHits)
+	childShardsTotal, ok := esSpanAttrIntSlice(attributes, "es_batch_child_shards_total")
+	require.True(t, ok)
+	assert.Equal(t, []int64{8, 4}, childShardsTotal)
+	childShardsSuccessful, ok := esSpanAttrIntSlice(attributes, "es_batch_child_shards_successful")
+	require.True(t, ok)
+	assert.Equal(t, []int64{7, 4}, childShardsSuccessful)
+	childShardsFailed, ok := esSpanAttrIntSlice(attributes, "es_batch_child_shards_failed")
+	require.True(t, ok)
+	assert.Equal(t, []int64{1, 0}, childShardsFailed)
+	childErrorTypes, ok := esSpanAttrStringSlice(attributes, "es_batch_child_error_types")
+	require.True(t, ok)
+	assert.Equal(t, []string{"shard_failure", "index_not_found_exception"}, childErrorTypes)
+
 	memberCount, ok := esSpanAttrInt(attributes, "es_batch_member_count")
 	require.True(t, ok)
-	assert.EqualValues(t, 1, memberCount)
+	assert.EqualValues(t, 2, memberCount)
 	bodyBytes, ok := esSpanAttrInt(attributes, "es_batch_body_bytes")
 	require.True(t, ok)
 	assert.Positive(t, bodyBytes)
+}
+
+func TestRawBatchSpanTruncatesOversizedSharedQueryBody(t *testing.T) {
+	recorder := setupESTraceRecorder(t)
+	const maxQueryBodyLength = 16 * 1024
+	queryBody := strings.Repeat("x", maxQueryBodyLength+1)
+	connect, instance, server := rawBatchTestServer(
+		t,
+		http.StatusOK,
+		`{"responses":[{"status":200,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}]}`,
+	)
+	defer server.Close()
+
+	batch := rawSingleBatch(t, rawBatchPrepared(t, connect, []string{"index-a"}, queryBody, 0))
+	_, err := instance.ExecuteRawBatch(context.Background(), batch, 0)
+	require.NoError(t, err)
+
+	attributes := endedSpanAttrs(t, recorder)
+	queryBodyAttribute, ok := esSpanAttrString(attributes, "query-body")
+	require.True(t, ok)
+	assert.Equal(t, queryBody[:maxQueryBodyLength], queryBodyAttribute)
+	queryBodySize, ok := esSpanAttrInt(attributes, "query-body-size")
+	require.True(t, ok)
+	assert.EqualValues(t, len([]byte(queryBody)), queryBodySize)
+	queryBodyTruncated, ok := esSpanAttrBool(attributes, "query-body-truncated")
+	require.True(t, ok)
+	assert.True(t, queryBodyTruncated)
+}
+
+func TestRawBatchSpanTruncatesSharedQueryBodyOnUTF8Boundary(t *testing.T) {
+	recorder := setupESTraceRecorder(t)
+	const maxQueryBodyBytes = 16 * 1024
+	queryBody := strings.Repeat("查", maxQueryBodyBytes/3+1)
+	connect, instance, server := rawBatchTestServer(
+		t,
+		http.StatusOK,
+		`{"responses":[{"status":200,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}]}`,
+	)
+	defer server.Close()
+
+	batch := rawSingleBatch(t, rawBatchPrepared(t, connect, []string{"index-a"}, queryBody, 0))
+	_, err := instance.ExecuteRawBatch(context.Background(), batch, 0)
+	require.NoError(t, err)
+
+	attributes := endedSpanAttrs(t, recorder)
+	queryBodyAttribute, ok := esSpanAttrString(attributes, "query-body")
+	require.True(t, ok)
+	assert.LessOrEqual(t, len([]byte(queryBodyAttribute)), maxQueryBodyBytes)
+	assert.True(t, utf8.ValidString(queryBodyAttribute))
+	assert.True(t, strings.HasPrefix(queryBody, queryBodyAttribute))
+	queryBodyTruncated, ok := esSpanAttrBool(attributes, "query-body-truncated")
+	require.True(t, ok)
+	assert.True(t, queryBodyTruncated)
+}
+
+func TestRawBatchSpanOmitsQueryBodyWhenMembersDiffer(t *testing.T) {
+	recorder := setupESTraceRecorder(t)
+	connect, instance, server := rawBatchTestServer(
+		t,
+		http.StatusOK,
+		`{"responses":[`+
+			`{"status":200,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}},`+
+			`{"status":200,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}]}`,
+	)
+	defer server.Close()
+
+	batch := rawBatchFromMembers(t, []RawBatchMember{
+		{Ordinal: 0, Prepared: rawBatchPrepared(t, connect, []string{"index-a"}, `{"query":{"term":{"level":"info"}}}`, 0)},
+		{Ordinal: 1, Prepared: rawBatchPrepared(t, connect, []string{"index-b"}, `{"query":{"term":{"level":"error"}}}`, 0)},
+	})
+	_, err := instance.ExecuteRawBatch(context.Background(), batch, 0)
+	require.NoError(t, err)
+
+	attributes := endedSpanAttrs(t, recorder)
+	sharedQueryBody, ok := esSpanAttrBool(attributes, "es_batch_shared_query_body")
+	require.True(t, ok)
+	assert.False(t, sharedQueryBody)
+	_, ok = esSpanAttrString(attributes, "query-body")
+	assert.False(t, ok)
+	_, ok = esSpanAttrInt(attributes, "query-body-size")
+	assert.False(t, ok)
+	_, ok = esSpanAttrBool(attributes, "query-body-truncated")
+	assert.False(t, ok)
+}
+
+func esSpanAttrIntSlice(attrs []attribute.KeyValue, key string) ([]int64, bool) {
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			return kv.Value.AsInt64Slice(), true
+		}
+	}
+	return nil, false
+}
+
+func esSpanAttrStringSlice(attrs []attribute.KeyValue, key string) ([]string, bool) {
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			return kv.Value.AsStringSlice(), true
+		}
+	}
+	return nil, false
 }
 
 func TestRawBatchExecuteClaimsPreparedMembersOnce(t *testing.T) {


### PR DESCRIPTION
## 变更说明

- 为 Elasticsearch _msearch batch wire Span 增加成员 ordinal、逻辑表标识和每成员索引数量。
- 全批最终 DSL 一致时记录一份公共 query-body；最大 16 KiB，并按 UTF-8 边界截断。
- 按 batch 顺序记录各 child 的 took、timeout、status、total hits、分片摘要和受限错误类型。
- 不记录连接、凭据、请求头、物理索引、原始错误原因或完整 NDJSON；成员 DSL 不一致时省略 query-body。

## 验证

- GOTOOLCHAIN=go1.24.4 go test -tags jsonsonic ./... -count=1
- GOTOOLCHAIN=go1.24.4 go test -race ./tsdb/elasticsearch -count=1
- GOTOOLCHAIN=go1.24.4 go test -race ./service/http -run batch-related-tests -count=1
- GOTOOLCHAIN=go1.24.4 go vet ./tsdb/elasticsearch ./service/http
- golangci-lint v1.64.8: no new findings relative to upstream/master

## 关联

close #1010158081136997142
