### PR TITLE
fix(unify-query): ES 聚合按原始字段名分组时维度被丢弃 --story=137248585

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/agg_format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/agg_format.go
@@ -42,6 +42,9 @@ type aggFormat struct {
 
 	promDataFormat func(k string) string
 
+	// extraLabelKeys 记录 ES 字段名需要额外补出的维度键，为空表示不补
+	extraLabelKeys map[string][]string
+
 	timeFormat func(i int64) int64
 
 	dims  []string
@@ -63,15 +66,24 @@ func (a *aggFormat) put() {
 }
 
 func (a *aggFormat) addLabel(name, value string) {
+	formatted := name
 	if a.promDataFormat != nil {
-		name = a.promDataFormat(name)
+		formatted = a.promDataFormat(name)
 	}
 
 	newLb := make(map[string]string)
 	for k, v := range a.item.labels {
 		newLb[k] = v
 	}
-	newLb[name] = value
+	newLb[formatted] = value
+
+	// 配了别名的字段在这里会被改写成别名，而 PromQL 的 by 子句用的是请求里写的字段名，
+	// 两者对不上时该维度会被整个聚合掉。所以按请求名再补一份，两种写法都能分组。
+	// 同层的多个桶共用一份 labels，这里必须无条件覆盖，否则会留下上一个桶的值。
+	for _, key := range a.extraLabelKeys[name] {
+		newLb[key] = value
+	}
+
 	a.item.labels = newLb
 }
 

--- a/pkg/unify-query/tsdb/elasticsearch/agg_format_alias_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/agg_format_alias_test.go
@@ -27,52 +27,40 @@ const aliasAggResponse = `{"aggregations":{"__ext.labels.app":{"doc_count_error_
 	`{"key":"api","doc_count":1,"dtEventTimeStamp":{"buckets":[{"key_as_string":"1733241600000","key":1733241600000,"doc_count":1,"_value":{"value":1.0}}]}}` +
 	`]}}}`
 
-// newAliasFormatFactory 复刻 Instance.QuerySeriesSet 里的字段名转换配置：
-// 出端先把 ES 字段名换成别名再做格式转换，入端反向。
+// multiDimAggResponse 是 app / cluster / signature 三层嵌套分桶的聚合响应，
+// 三个字段都配了别名，且 web 下有 c1、c2 两个 cluster，api 下只有 c1。
+const multiDimAggResponse = `{"aggregations":{"__ext.labels.app":{"buckets":[` +
+	`{"key":"web","doc_count":3,"__ext.cluster":{"buckets":[` +
+	`{"key":"c1","doc_count":2,"__dist_05":{"buckets":[` +
+	`{"key":"sigA","doc_count":2,"dtEventTimeStamp":{"buckets":[{"key_as_string":"1733241600000","key":1733241600000,"doc_count":2,"_value":{"value":2.0}}]}}]}},` +
+	`{"key":"c2","doc_count":1,"__dist_05":{"buckets":[` +
+	`{"key":"sigB","doc_count":1,"dtEventTimeStamp":{"buckets":[{"key_as_string":"1733241600000","key":1733241600000,"doc_count":1,"_value":{"value":1.0}}]}}]}}]}},` +
+	`{"key":"api","doc_count":1,"__ext.cluster":{"buckets":[` +
+	`{"key":"c1","doc_count":1,"__dist_05":{"buckets":[` +
+	`{"key":"sigC","doc_count":1,"dtEventTimeStamp":{"buckets":[{"key_as_string":"1733241600000","key":1733241600000,"doc_count":1,"_value":{"value":1.0}}]}}]}}]}}` +
+	`]}}}`
+
+// newAliasFormatFactory 直接走生产接线 newSeriesFormatFactory，
+// 这样别名改写与 aliasFreeEncode 之间的不对称一旦被改动，用例就会红。
 func newAliasFormatFactory(ctx context.Context, fieldAlias metadata.FieldAlias, isReference bool) *FormatFactory {
-	encodeFunc := metadata.GetFieldFormat(ctx).EncodeFunc()
-	decodeFunc := metadata.GetFieldFormat(ctx).DecodeFunc()
+	metadata.GetQueryParams(ctx).SetIsReference(isReference)
 
-	reverseAlias := make(map[string]string, len(fieldAlias))
-	for k, v := range fieldAlias {
-		reverseAlias[v] = k
-	}
-
-	return NewFormatFactory(ctx).
-		WithTransform(func(s string) string {
-			ns := s
-			if alias, ok := reverseAlias[ns]; ok {
-				ns = alias
-			}
-			if encodeFunc != nil {
-				ns = encodeFunc(ns)
-			}
-			return ns
-		}, func(s string) string {
-			ns := s
-			if decodeFunc != nil {
-				ns = decodeFunc(ns)
-			}
-			if alias, ok := fieldAlias[ns]; ok {
-				ns = alias
-			}
-			return ns
-		}).
-		WithAliasFreeEncode(func(s string) string {
-			if encodeFunc != nil {
-				return encodeFunc(s)
-			}
-			return s
-		}).
-		WithIsReference(isReference).
-		WithQuery("", metadata.TimeField{
+	return newSeriesFormatFactory(ctx, &metadata.Query{
+		FieldAlias: fieldAlias,
+		TimeField: metadata.TimeField{
 			Name: DefaultTimeFieldName,
 			Type: DefaultTimeFieldType,
 			Unit: DefaultTimeFieldUnit,
-		}, time.Time{}, time.Time{}, "", 0)
+		},
+	}, nil, time.Time{}, time.Time{}, "", 0)
 }
 
 func aggLabels(t *testing.T, fact *FormatFactory, dimensions []string) []map[string]string {
+	t.Helper()
+	return aggLabelsFrom(t, fact, dimensions, aliasAggResponse)
+}
+
+func aggLabelsFrom(t *testing.T, fact *FormatFactory, dimensions []string, response string) []map[string]string {
 	t.Helper()
 
 	_, _, err := fact.EsAgg(metadata.Aggregates{
@@ -85,7 +73,7 @@ func aggLabels(t *testing.T, fact *FormatFactory, dimensions []string) []map[str
 	assert.NoError(t, err)
 
 	var sr *elastic.SearchResult
-	assert.NoError(t, json.Unmarshal([]byte(aliasAggResponse), &sr))
+	assert.NoError(t, json.Unmarshal([]byte(response), &sr))
 
 	qr, err := fact.AggDataFormat(sr.Aggregations, nil)
 	assert.NoError(t, err)
@@ -159,4 +147,37 @@ func TestAggDataFormat_AliasFreeKeyIsPromQLCompatible(t *testing.T) {
 		assert.Contains(t, lb, "__ext__bk_46__labels__bk_46__app")
 		assert.Contains(t, lb, "app")
 	}
+}
+
+// TestAggDataFormat_AliasFreeDimensionKeyWithNestedBuckets 复刻线上聚类告警的形态：
+// signature 用别名请求、另外两个用原始字段名请求，且分桶不对称（web 有两个 cluster，api 只有一个）。
+// 同层的多个桶共用一份 labels，这里验证嵌套桶下补键跟对了各自的值，没有残留上一个桶的。
+func TestAggDataFormat_AliasFreeDimensionKeyWithNestedBuckets(t *testing.T) {
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+
+	fieldAlias := metadata.FieldAlias{
+		"signature": "__dist_05",
+		"cluster":   "__ext.cluster",
+		"app":       "__ext.labels.app",
+	}
+	labels := aggLabelsFrom(t, newAliasFormatFactory(ctx, fieldAlias, false),
+		[]string{"signature", "__ext.cluster", "__ext.labels.app"}, multiDimAggResponse)
+
+	assert.Len(t, labels, 3)
+	for _, lb := range labels {
+		assert.Equal(t, lb["app"], lb["__ext__bk_46__labels__bk_46__app"], "app 补键必须与别名键同值")
+		assert.Equal(t, lb["cluster"], lb["__ext__bk_46__cluster"], "cluster 补键必须与别名键同值")
+		// signature 是用别名请求的，本来就匹配得上，不该多补键
+		assert.NotEmpty(t, lb["signature"])
+		assert.NotContains(t, lb, "__dist_05")
+	}
+
+	got := make(map[string][2]string, len(labels))
+	for _, lb := range labels {
+		got[lb["signature"]] = [2]string{lb["__ext__bk_46__labels__bk_46__app"], lb["__ext__bk_46__cluster"]}
+	}
+	assert.Equal(t, [2]string{"web", "c1"}, got["sigA"])
+	assert.Equal(t, [2]string{"web", "c2"}, got["sigB"])
+	assert.Equal(t, [2]string{"api", "c1"}, got["sigC"])
 }

--- a/pkg/unify-query/tsdb/elasticsearch/agg_format_alias_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/agg_format_alias_test.go
@@ -1,0 +1,162 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package elasticsearch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	elastic "github.com/olivere/elastic/v7"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/json"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
+)
+
+// aliasAggResponse 是按 __ext.labels.app 分桶的聚合响应，该字段配了别名 app。
+const aliasAggResponse = `{"aggregations":{"__ext.labels.app":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[` +
+	`{"key":"web","doc_count":2,"dtEventTimeStamp":{"buckets":[{"key_as_string":"1733241600000","key":1733241600000,"doc_count":2,"_value":{"value":2.0}}]}},` +
+	`{"key":"api","doc_count":1,"dtEventTimeStamp":{"buckets":[{"key_as_string":"1733241600000","key":1733241600000,"doc_count":1,"_value":{"value":1.0}}]}}` +
+	`]}}}`
+
+// newAliasFormatFactory 复刻 Instance.QuerySeriesSet 里的字段名转换配置：
+// 出端先把 ES 字段名换成别名再做格式转换，入端反向。
+func newAliasFormatFactory(ctx context.Context, fieldAlias metadata.FieldAlias, isReference bool) *FormatFactory {
+	encodeFunc := metadata.GetFieldFormat(ctx).EncodeFunc()
+	decodeFunc := metadata.GetFieldFormat(ctx).DecodeFunc()
+
+	reverseAlias := make(map[string]string, len(fieldAlias))
+	for k, v := range fieldAlias {
+		reverseAlias[v] = k
+	}
+
+	return NewFormatFactory(ctx).
+		WithTransform(func(s string) string {
+			ns := s
+			if alias, ok := reverseAlias[ns]; ok {
+				ns = alias
+			}
+			if encodeFunc != nil {
+				ns = encodeFunc(ns)
+			}
+			return ns
+		}, func(s string) string {
+			ns := s
+			if decodeFunc != nil {
+				ns = decodeFunc(ns)
+			}
+			if alias, ok := fieldAlias[ns]; ok {
+				ns = alias
+			}
+			return ns
+		}).
+		WithAliasFreeEncode(func(s string) string {
+			if encodeFunc != nil {
+				return encodeFunc(s)
+			}
+			return s
+		}).
+		WithIsReference(isReference).
+		WithQuery("", metadata.TimeField{
+			Name: DefaultTimeFieldName,
+			Type: DefaultTimeFieldType,
+			Unit: DefaultTimeFieldUnit,
+		}, time.Time{}, time.Time{}, "", 0)
+}
+
+func aggLabels(t *testing.T, fact *FormatFactory, dimensions []string) []map[string]string {
+	t.Helper()
+
+	_, _, err := fact.EsAgg(metadata.Aggregates{
+		{
+			Name:       "max",
+			Dimensions: dimensions,
+			Window:     time.Hour * 24,
+		},
+	})
+	assert.NoError(t, err)
+
+	var sr *elastic.SearchResult
+	assert.NoError(t, json.Unmarshal([]byte(aliasAggResponse), &sr))
+
+	qr, err := fact.AggDataFormat(sr.Aggregations, nil)
+	assert.NoError(t, err)
+
+	labels := make([]map[string]string, 0, len(qr.Timeseries))
+	for _, ts := range qr.Timeseries {
+		lb := make(map[string]string, len(ts.Labels))
+		for _, l := range ts.Labels {
+			lb[l.Name] = l.Value
+		}
+		labels = append(labels, lb)
+	}
+	return labels
+}
+
+// TestAggDataFormat_AliasFreeDimensionKey 覆盖配了别名的字段按原始字段名分组的场景。
+// PromQL 的 by 子句只做格式转换、不认别名，聚合结果若只留别名键，按原始字段名分组会匹配不上而丢维度。
+func TestAggDataFormat_AliasFreeDimensionKey(t *testing.T) {
+	metadata.InitMetadata()
+
+	fieldAlias := metadata.FieldAlias{"app": "__ext.labels.app"}
+	// PromQL 语句里的维度名只经过格式转换，这里对齐同一套规则。
+	promQLKey := metadata.GetFieldFormat(context.Background()).EncodeFunc()("__ext.labels.app")
+
+	t.Run("group by original field keeps both keys", func(t *testing.T) {
+		ctx := metadata.InitHashID(context.Background())
+		labels := aggLabels(t, newAliasFormatFactory(ctx, fieldAlias, false), []string{"__ext.labels.app"})
+
+		assert.Len(t, labels, 2)
+		for _, lb := range labels {
+			assert.Len(t, lb, 2)
+			assert.Equal(t, lb["app"], lb[promQLKey], "两个维度键必须指向同一个值")
+			assert.Contains(t, []string{"web", "api"}, lb["app"])
+		}
+	})
+
+	// 用别名分组本来就能匹配上，不该多补一个键，避免无谓地改变既有响应。
+	for name, c := range map[string]struct {
+		fieldAlias  metadata.FieldAlias
+		dimensions  []string
+		isReference bool
+	}{
+		"group by alias":           {fieldAlias: fieldAlias, dimensions: []string{"app"}},
+		"reference query":          {fieldAlias: fieldAlias, dimensions: []string{"__ext.labels.app"}, isReference: true},
+		"field without alias":      {dimensions: []string{"__ext.labels.app"}},
+		"reference group by alias": {fieldAlias: fieldAlias, dimensions: []string{"app"}, isReference: true},
+	} {
+		t.Run(name+" keeps single key", func(t *testing.T) {
+			ctx := metadata.InitHashID(context.Background())
+			labels := aggLabels(t, newAliasFormatFactory(ctx, c.fieldAlias, c.isReference), c.dimensions)
+
+			assert.Len(t, labels, 2)
+			for _, lb := range labels {
+				assert.Len(t, lb, 1)
+			}
+		})
+	}
+}
+
+// TestAggDataFormat_AliasFreeKeyIsPromQLCompatible 固定补出来的键与 PromQL 侧的口径一致，
+// 避免后续改动只补了原始字段名——那样带点的字段在 PromQL 里依然匹配不上。
+func TestAggDataFormat_AliasFreeKeyIsPromQLCompatible(t *testing.T) {
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+
+	labels := aggLabels(t, newAliasFormatFactory(ctx, metadata.FieldAlias{"app": "__ext.labels.app"}, false), []string{"__ext.labels.app"})
+	assert.NotEmpty(t, labels)
+
+	for _, lb := range labels {
+		assert.NotContains(t, lb, "__ext.labels.app", "带点的键在 PromQL 里不合法，必须是格式转换后的形式")
+		assert.Contains(t, lb, "__ext__bk_46__labels__bk_46__app")
+		assert.Contains(t, lb, "app")
+	}
+}

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -161,6 +161,11 @@ type FormatFactory struct {
 	decode func(k string) string
 	encode func(k string) string
 
+	// aliasFreeEncode 与 encode 的差别只在于不做别名改写，用于还原请求里写的维度名
+	aliasFreeEncode func(k string) string
+	// extraLabelKeys 记录 ES 字段名需要额外补出的维度键，只有请求名与别名不一致时才有内容
+	extraLabelKeys map[string][]string
+
 	fieldsMap metadata.FieldsMap
 
 	data map[string]any
@@ -321,6 +326,36 @@ func (f *FormatFactory) WithTransform(encode func(string) string, decode func(st
 		f.valueField = decode(f.valueField)
 	}
 	return f
+}
+
+// WithAliasFreeEncode 注册不做别名改写的字段名转换，用于还原请求里写的维度名。
+func (f *FormatFactory) WithAliasFreeEncode(encode func(string) string) *FormatFactory {
+	f.aliasFreeEncode = encode
+	return f
+}
+
+// recordRequestedDimension 记录请求里写的维度名。出端默认把字段名改写成别名，
+// 而 PromQL 的 by 子句用的是请求名，两者不一致时该维度会被整个聚合掉，
+// 所以这里留一份请求名，供聚合结果补出可分组的维度键。
+func (f *FormatFactory) recordRequestedDimension(requested, field string) {
+	if f.aliasFreeEncode == nil {
+		return
+	}
+
+	key := f.aliasFreeEncode(requested)
+	if key == "" || key == f.encode(field) {
+		return
+	}
+
+	if f.extraLabelKeys == nil {
+		f.extraLabelKeys = make(map[string][]string)
+	}
+	for _, exist := range f.extraLabelKeys[field] {
+		if exist == key {
+			return
+		}
+	}
+	f.extraLabelKeys[field] = append(f.extraLabelKeys[field], key)
 }
 
 func (f *FormatFactory) WithOrders(orders metadata.Orders) *FormatFactory {
@@ -498,6 +533,12 @@ func (f *FormatFactory) AggDataFormat(data elastic.Aggregations, metricLabel *pr
 		items:          make(items, 0),
 		promDataFormat: f.encode,
 		timeFormat:     f.toMillisecond,
+	}
+
+	// reference 查询直出存储引擎的聚合结果，不经 PromQL 分组，补键只会凭空多出一列，所以只在走
+	// PromQL 的查询上补。
+	if !f.isReference {
+		af.extraLabelKeys = f.extraLabelKeys
 	}
 
 	af.get()
@@ -861,9 +902,11 @@ func (f *FormatFactory) EsAgg(aggregates metadata.Aggregates) (string, elastic.A
 				if dim == "" || dim == labels.MetricName {
 					continue
 				}
+				requested := dim
 				if f.decode != nil {
 					dim = f.decode(dim)
 				}
+				f.recordRequestedDimension(requested, dim)
 
 				f.termAgg(dim, idx == 0)
 			}

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -342,8 +342,13 @@ func (f *FormatFactory) recordRequestedDimension(requested, field string) {
 		return
 	}
 
+	encoded := field
+	if f.encode != nil {
+		encoded = f.encode(field)
+	}
+
 	key := f.aliasFreeEncode(requested)
-	if key == "" || key == f.encode(field) {
+	if key == "" || key == encoded {
 		return
 	}
 
@@ -535,8 +540,11 @@ func (f *FormatFactory) AggDataFormat(data elastic.Aggregations, metricLabel *pr
 		timeFormat:     f.toMillisecond,
 	}
 
-	// reference 查询直出存储引擎的聚合结果，不经 PromQL 分组，补键只会凭空多出一列，所以只在走
-	// PromQL 的查询上补。
+	// reference 查询直出存储引擎的聚合结果，不经 PromQL 分组，补键只会凭空多出一列，
+	// 而下游是按结果列的下标位置取值的，多一列会直接错位。所以 reference 保持只返回别名键，
+	// 用原始字段名请求、拿到别名键这个改名行为不变，由下游按别名读取。
+	// 这与 metadata.FieldAlias.AddAliasKeysWhenOriginalFieldPresent 的双键是同一套过渡方案，
+	// 那里带着「等前端适配之后再移除」的 TODO，将来清理时两处应一起处理。
 	if !f.isReference {
 		af.extraLabelKeys = f.extraLabelKeys
 	}

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -850,6 +850,14 @@ func (i *Instance) QuerySeriesSet(
 			return ns
 		},
 		).
+		// PromQL 的 by 子句只做格式转换、不认别名（见 structured.QueryTs 生成语句处），
+		// 出端若只留别名键，按原始字段名分组就会匹配不上而丢维度，这里补一份同口径的键。
+		WithAliasFreeEncode(func(s string) string {
+			if encodeFunc != nil {
+				return encodeFunc(s)
+			}
+			return s
+		}).
 		WithIncludeValues(labelMap).
 		WithIsReference(metadata.GetQueryParams(ctx).IsReference).
 		WithQuery(query.Field, query.TimeField, qo.start, qo.end, unit, size).

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -813,8 +813,26 @@ func (i *Instance) QuerySeriesSet(
 		size = i.maxSize
 	}
 
-	labelMap := function.LabelMap(ctx, query)
+	fact := newSeriesFormatFactory(ctx, query, fieldMap, qo.start, qo.end, unit, size)
 
+	if len(query.Aggregates) == 0 {
+		return storage.ErrSeriesSet(fmt.Errorf("aggregates is empty"))
+	}
+
+	return i.queryWithAgg(ctx, qo, fact)
+}
+
+// newSeriesFormatFactory 组装时序聚合查询的字段名转换：
+// 出端把 ES 字段名换成别名再做格式转换，入端反向；aliasFreeEncode 只做格式转换、不认别名，
+// 用于还原请求里写的维度名。这组不对称正是补键逻辑的前提，改动时需连同 agg_format_alias_test.go 一起看。
+func newSeriesFormatFactory(
+	ctx context.Context,
+	query *metadata.Query,
+	fieldMap metadata.FieldsMap,
+	start, end time.Time,
+	unit string,
+	size int,
+) *FormatFactory {
 	encodeFunc := metadata.GetFieldFormat(ctx).EncodeFunc()
 	decodeFunc := metadata.GetFieldFormat(ctx).DecodeFunc()
 
@@ -823,7 +841,7 @@ func (i *Instance) QuerySeriesSet(
 		reverseAlias[v] = k
 	}
 
-	fact := NewFormatFactory(ctx).
+	return NewFormatFactory(ctx).
 		WithTransform(func(s string) string {
 			// 别名替换
 			ns := s
@@ -858,17 +876,11 @@ func (i *Instance) QuerySeriesSet(
 			}
 			return s
 		}).
-		WithIncludeValues(labelMap).
+		WithIncludeValues(function.LabelMap(ctx, query)).
 		WithIsReference(metadata.GetQueryParams(ctx).IsReference).
-		WithQuery(query.Field, query.TimeField, qo.start, qo.end, unit, size).
+		WithQuery(query.Field, query.TimeField, start, end, unit, size).
 		WithFieldMap(fieldMap).
 		WithOrders(query.Orders)
-
-	if len(query.Aggregates) == 0 {
-		return storage.ErrSeriesSet(fmt.Errorf("aggregates is empty"))
-	}
-
-	return i.queryWithAgg(ctx, qo, fact)
 }
 
 func (i *Instance) QueryLabelNames(ctx context.Context, query *metadata.Query, start, end time.Time) ([]string, error) {


### PR DESCRIPTION
## 问题

结果表配了字段别名（`field_alias`）后，用**原始字段名**作为聚合维度查询 `/query/ts`，该维度会被整个丢弃：响应里既没有这个维度，序列也因为少了一层拆分而被合并。用别名查询则正常。

以配了 `app -> __ext.labels.app` 的索引集为例，同一份数据、同一时间窗，只有维度名写法不同：

```
by (signature, __ext.labels.app)  ->  实际分组 [signature]              24 条序列
by (signature, app)               ->  实际分组 [app, signature]         39 条序列
```

对上层的影响不只是维度栏为空：聚合口径同时退化了，多个 app 下的同一个 signature 会被合并成一条，粒度变粗。

## 原因

维度名在两个地方各自转换，用了不同的规则：

| 环节 | 转换 | `__ext.labels.app` 得到 |
|------|------|------------------------|
| PromQL `by` 子句（`structured` 生成语句处） | 只做格式转换 | `__ext__bk_46__labels__bk_46__app` |
| ES 出端 series label（`QuerySeriesSet` 的 transform） | 先别名改写、再格式转换 | `app` |

ES 侧分桶其实是对的，数据一直在；是 PromQL 按一个 series 上不存在的 label 分组，才把维度聚合掉了。没配别名的字段两边规则一致，所以不受影响；`/query/ts/reference` 直出存储引擎聚合结果、不经 PromQL 分组，也不受影响。

## 改动

聚合结果在别名键之外，按请求里写的维度名补一份同口径的键，两种写法都能分组：

- 只在请求名与别名不一致时补，用别名查询的响应完全不变；
- 补出的键与 PromQL 侧口径一致（同样只做格式转换），否则带点的字段仍然匹配不上；
- reference 查询不补，避免凭空多出一列。

## 测试

新增 `agg_format_alias_test.go`，覆盖按原始字段名分组补键、按别名分组不补、无别名不补、reference 不补，并固定补出的键必须是格式转换后的形式。已验证去掉修复后这些用例会失败。`tsdb/`、`service/`、`query/` 全部测试通过。

详见 TAPD #1010158081137248585

## 评审后的调整

- 把 `QuerySeriesSet` 里的 `FormatFactory` 构造抽成包内函数 `newSeriesFormatFactory`，生产代码和测试共用。此前测试用手写闭包复刻接线，改坏 `instance.go` 测试也不会红，现在这组「出端改写别名、`aliasFreeEncode` 不改写」的不对称完全来自生产代码。
- `recordRequestedDimension` 里 `f.encode` 判空后再比较，与同文件其它写法保持一致。抽出公共函数后 `WithAliasFreeEncode` 不再只有单一调用点，这个防护也变得有实际意义。
- 新增嵌套桶用例，复刻线上聚类告警的形态：`signature` 用别名请求、另外两个维度用原始字段名请求，且分桶不对称（一个 app 下两个 cluster、另一个只有一个）。锁住同层多个桶共用一份 labels 时补键不串值，同时锁住多维场景下用别名请求仍然不补键。
- reference 不补键的注释补上下游契约：结果是按列下标取值的，多一列会直接错位；并与 `metadata.FieldAlias.AddAliasKeysWhenOriginalFieldPresent` 的双键 TODO 建立关联，将来清理过渡方案时两处应一起处理。

所有回归用例都验证过有效性：去掉补键循环后会失败。`tsdb/`、`service/`、`query/` 全部通过。
