### PR TITLE
feat: tag_values 枚举查询支持 query_string 过滤条件 --story=137100977

### DIFF
--- a/pkg/unify-query/docs/docs.go
+++ b/pkg/unify-query/docs/docs.go
@@ -1476,6 +1476,10 @@ const docTemplate = `{
                 "metric_name": {
                     "type": "string"
                 },
+                "query_string": {
+                    "description": "QueryString 日志查询串，用于在枚举维度值前过滤日志数据集。",
+                    "type": "string"
+                },
                 "slimit": {
                     "type": "integer"
                 },

--- a/pkg/unify-query/docs/swagger.json
+++ b/pkg/unify-query/docs/swagger.json
@@ -1460,6 +1460,10 @@
                 "metric_name": {
                     "type": "string"
                 },
+                "query_string": {
+                    "description": "QueryString 日志查询串，用于在枚举维度值前过滤日志数据集。",
+                    "type": "string"
+                },
                 "slimit": {
                     "type": "integer"
                 },

--- a/pkg/unify-query/docs/swagger.yaml
+++ b/pkg/unify-query/docs/swagger.yaml
@@ -202,6 +202,9 @@ definitions:
         type: integer
       metric_name:
         type: string
+      query_string:
+        description: QueryString 日志查询串，用于在枚举维度值前过滤日志数据集。
+        type: string
       slimit:
         type: integer
       start_time:

--- a/pkg/unify-query/service/http/api.go
+++ b/pkg/unify-query/service/http/api.go
@@ -714,6 +714,7 @@ func infoParamsToQueryRef(ctx context.Context, params *Params) (queryRef metadat
 				FieldName:         params.Metric,
 				IsRegexp:          params.IsRegexp,
 				Conditions:        params.Conditions,
+				QueryString:       params.QueryString,
 				TableIDConditions: params.TableIDConditions,
 				Limit:             params.Limit,
 				ReferenceName:     metadata.DefaultReferenceName,

--- a/pkg/unify-query/service/http/handler_test.go
+++ b/pkg/unify-query/service/http/handler_test.go
@@ -669,8 +669,10 @@ func TestInfoParamsToQueryRef(t *testing.T) {
 	metadata.SetUser(ctx, &metadata.User{SpaceUID: influxdb.SpaceUid})
 
 	testCases := map[string]struct {
-		params     *Params
-		expectedRT string
+		params           *Params
+		body             string
+		expectedRT       string
+		expectedQueryStr string
 	}{
 		"route by table_id_conditions when table_id and metric_name empty": {
 			params: &Params{
@@ -684,14 +686,36 @@ func TestInfoParamsToQueryRef(t *testing.T) {
 			},
 			expectedRT: influxdb.ResultTableEs,
 		},
+		"preserve query_string from tag values request": {
+			params: &Params{
+				DataSource: "bklog",
+				TableID:    "nano",
+				Metric:     "_index",
+			},
+			body:             `{"data_source":"bklog","table_id":"nano","metric_name":"_index","query_string":"level:error"}`,
+			expectedQueryStr: "level:error",
+		},
 	}
 
 	for name, c := range testCases {
 		t.Run(name, func(t *testing.T) {
+			if c.body != "" {
+				assert.NoError(t, json.NewDecoder(bytes.NewBufferString(c.body)).Decode(c.params))
+			}
 			queryRef, err := infoParamsToQueryRef(ctx, c.params)
 			assert.NoError(t, err)
-			assert.Truef(t, queryRefContainsResultTable(queryRef, c.expectedRT),
-				"expected RT %q to be matched by TableIDConditions", c.expectedRT)
+			if c.expectedRT != "" {
+				assert.Truef(t, queryRefContainsResultTable(queryRef, c.expectedRT),
+					"expected RT %q to be matched by TableIDConditions", c.expectedRT)
+			}
+			if c.expectedQueryStr != "" {
+				queryCount := 0
+				queryRef.Range("", func(query *metadata.Query) {
+					queryCount++
+					assert.Equal(t, c.expectedQueryStr, query.QueryString)
+				})
+				assert.Greater(t, queryCount, 0)
+			}
 		})
 	}
 }

--- a/pkg/unify-query/service/http/infos.go
+++ b/pkg/unify-query/service/http/infos.go
@@ -36,6 +36,8 @@ type Params struct {
 	IsRegexp bool `json:"is_regexp" example:"false"`
 
 	Conditions structured.Conditions `json:"conditions"`
+	// QueryString 日志查询串，用于在枚举维度值前过滤日志数据集。
+	QueryString string `json:"query_string,omitempty"`
 	// TableIDConditions 表标签条件；与 /query/ts 的 body.table_id_conditions 一致，
 	// 仅在未指定 table_id / data_label 的全空间扫表场景下按结果表 Labels 收窄候选 RT。
 	TableIDConditions structured.AllConditions `json:"table_id_conditions,omitempty"`

--- a/pkg/unify-query/tsdb/elasticsearch/instance_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance_test.go
@@ -1539,6 +1539,50 @@ func TestInstance_QueryLabelValuesConcurrentSharedQueryDoesNotMutate(t *testing.
 	assert.Equal(t, originalAggregates, query.Aggregates)
 }
 
+func TestBuildESQuerySourceTagValuesQueryString(t *testing.T) {
+	ctx := metadata.InitHashID(context.Background())
+	start := time.Unix(1764074673, 0)
+	end := time.Unix(1764078273, 0)
+
+	for name, tc := range map[string]struct {
+		queryString string
+		expected    string
+	}{
+		"query string filters enum values": {
+			queryString: "level:error",
+			expected:    `{"aggregations":{"level":{"aggregations":{"_value":{"cardinality":{"field":"level"}}},"terms":{"field":"level","missing":" "}}},"query":{"bool":{"filter":[{"exists":{"field":"level"}},{"range":{"dtEventTimeStamp":{"format":"epoch_second","from":1764074673,"include_lower":true,"include_upper":true,"to":1764078273}}},{"term":{"level":"error"}}]}},"size":0}`,
+		},
+		"empty query string keeps enum filters": {
+			expected: `{"aggregations":{"level":{"aggregations":{"_value":{"cardinality":{"field":"level"}}},"terms":{"field":"level","missing":" "}}},"query":{"bool":{"filter":[{"exists":{"field":"level"}},{"range":{"dtEventTimeStamp":{"format":"epoch_second","from":1764074673,"include_lower":true,"include_upper":true,"to":1764078273}}}]}},"size":0}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			query := &metadata.Query{
+				QueryString: tc.queryString,
+				AllConditions: metadata.AllConditions{{{
+					DimensionName: "level",
+					Operator:      metadata.ConditionExisted,
+				}}},
+				Aggregates: metadata.Aggregates{{
+					Name:       Cardinality,
+					Field:      "level",
+					Dimensions: []string{"level"},
+					Without:    true,
+				}},
+			}
+			fact := NewFormatFactory(ctx).
+				WithQuery("level", metadata.TimeField{Name: "dtEventTimeStamp", Type: TimeFieldTypeTime, Unit: "s"}, start, end, "s", 0).
+				WithFieldMap(metadata.FieldsMap{
+					"level": {FieldName: "level", FieldType: KeyWord},
+				})
+
+			_, _, body, err := buildESQuerySource(ctx, query, fact, nil)
+			assert.NoError(t, err)
+			assert.JSONEq(t, tc.expected, body)
+		})
+	}
+}
+
 func TestInstance_QuerySeries(t *testing.T) {
 	mock.Init()
 

--- a/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/query_string_test.go
@@ -105,6 +105,11 @@ func TestQsToDsl(t *testing.T) {
 		err      error
 	}{
 		{
+			name:     "keyword field query string becomes term query",
+			q:        `level:error`,
+			expected: `{"term":{"level":"error"}}`,
+		},
+		{
 			q:        `log: "ERROR MSG"`,
 			expected: `{"match_phrase":{"log":{"query":"ERROR MSG"}}}`,
 		},


### PR DESCRIPTION
## 变更说明

- 为 `/query/ts/info/tag_values` 请求参数增加可选 `query_string`
- 将查询串透传到结构化查询，并参与枚举值 Elasticsearch DSL 构造
- 保持空查询串场景的原有枚举行为
- 更新 Swagger API 文档

## 测试

- `go test ./service/http ./tsdb/elasticsearch -count=1`
- 覆盖 `level:error` 转换为 `term` 查询，并与 `exists(level)`、时间范围共同组成过滤条件

TAPD #1010158081137100977
