### PR TITLE
fix(alarmd): align Kafka producer compatibility baseline

### DIFF
--- a/pkg/alarmd/kafka/producer_config.go
+++ b/pkg/alarmd/kafka/producer_config.go
@@ -92,8 +92,8 @@ func (c DecisionSinkConfig) Validate() error {
 	if err != nil {
 		return fmt.Errorf("kafka decision producer: broker_version %q: %w", c.BrokerVersion, err)
 	}
-	if !version.IsAtLeast(sarama.V0_11_0_0) || !sarama.MaxVersion.IsAtLeast(version) {
-		return fmt.Errorf("kafka decision producer: broker_version %q is outside supported producer range 0.11.0.0..%s", c.BrokerVersion, sarama.MaxVersion)
+	if !version.IsAtLeast(sarama.V0_10_2_0) || !sarama.MaxVersion.IsAtLeast(version) {
+		return fmt.Errorf("kafka decision producer: broker_version %q is outside supported producer range 0.10.2.0..%s", c.BrokerVersion, sarama.MaxVersion)
 	}
 	return nil
 }

--- a/pkg/alarmd/kafka/producer_config_test.go
+++ b/pkg/alarmd/kafka/producer_config_test.go
@@ -75,6 +75,26 @@ func TestNewDecisionProducerConfigForcesAcknowledgementAndBounds(t *testing.T) {
 	}
 }
 
+func TestNewDecisionProducerConfigSupportsDatalinkKafkaBaseline(t *testing.T) {
+	t.Parallel()
+
+	coordinates := validDecisionSinkConfig()
+	coordinates.BrokerVersion = "0.10.2.0"
+	config, err := NewDecisionProducerConfig(coordinates)
+	if err != nil {
+		t.Fatalf("NewDecisionProducerConfig() error = %v", err)
+	}
+	if config.Version != sarama.V0_10_2_0 {
+		t.Fatalf("broker version = %s, want %s", config.Version, sarama.V0_10_2_0)
+	}
+	if config.Producer.Idempotent {
+		t.Fatal("0.10.2-compatible Shadow producer must not require InitProducerID")
+	}
+	if config.Producer.RequiredAcks != sarama.WaitForAll {
+		t.Fatalf("required acks = %d, want WaitForAll", config.Producer.RequiredAcks)
+	}
+}
+
 func TestDecisionSinkConfigRejectsInvalidCoordinatesAndPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -111,7 +131,7 @@ func TestDecisionSinkConfigRejectsInvalidCoordinatesAndPolicy(t *testing.T) {
 		"missing client":        func(config *DecisionSinkConfig) { config.ClientID = "" },
 		"missing version":       func(config *DecisionSinkConfig) { config.BrokerVersion = "" },
 		"invalid version":       func(config *DecisionSinkConfig) { config.BrokerVersion = "invalid" },
-		"version below minimum": func(config *DecisionSinkConfig) { config.BrokerVersion = "0.10.2.0" },
+		"version below minimum": func(config *DecisionSinkConfig) { config.BrokerVersion = "0.10.1.0" },
 		"version above maximum": func(config *DecisionSinkConfig) { config.BrokerVersion = "9.9.9" },
 	}
 	for name, mutate := range tests {


### PR DESCRIPTION
## What
- accept the existing datalink Kafka 0.10.2 client baseline for alarmd Shadow producers
- keep synchronous WaitForAll acknowledgements, bounded retries, stable-key partitioning and the non-transactional at-least-once model
- add a regression test for the 0.10.2 configuration

## Why
The alarmd consumer already supports 0.10.2, while the producer validation still required 0.11 despite not using the InitProducerID path. This prevented one shared broker version from following the established datalink compatibility baseline.

## Verification
- make verify
- make test
- make race
- make lint
- BUILD_NO=1 make build