### PR TITLE
fix: 修复 UQ Elasticsearch 批内成功响应状态观测为 0 --bug=137023934 --story=137023934

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/raw_batch.go
+++ b/pkg/unify-query/tsdb/elasticsearch/raw_batch.go
@@ -456,7 +456,12 @@ func recordRawBatchResponseTrace(
 			continue
 		}
 		tookMillis[index] = child.TookInMillis
-		statuses[index] = int64(child.Status)
+		status := child.Status
+		if status == 0 && child.Error == nil {
+			// Successful _msearch responses may omit the status field.
+			status = http.StatusOK
+		}
+		statuses[index] = int64(status)
 		totalHits[index] = child.TotalHits()
 		if child.TimedOut {
 			timedOutOrdinals = append(timedOutOrdinals, int64(members[index].Ordinal))

--- a/pkg/unify-query/tsdb/elasticsearch/raw_batch_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/raw_batch_test.go
@@ -489,7 +489,7 @@ func TestRawBatchSpanRecordsMemberDiagnosticsWithoutConnectionDetails(t *testing
 		_, _ = io.WriteString(
 			writer,
 			`{"responses":[`+
-				`{"took":932,"timed_out":true,"status":200,"_shards":{"total":8,"successful":7,"failed":1},`+
+				`{"took":932,"timed_out":true,"_shards":{"total":8,"successful":7,"failed":1},`+
 				`"hits":{"total":{"value":23,"relation":"eq"},"hits":[]}},`+
 				`{"took":41,"timed_out":false,"status":404,"_shards":{"total":4,"successful":4,"failed":0},`+
 				`"error":{"type":"index_not_found_exception","reason":"must-not-leak"}}]}`,


### PR DESCRIPTION
## 问题

Elasticsearch _msearch 的成功子响应可能不携带 status。SDK 反序列化后保留 int 零值，导致 Trace 中的 es_batch_child_statuses 将成功成员记录为 0。

该问题只影响可观测数据，不改变查询结果、错误判定或请求性能。

## 修复

- 当子响应 status 为 0 且不存在顶层 error 时，仅在 Trace 记录中归一为 HTTP 200
- 保留显式状态码以及未知错误状态，不修改原始响应对象
- 使用不含 status 的成功响应形态补充回归覆盖

## 验证

- GOTOOLCHAIN=go1.24.4 go test -tags jsonsonic ./... -count=1
- GOTOOLCHAIN=go1.24.4 go test -race ./tsdb/elasticsearch -count=1
- GOTOOLCHAIN=go1.24.4 go vet ./tsdb/elasticsearch
- git diff --check

close #1010158081137023934