### PR TITLE
fix(alarm-engine): prime producer topic metadata

### DIFF
--- a/pkg/alarm-engine/kafka/comparison_audit_sink.go
+++ b/pkg/alarm-engine/kafka/comparison_audit_sink.go
@@ -92,7 +92,7 @@ func OpenComparisonAuditSink(coordinates ComparisonAuditSinkConfig) (*Comparison
 	if err != nil {
 		return nil, fmt.Errorf("kafka comparison audit sink: open client: %w", err)
 	}
-	producer, err := sarama.NewSyncProducerFromClient(client)
+	producer, err := newSyncProducerForOutput(client, coordinates.OutputTopic)
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("kafka comparison audit sink: open producer: %w", err), client.Close())
 	}

--- a/pkg/alarm-engine/kafka/decision_sink.go
+++ b/pkg/alarm-engine/kafka/decision_sink.go
@@ -35,6 +35,13 @@ type closeableClient interface {
 	Close() error
 }
 
+func newSyncProducerForOutput(client sarama.Client, outputTopic string) (sarama.SyncProducer, error) {
+	if err := client.RefreshMetadata(outputTopic); err != nil {
+		return nil, fmt.Errorf("refresh output topic metadata: %w", err)
+	}
+	return sarama.NewSyncProducerFromClient(client)
+}
+
 // DecisionSink owns one isolated synchronous producer and its dedicated
 // client. It is safe for concurrent use by multiple consumer claims.
 type DecisionSink struct {
@@ -69,7 +76,7 @@ func OpenDecisionSink(coordinates DecisionSinkConfig) (*DecisionSink, error) {
 	if err != nil {
 		return nil, fmt.Errorf("kafka decision sink: open client: %w", err)
 	}
-	producer, err := sarama.NewSyncProducerFromClient(client)
+	producer, err := newSyncProducerForOutput(client, coordinates.OutputTopic)
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("kafka decision sink: open producer: %w", err), client.Close())
 	}

--- a/pkg/alarm-engine/kafka/decision_sink_test.go
+++ b/pkg/alarm-engine/kafka/decision_sink_test.go
@@ -25,6 +25,46 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarm-engine/contract"
 )
 
+func TestOpenDecisionSinkPrimesOnlyOutputTopicBeforeIdempotentProducer(t *testing.T) {
+	broker := sarama.NewMockBroker(t, 1)
+	defer broker.Close()
+
+	coordinates := validDecisionSinkConfig()
+	coordinates.Brokers = []string{broker.Addr()}
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()).
+			SetLeader(coordinates.OutputTopic, 0, broker.BrokerID()),
+		"InitProducerIDRequest": sarama.NewMockWrapper(&sarama.InitProducerIDResponse{
+			ProducerID:    1000,
+			ProducerEpoch: 1,
+		}),
+	})
+
+	sink, err := OpenDecisionSink(coordinates)
+	if err != nil {
+		t.Fatalf("OpenDecisionSink() error = %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	history := broker.History()
+	if len(history) < 2 {
+		t.Fatalf("broker requests = %d, want metadata then InitProducerID", len(history))
+	}
+	metadata, ok := history[0].Request.(*sarama.MetadataRequest)
+	if !ok {
+		t.Fatalf("first broker request = %T, want *sarama.MetadataRequest", history[0].Request)
+	}
+	if len(metadata.Topics) != 1 || metadata.Topics[0] != coordinates.OutputTopic {
+		t.Fatalf("metadata topics = %v, want only %q", metadata.Topics, coordinates.OutputTopic)
+	}
+	if _, ok := history[1].Request.(*sarama.InitProducerIDRequest); !ok {
+		t.Fatalf("second broker request = %T, want *sarama.InitProducerIDRequest", history[1].Request)
+	}
+}
+
 func TestDecisionSinkWritesOneOfficiallyEncodedRecordAfterAcknowledgement(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 背景

BKOP Shadow 中 Trigger 与 Comparator 在创建 Sarama 幂等 SyncProducer 时发生空指针崩溃。`Metadata.Full=false` 下 client 尚无可用 broker，Sarama v1.27.1 的 `InitProducerID` 可返回空响应。

## 修改

- 创建 Decision/Audit Producer 前，仅刷新对应输出 Topic 元数据
- 保持 `Metadata.Full=false`，不拉取全集群 Topic 元数据
- 增加 MockBroker 回归，固定 Metadata → InitProducerID 顺序及精确 Topic 范围

## 验证

- `make verify test race lint build`
- Kafka 包定向回归与 race 通过
