### PR TITLE
fix(unify-query): 纠正 conditions 与字段存在性条件的 AND 组合 --bug=162154220

### DIFF
--- a/pkg/unify-query/metadata/struct.go
+++ b/pkg/unify-query/metadata/struct.go
@@ -306,6 +306,29 @@ type Orders []Order
 
 type AllConditions [][]ConditionField
 
+// MergeAllConditions returns source AND target while preserving AllConditions
+// as disjunctive normal form: outer groups are OR branches and inner fields are
+// AND clauses.
+func MergeAllConditions(source, target AllConditions) AllConditions {
+	if len(source) == 0 {
+		return target
+	}
+	if len(target) == 0 {
+		return source
+	}
+
+	merged := make(AllConditions, 0, len(source)*len(target))
+	for _, sourceGroup := range source {
+		for _, targetGroup := range target {
+			group := make([]ConditionField, 0, len(sourceGroup)+len(targetGroup))
+			group = append(group, sourceGroup...)
+			group = append(group, targetGroup...)
+			merged = append(merged, group)
+		}
+	}
+	return merged
+}
+
 type QueryList []*Query
 
 type QueryMetric struct {

--- a/pkg/unify-query/metadata/struct.go
+++ b/pkg/unify-query/metadata/struct.go
@@ -306,9 +306,8 @@ type Orders []Order
 
 type AllConditions [][]ConditionField
 
-// MergeAllConditions returns source AND target while preserving AllConditions
-// as disjunctive normal form: outer groups are OR branches and inner fields are
-// AND clauses.
+// MergeAllConditions 将 source 和 target 做 AND 合并，并保持 AllConditions 的析取范式：
+// 外层分组表示 OR 分支，内层字段表示 AND 条件。
 func MergeAllConditions(source, target AllConditions) AllConditions {
 	if len(source) == 0 {
 		return target

--- a/pkg/unify-query/tsdb/elasticsearch/format_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format_test.go
@@ -43,6 +43,62 @@ func TestFormatFactory_Query(t *testing.T) {
 			},
 			expected: `{"query":{"match_phrase":{"key":{"query":"val-1"}}}}`,
 		},
+		"condition and existed field in same group": {
+			conditions: metadata.AllConditions{{
+				{
+					DimensionName: "level",
+					Value:         []string{"__uq_conditions_should_match_nothing__"},
+					Operator:      structured.ConditionEqual,
+				},
+				{
+					DimensionName: "path",
+					Operator:      structured.ConditionExisted,
+				},
+			}},
+			expected: `{"query":{"bool":{"must":[{"match_phrase":{"level":{"query":"__uq_conditions_should_match_nothing__"}}},{"exists":{"field":"path"}}]}}}`,
+		},
+		"condition and existed field in separate groups": {
+			conditions: metadata.AllConditions{
+				{{
+					DimensionName: "level",
+					Value:         []string{"__uq_conditions_should_match_nothing__"},
+					Operator:      structured.ConditionEqual,
+				}},
+				{{
+					DimensionName: "path",
+					Operator:      structured.ConditionExisted,
+				}},
+			},
+			expected: `{"query":{"bool":{"should":[{"match_phrase":{"level":{"query":"__uq_conditions_should_match_nothing__"}}},{"exists":{"field":"path"}}]}}}`,
+		},
+		"OR condition groups AND existed field": {
+			conditions: metadata.MergeAllConditions(
+				metadata.AllConditions{
+					{{
+						DimensionName: "level",
+						Value:         []string{"info"},
+						Operator:      structured.ConditionEqual,
+					}},
+					{{
+						DimensionName: "level",
+						Value:         []string{"warn"},
+						Operator:      structured.ConditionEqual,
+					}},
+				},
+				metadata.AllConditions{{{
+					DimensionName: "path",
+					Operator:      structured.ConditionExisted,
+				}}},
+			),
+			expected: `{"query":{"bool":{"should":[{"bool":{"must":[{"match_phrase":{"level":{"query":"info"}}},{"exists":{"field":"path"}}]}},{"bool":{"must":[{"match_phrase":{"level":{"query":"warn"}}},{"exists":{"field":"path"}}]}}]}}}`,
+		},
+		"empty conditions AND existed field": {
+			conditions: metadata.MergeAllConditions(nil, metadata.AllConditions{{{
+				DimensionName: "path",
+				Operator:      structured.ConditionExisted,
+			}}}),
+			expected: `{"query":{"exists":{"field":"path"}}}`,
+		},
 		"query 2": {
 			conditions: metadata.AllConditions{
 				{

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -919,14 +919,15 @@ func (i *Instance) QueryLabelValues(ctx context.Context, query *metadata.Query, 
 		WithQuery(name, labelValuesQuery.TimeField, start, end, unit, 0).
 		WithFieldMap(fieldMap)
 
-	// 添加 exists 条件确保字段存在
-	labelValuesQuery.AllConditions = append(labelValuesQuery.AllConditions, []metadata.ConditionField{
-		{
+	// 枚举字段存在性需要与完整业务条件表达式相与，而不是新增 OR 分支。
+	labelValuesQuery.AllConditions = metadata.MergeAllConditions(
+		labelValuesQuery.AllConditions,
+		metadata.AllConditions{{{
 			DimensionName: name,
 			Value:         []string{},
 			Operator:      metadata.ConditionExisted,
-		},
-	})
+		}}},
+	)
 
 	labelValuesQuery.Aggregates = append(labelValuesQuery.Aggregates, metadata.Aggregate{
 		Name:       Cardinality,


### PR DESCRIPTION
## Summary
- Combine the additional field-exists constraint with every `AllConditions` OR branch.
- Add `TestFormatFactory_Query` regressions for AND, OR, and distributed OR conditions.

## Tests
- `go test ./... -count=1`
- `go test -race ./tsdb/elasticsearch -run "^TestInstance_QueryLabelValuesConcurrentSharedQueryDoesNotMutate$" -count=1`
- `go vet ./metadata ./tsdb/elasticsearch`