### PR TITLE
feat: 【UnifyQuery】reference 聚合按原始字段名请求时返回原始字段名而非别名 --story=137269011

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/agg_format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/agg_format.go
@@ -45,6 +45,9 @@ type aggFormat struct {
 	// extraLabelKeys 记录 ES 字段名需要额外补出的维度键，为空表示不补
 	extraLabelKeys map[string][]string
 
+	// renameLabel 为真时，用 extraLabelKeys 里的请求名替换出端的别名键，而不是额外补一份
+	renameLabel bool
+
 	timeFormat func(i int64) int64
 
 	dims  []string
@@ -75,12 +78,16 @@ func (a *aggFormat) addLabel(name, value string) {
 	for k, v := range a.item.labels {
 		newLb[k] = v
 	}
-	newLb[formatted] = value
 
-	// 配了别名的字段在这里会被改写成别名，而 PromQL 的 by 子句用的是请求里写的字段名，
-	// 两者对不上时该维度会被整个聚合掉。所以按请求名再补一份，两种写法都能分组。
+	// 配了别名的字段在这里会被改写成别名，而请求里写的是原始字段名，两者对不上。
+	// 补一份请求名的键，PromQL 的 by 子句和按请求名取值的调用方都能对上；
+	// renameLabel 场景下补键会多出一列，所以换成只留请求名，别名键不再输出。
 	// 同层的多个桶共用一份 labels，这里必须无条件覆盖，否则会留下上一个桶的值。
-	for _, key := range a.extraLabelKeys[name] {
+	keys := a.extraLabelKeys[name]
+	if !a.renameLabel || len(keys) == 0 {
+		newLb[formatted] = value
+	}
+	for _, key := range keys {
 		newLb[key] = value
 	}
 

--- a/pkg/unify-query/tsdb/elasticsearch/agg_format_alias_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/agg_format_alias_test.go
@@ -112,18 +112,15 @@ func TestAggDataFormat_AliasFreeDimensionKey(t *testing.T) {
 
 	// 用别名分组本来就能匹配上，不该多补一个键，避免无谓地改变既有响应。
 	for name, c := range map[string]struct {
-		fieldAlias  metadata.FieldAlias
-		dimensions  []string
-		isReference bool
+		fieldAlias metadata.FieldAlias
+		dimensions []string
 	}{
-		"group by alias":           {fieldAlias: fieldAlias, dimensions: []string{"app"}},
-		"reference query":          {fieldAlias: fieldAlias, dimensions: []string{"__ext.labels.app"}, isReference: true},
-		"field without alias":      {dimensions: []string{"__ext.labels.app"}},
-		"reference group by alias": {fieldAlias: fieldAlias, dimensions: []string{"app"}, isReference: true},
+		"group by alias":      {fieldAlias: fieldAlias, dimensions: []string{"app"}},
+		"field without alias": {dimensions: []string{"__ext.labels.app"}},
 	} {
 		t.Run(name+" keeps single key", func(t *testing.T) {
 			ctx := metadata.InitHashID(context.Background())
-			labels := aggLabels(t, newAliasFormatFactory(ctx, c.fieldAlias, c.isReference), c.dimensions)
+			labels := aggLabels(t, newAliasFormatFactory(ctx, c.fieldAlias, false), c.dimensions)
 
 			assert.Len(t, labels, 2)
 			for _, lb := range labels {
@@ -131,6 +128,40 @@ func TestAggDataFormat_AliasFreeDimensionKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAggDataFormat_ReferenceKeepsRequestedDimensionKey 覆盖 reference 查询按原始字段名分组的场景。
+// reference 直出聚合结果、下游按结果列取值，补键会多出一列导致错位，所以这里是把别名键重命名为请求名：
+// 列数不变，调用方按请求里写的字段名就能取到值。
+func TestAggDataFormat_ReferenceKeepsRequestedDimensionKey(t *testing.T) {
+	metadata.InitMetadata()
+
+	fieldAlias := metadata.FieldAlias{"app": "__ext.labels.app"}
+	promQLKey := metadata.GetFieldFormat(context.Background()).EncodeFunc()("__ext.labels.app")
+
+	t.Run("group by original field returns requested key", func(t *testing.T) {
+		ctx := metadata.InitHashID(context.Background())
+		labels := aggLabels(t, newAliasFormatFactory(ctx, fieldAlias, true), []string{"__ext.labels.app"})
+
+		assert.Len(t, labels, 2)
+		for _, lb := range labels {
+			assert.Len(t, lb, 1, "reference 是改名不是补键，列数必须保持不变")
+			assert.NotContains(t, lb, "app", "按原始字段名请求就不该返回别名键")
+			assert.Contains(t, []string{"web", "api"}, lb[promQLKey])
+		}
+	})
+
+	t.Run("group by alias still returns alias key", func(t *testing.T) {
+		ctx := metadata.InitHashID(context.Background())
+		labels := aggLabels(t, newAliasFormatFactory(ctx, fieldAlias, true), []string{"app"})
+
+		assert.Len(t, labels, 2)
+		for _, lb := range labels {
+			assert.Len(t, lb, 1)
+			assert.NotContains(t, lb, promQLKey, "按别名请求就该原样返回别名键")
+			assert.Contains(t, []string{"web", "api"}, lb["app"])
+		}
+	})
 }
 
 // TestAggDataFormat_AliasFreeKeyIsPromQLCompatible 固定补出来的键与 PromQL 侧的口径一致，
@@ -175,6 +206,38 @@ func TestAggDataFormat_AliasFreeDimensionKeyWithNestedBuckets(t *testing.T) {
 
 	got := make(map[string][2]string, len(labels))
 	for _, lb := range labels {
+		got[lb["signature"]] = [2]string{lb["__ext__bk_46__labels__bk_46__app"], lb["__ext__bk_46__cluster"]}
+	}
+	assert.Equal(t, [2]string{"web", "c1"}, got["sigA"])
+	assert.Equal(t, [2]string{"web", "c2"}, got["sigB"])
+	assert.Equal(t, [2]string{"api", "c1"}, got["sigC"])
+}
+
+// TestAggDataFormat_ReferenceDimensionKeyWithNestedBuckets 用与上一个用例相同的嵌套桶形态验证 reference：
+// 用别名请求的维度保持别名，用原始字段名请求的换成请求名，维度数与请求一致，且各桶取到自己的值。
+func TestAggDataFormat_ReferenceDimensionKeyWithNestedBuckets(t *testing.T) {
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+
+	fieldAlias := metadata.FieldAlias{
+		"signature": "__dist_05",
+		"cluster":   "__ext.cluster",
+		"app":       "__ext.labels.app",
+	}
+	labels := aggLabelsFrom(t, newAliasFormatFactory(ctx, fieldAlias, true),
+		[]string{"signature", "__ext.cluster", "__ext.labels.app"}, multiDimAggResponse)
+
+	assert.Len(t, labels, 3)
+	got := make(map[string][2]string, len(labels))
+	for _, lb := range labels {
+		assert.Len(t, lb, 3, "reference 是改名不是补键，维度数必须与请求一致")
+		// 这两个用原始字段名请求，别名键不该再出现
+		assert.NotContains(t, lb, "app")
+		assert.NotContains(t, lb, "cluster")
+		// signature 用别名请求，保持别名
+		assert.NotEmpty(t, lb["signature"])
+		assert.NotContains(t, lb, "__dist_05")
+
 		got[lb["signature"]] = [2]string{lb["__ext__bk_46__labels__bk_46__app"], lb["__ext__bk_46__cluster"]}
 	}
 	assert.Equal(t, [2]string{"web", "c1"}, got["sigA"])

--- a/pkg/unify-query/tsdb/elasticsearch/format.go
+++ b/pkg/unify-query/tsdb/elasticsearch/format.go
@@ -540,14 +540,13 @@ func (f *FormatFactory) AggDataFormat(data elastic.Aggregations, metricLabel *pr
 		timeFormat:     f.toMillisecond,
 	}
 
-	// reference 查询直出存储引擎的聚合结果，不经 PromQL 分组，补键只会凭空多出一列，
-	// 而下游是按结果列的下标位置取值的，多一列会直接错位。所以 reference 保持只返回别名键，
-	// 用原始字段名请求、拿到别名键这个改名行为不变，由下游按别名读取。
-	// 这与 metadata.FieldAlias.AddAliasKeysWhenOriginalFieldPresent 的双键是同一套过渡方案，
-	// 那里带着「等前端适配之后再移除」的 TODO，将来清理时两处应一起处理。
-	if !f.isReference {
-		af.extraLabelKeys = f.extraLabelKeys
-	}
+	// 配了别名的字段，出端默认只留别名键，而请求里写的是原始字段名，两边对不上。
+	// ts 查询要经 PromQL 分组，by 子句认的是请求名，所以补一份请求名的键让两种写法都能分组；
+	// 这份双键与 metadata.FieldAlias.AddAliasKeysWhenOriginalFieldPresent 是同一套过渡方案，将来一起清理。
+	// reference 查询直出聚合结果、下游按结果列取值，补键会凭空多出一列导致错位，
+	// 所以改成把别名键重命名为请求名：列数不变，且与 /query/ts、bksql 的返回口径一致。
+	af.extraLabelKeys = f.extraLabelKeys
+	af.renameLabel = f.isReference
 
 	af.get()
 	defer af.put()


### PR DESCRIPTION
## 问题

#1443 修的是 `/query/ts` 用原始字段名分组时维度被丢弃。`/query/ts/reference` 不经 PromQL 分组，不存在丢维度，但留着同一处别名不对称的另一半表现：**用原始字段名请求聚合维度，返回的 `group_keys` 是别名**。

以配了 `app -> __ext.labels.app` 的索引集为例：

```
请求 dimensions: ["__ext.labels.app"]   ->  返回 group_keys: ["app"]
```

调用方按自己请求里写的字段名取值，取不到。而且 #1443 合入后，同一份别名配置下 `/query/ts` 返回请求名、reference 返回别名，两个端点口径分裂，调用方没法用同一套逻辑解析。bksql/Doris 侧默认返回请求的字段名，ES reference 是唯一的例外。

已核实的影响：

- 日志平台 terms 聚合：结果按返回名建索引、再用请求名去取，配了别名的字段聚合结果直接为空
- 日志平台聚类 pattern 查询：请求名与返回名对不上的维度被静默丢弃，「仅查看新类」返回空
- 日志平台图表聚合：`cardinality` 走 reference、其余聚合走 ts，#1443 之后同一功能的不同聚合方法会返回不同的维度名
- 监控平台：reference 与 ts 共用同一段维度解析，同样按请求名读取，没有别名映射

## 原因

和 #1443 是同一处不对称：出端 series label 先做别名改写再格式转换，而请求里写的是原始字段名。

#1443 给 ts 的解法是**补键**，在别名键之外再补一份请求名的键，让 PromQL 的 `by` 子句能匹配上。当时 reference 被显式排除，理由是 reference 直出存储引擎聚合结果、下游按结果列下标取值，补键会凭空多出一列导致错位。

这个理由是成立的，但它只解决了「不能补键」，没解决「返回的不是请求名」。

## 改动

reference 改成**改名**而不是补键：把出端的别名键替换成请求名，列数不变。

- 复用 #1443 已经算好的 `extraLabelKeys`，不额外引入数据结构
- 只在请求名与别名不一致时生效。用别名请求时该映射本来就是空的，响应完全不变
- ts 路径保持 #1443 的补键行为不动
- 不引入请求级开关

源码净增 6 行。

## 测试

- 新增 `TestAggDataFormat_ReferenceKeepsRequestedDimensionKey`：按原始字段名请求返回请求名且不含别名键，按别名请求仍返回别名键，两者列数都保持 1
- 新增 `TestAggDataFormat_ReferenceDimensionKeyWithNestedBuckets`：复用 #1443 的多维嵌套桶数据，验证 reference 下混合请求（`signature` 用别名、另两个用原始字段名）各自的键正确、维度数与请求一致、同层多个桶不串值
- 把 #1443 里两个 reference 用例从只断言标签数量改为断言具体维度名。原来的写法即使改名行为出错也照样能过
- 变异验证：把 `renameLabel` 强制置 false 后新增用例都失败，报 `map[__ext__bk_46__labels__bk_46__app:web app:web] should have 1 item(s), but has 2`，同时印证了「补键会多一列」这个前提确实成立

`go build ./...`、`go test ./tsdb/elasticsearch/...`、`gofmt`、`go vet` 均通过。

## 兼容性

对 reference 端点是行为变更：配置了别名的结果表上，用原始字段名请求时返回的维度名从别名变为请求名。用别名请求的调用方不受影响。

已逐一核对日志平台与监控平台两侧全部 reference 消费点，均按请求名读取、没有别名映射逻辑，因此对这两个平台不构成破坏，反而能修掉上面列的几处静默失败。其余 reference 调用方麻烦帮忙确认一下有没有依赖别名返回的。

close #1010158081137269011
