### PR TITLE
fix: avoid unsupported Kafka producer handshake

### DIFF
--- a/pkg/alarm-engine/kafka/decision_sink_test.go
+++ b/pkg/alarm-engine/kafka/decision_sink_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarm-engine/contract"
 )
 
-func TestOpenDecisionSinkPrimesOnlyOutputTopicBeforeIdempotentProducer(t *testing.T) {
+func TestOpenDecisionSinkPrimesOnlyOutputTopicWithoutTransactionalHandshake(t *testing.T) {
 	broker := sarama.NewMockBroker(t, 1)
 	defer broker.Close()
 
@@ -35,10 +35,6 @@ func TestOpenDecisionSinkPrimesOnlyOutputTopicBeforeIdempotentProducer(t *testin
 		"MetadataRequest": sarama.NewMockMetadataResponse(t).
 			SetBroker(broker.Addr(), broker.BrokerID()).
 			SetLeader(coordinates.OutputTopic, 0, broker.BrokerID()),
-		"InitProducerIDRequest": sarama.NewMockWrapper(&sarama.InitProducerIDResponse{
-			ProducerID:    1000,
-			ProducerEpoch: 1,
-		}),
 	})
 
 	sink, err := OpenDecisionSink(coordinates)
@@ -50,8 +46,8 @@ func TestOpenDecisionSinkPrimesOnlyOutputTopicBeforeIdempotentProducer(t *testin
 	}
 
 	history := broker.History()
-	if len(history) < 2 {
-		t.Fatalf("broker requests = %d, want metadata then InitProducerID", len(history))
+	if len(history) < 1 {
+		t.Fatal("broker did not receive output topic metadata request")
 	}
 	metadata, ok := history[0].Request.(*sarama.MetadataRequest)
 	if !ok {
@@ -60,8 +56,10 @@ func TestOpenDecisionSinkPrimesOnlyOutputTopicBeforeIdempotentProducer(t *testin
 	if len(metadata.Topics) != 1 || metadata.Topics[0] != coordinates.OutputTopic {
 		t.Fatalf("metadata topics = %v, want only %q", metadata.Topics, coordinates.OutputTopic)
 	}
-	if _, ok := history[1].Request.(*sarama.InitProducerIDRequest); !ok {
-		t.Fatalf("second broker request = %T, want *sarama.InitProducerIDRequest", history[1].Request)
+	for _, request := range history {
+		if _, ok := request.Request.(*sarama.InitProducerIDRequest); ok {
+			t.Fatal("Shadow producer must not require InitProducerID")
+		}
 	}
 }
 

--- a/pkg/alarm-engine/kafka/producer_config.go
+++ b/pkg/alarm-engine/kafka/producer_config.go
@@ -93,7 +93,7 @@ func (c DecisionSinkConfig) Validate() error {
 		return fmt.Errorf("kafka decision producer: broker_version %q: %w", c.BrokerVersion, err)
 	}
 	if !version.IsAtLeast(sarama.V0_11_0_0) || !sarama.MaxVersion.IsAtLeast(version) {
-		return fmt.Errorf("kafka decision producer: broker_version %q is outside idempotent producer range 0.11.0.0..%s", c.BrokerVersion, sarama.MaxVersion)
+		return fmt.Errorf("kafka decision producer: broker_version %q is outside supported producer range 0.11.0.0..%s", c.BrokerVersion, sarama.MaxVersion)
 	}
 	return nil
 }
@@ -119,7 +119,10 @@ func NewDecisionProducerConfig(coordinates DecisionSinkConfig) (*sarama.Config, 
 	config.Metadata.Timeout = decisionProducerTimeout
 	config.Producer.RequiredAcks = sarama.WaitForAll
 	config.Producer.Timeout = decisionProducerTimeout
-	config.Producer.Idempotent = true
+	// Shadow output is intentionally at-least-once. Stable decision and audit
+	// identifiers make replays observable without depending on the broker's
+	// InitProducerID path.
+	config.Producer.Idempotent = false
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
 	config.Producer.Retry.Max = decisionProducerRetryMax

--- a/pkg/alarm-engine/kafka/producer_config_test.go
+++ b/pkg/alarm-engine/kafka/producer_config_test.go
@@ -28,8 +28,8 @@ func TestNewDecisionProducerConfigForcesAcknowledgementAndBounds(t *testing.T) {
 	if config.Producer.RequiredAcks != sarama.WaitForAll {
 		t.Fatalf("required acks = %d, want WaitForAll", config.Producer.RequiredAcks)
 	}
-	if !config.Producer.Idempotent {
-		t.Fatal("producer idempotence must be enabled")
+	if config.Producer.Idempotent {
+		t.Fatal("Shadow producer must not require the broker InitProducerID path")
 	}
 	if !config.Producer.Return.Successes || !config.Producer.Return.Errors {
 		t.Fatal("sync producer acknowledgement channels must be enabled")


### PR DESCRIPTION
## What changed

- keep synchronous WaitForAll acknowledgements, bounded retries and stable decision/audit identifiers
- disable the idempotent producer handshake for the isolated Shadow outputs
- add a regression test proving producer startup does not require InitProducerID

## Why

The output contract is intentionally at-least-once. Sarama v1.27.1 enters the InitProducerID path only when producer idempotence is enabled, while the existing datalink Kafka producers use acknowledgement and retry semantics without that handshake.

## Verification

- go test ./kafka targeted regression, count=100
- go test -race ./kafka targeted regression, count=20
- make verify
- make test
- make race
- make lint
- make BUILD_NO=1 build