### PR TITLE
fix(alarmd): 收口全量 Shadow 消息、语义与状态边界 --story=137445002

### DIFF
--- a/pkg/alarmd/cmd/alarmd-comparator/runtime.go
+++ b/pkg/alarmd/cmd/alarmd-comparator/runtime.go
@@ -33,14 +33,15 @@ type comparisonCounted struct {
 	missingPython bool
 }
 
-// comparisonResultLedger keeps the comparison counters on the authoritative
-// TriggerInput denominator. One input is audited again on replay and every time
-// a barrier freezes another missing role, so counting each audit would inflate
-// match, mismatch and missing beyond the number of compared inputs. A verdict
-// that actually changes is still counted, because that is a real divergence.
+// comparisonResultLedger keeps a bounded recent deduplication window for the
+// comparison counters. One input can be audited again on replay and as coverage
+// changes, while a long-running Shadow process must not retain every historical
+// input forever.
 type comparisonResultLedger struct {
 	capacity int
 	counted  map[string]comparisonCounted
+	order    []string
+	head     int
 }
 
 func newComparisonResultLedger(capacity int) (*comparisonResultLedger, error) {
@@ -50,26 +51,14 @@ func newComparisonResultLedger(capacity int) (*comparisonResultLedger, error) {
 	return &comparisonResultLedger{capacity: capacity, counted: make(map[string]comparisonCounted)}, nil
 }
 
-// reserve fails closed before the audit is published when the batch would take
-// the ledger past the capacity the finite run was sized for.
-func (l *comparisonResultLedger) reserve(batch *contract.ComparisonAuditBatch) error {
-	admitted := make(map[string]struct{}, len(batch.Audits))
-	for _, audit := range batch.Audits {
-		if _, ok := l.counted[audit.InputID]; ok {
-			continue
-		}
-		admitted[audit.InputID] = struct{}{}
-	}
-	if len(l.counted)+len(admitted) > l.capacity {
-		return fmt.Errorf("comparator runtime: comparison result ledger is full at %d inputs", l.capacity)
-	}
-	return nil
-}
-
 // admit returns only the results this audit adds on top of what the input has
 // already contributed.
 func (l *comparisonResultLedger) admit(audit contract.ComparisonAudit) []metric.CompareResult {
-	state := l.counted[audit.InputID]
+	state, exists := l.counted[audit.InputID]
+	if !exists {
+		l.makeRoom()
+		l.order = append(l.order, audit.InputID)
+	}
 	var results []metric.CompareResult
 	switch audit.Verdict {
 	case contract.ComparisonVerdictMatch, contract.ComparisonVerdictHardDiff:
@@ -101,6 +90,21 @@ func (l *comparisonResultLedger) admit(audit contract.ComparisonAudit) []metric.
 	}
 	l.counted[audit.InputID] = state
 	return results
+}
+
+func (l *comparisonResultLedger) makeRoom() {
+	for len(l.counted) >= l.capacity && l.head < len(l.order) {
+		inputID := l.order[l.head]
+		l.head++
+		delete(l.counted, inputID)
+	}
+	if l.head == len(l.order) {
+		l.order = nil
+		l.head = 0
+	} else if l.head >= 1024 && l.head*2 >= len(l.order) {
+		l.order = append([]string(nil), l.order[l.head:]...)
+		l.head = 0
+	}
 }
 
 type recordingComparisonAuditSink struct {
@@ -142,9 +146,6 @@ func (s *recordingComparisonAuditSink) WriteBatch(ctx context.Context, batch *co
 	started := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.ledger.reserve(batch); err != nil {
-		return err
-	}
 	if err := s.next.WriteBatch(ctx, batch); err != nil {
 		return err
 	}

--- a/pkg/alarmd/cmd/alarmd-comparator/runtime_test.go
+++ b/pkg/alarmd/cmd/alarmd-comparator/runtime_test.go
@@ -88,7 +88,7 @@ func TestComparisonResultLedgerIgnoresCoverageGapsWithoutABarrier(t *testing.T) 
 	}
 }
 
-func TestRecordingComparisonAuditSinkFailsClosedAtCapacityBeforePublishing(t *testing.T) {
+func TestRecordingComparisonAuditSinkKeepsARollingDeduplicationWindow(t *testing.T) {
 	t.Parallel()
 
 	published := 0
@@ -101,11 +101,17 @@ func TestRecordingComparisonAuditSinkFailsClosedAtCapacityBeforePublishing(t *te
 		t.Fatalf("WriteBatch(first) error = %v", err)
 	}
 	second := &contract.ComparisonAuditBatch{Audits: []contract.ComparisonAudit{verdictAudit("input-2", contract.ComparisonVerdictMatch)}}
-	if err := sink.WriteBatch(context.Background(), second); err == nil {
-		t.Fatal("WriteBatch() accepted an input beyond the ledger capacity")
+	if err := sink.WriteBatch(context.Background(), second); err != nil {
+		t.Fatalf("WriteBatch(second) error = %v", err)
 	}
-	if published != 1 {
-		t.Fatalf("published batches = %d, want the over-capacity batch rejected before publishing", published)
+	if published != 2 {
+		t.Fatalf("published batches = %d, want both batches", published)
+	}
+	if _, ok := sink.ledger.counted["input-1"]; ok {
+		t.Fatal("oldest input remained in the rolling deduplication window")
+	}
+	if _, ok := sink.ledger.counted["input-2"]; !ok {
+		t.Fatal("newest input was not retained in the rolling deduplication window")
 	}
 }
 

--- a/pkg/alarmd/comparator/audit.go
+++ b/pkg/alarmd/comparator/audit.go
@@ -66,6 +66,7 @@ func (r *Run) PreviewAudits(prepared Prepared, gates Gates) ([]*contract.Compari
 	if err != nil {
 		return nil, r.invalidateLocked(fmt.Errorf("comparator: build audit batches: %w", err))
 	}
+	r.inflight.auditsPrepared = true
 	return batches, nil
 }
 

--- a/pkg/alarmd/comparator/coverage.go
+++ b/pkg/alarmd/comparator/coverage.go
@@ -300,7 +300,7 @@ func (r *Run) coverageComparableLocked(inputID string) bool {
 }
 
 func coverageEntryComparable(item *coverageEntry) bool {
-	if item == nil || !item.present[StreamInput] || !item.present[StreamGo] || !item.present[StreamPython] {
+	if !coverageEntryComplete(item) {
 		return false
 	}
 	for _, late := range item.late {
@@ -309,6 +309,10 @@ func coverageEntryComparable(item *coverageEntry) bool {
 		}
 	}
 	return true
+}
+
+func coverageEntryComplete(item *coverageEntry) bool {
+	return item != nil && item.present[StreamInput] && item.present[StreamGo] && item.present[StreamPython]
 }
 
 func (r *Run) requireCoverageLocked(epoch string) error {

--- a/pkg/alarmd/comparator/coverage_test.go
+++ b/pkg/alarmd/comparator/coverage_test.go
@@ -438,7 +438,7 @@ func TestCoverageConfigurationAndClockFailClosed(t *testing.T) {
 	}
 }
 
-func TestCoverageCapacityFailsClosedWithoutEviction(t *testing.T) {
+func TestCoverageCapacityReusesCompletedEntries(t *testing.T) {
 	t.Parallel()
 
 	clock := &manualRunClock{now: time.Date(2026, time.August, 18, 0, 0, 0, 0, time.UTC)}
@@ -448,11 +448,11 @@ func TestCoverageCapacityFailsClosedWithoutEviction(t *testing.T) {
 	}
 	inputPayload, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
+	commitAuditedStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitAuditedStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
+	commitAuditedStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	secondPayload, second := testTriggerInput(t, "anomalous")
-	if _, err := run.Prepare(StreamRecord{
+	prepared, err := run.Prepare(StreamRecord{
 		Epoch:     "run-1",
 		Role:      StreamInput,
 		Topic:     "input",
@@ -460,11 +460,15 @@ func TestCoverageCapacityFailsClosedWithoutEviction(t *testing.T) {
 		Offset:    21,
 		Key:       mustPartitionKey(t, second),
 		Value:     secondPayload,
-	}); err == nil {
-		t.Fatal("Prepare() silently evicted a completed coverage entry")
+	})
+	if err != nil {
+		t.Fatalf("Prepare() did not reuse completed capacity: %v", err)
 	}
-	if run.Valid() {
-		t.Fatal("coverage capacity exhaustion left the Run valid")
+	if _, err := run.CommitSucceeded(prepared); err != nil {
+		t.Fatalf("CommitSucceeded() error = %v", err)
+	}
+	if !run.Valid() {
+		t.Fatal("completed-entry reuse invalidated the Run")
 	}
 }
 
@@ -489,6 +493,20 @@ func commitStreamRecord(t *testing.T, run *Run, record StreamRecord) {
 	prepared, err := run.Prepare(record)
 	if err != nil {
 		t.Fatalf("Prepare() error = %v", err)
+	}
+	if _, err := run.CommitSucceeded(prepared); err != nil {
+		t.Fatalf("CommitSucceeded() error = %v", err)
+	}
+}
+
+func commitAuditedStreamRecord(t *testing.T, run *Run, record StreamRecord) {
+	t.Helper()
+	prepared, err := run.Prepare(record)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	if _, err := run.PreviewAudits(prepared, Gates{StableEpoch: true}); err != nil {
+		t.Fatalf("PreviewAudits() error = %v", err)
 	}
 	if _, err := run.CommitSucceeded(prepared); err != nil {
 		t.Fatalf("CommitSucceeded() error = %v", err)

--- a/pkg/alarmd/comparator/joiner.go
+++ b/pkg/alarmd/comparator/joiner.go
@@ -99,10 +99,12 @@ type Assessment struct {
 }
 
 type Joiner struct {
-	mu         sync.Mutex
-	runEpoch   string
-	maxEntries int
-	entries    map[string]*entry
+	mu          sync.Mutex
+	runEpoch    string
+	maxEntries  int
+	entries     map[string]*entry
+	releasable  []string
+	releaseHead int
 }
 
 type entry struct {
@@ -114,6 +116,7 @@ type entry struct {
 	pythonConflict bool
 	goInvalid      bool
 	pythonInvalid  bool
+	releasable     bool
 }
 
 type sourceObservation struct {
@@ -397,9 +400,55 @@ func (j *Joiner) requireCapacity(inputIDs []string) error {
 		}
 	}
 	if len(j.entries)+newEntries > j.maxEntries {
-		return fmt.Errorf("comparator: entry capacity exceeded")
+		return fmt.Errorf(
+			"comparator: entry capacity exceeded: current=%d new=%d max=%d",
+			len(j.entries), newEntries, j.maxEntries,
+		)
 	}
 	return nil
+}
+
+// markReleasable records entries whose authoritative input and both decisions
+// have been audited and committed. They remain available for recent replay and
+// conflict detection until capacity is needed by a later stream record.
+func (j *Joiner) markReleasable(inputIDs []string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	for _, inputID := range inputIDs {
+		item := j.entries[inputID]
+		if item == nil || item.releasable {
+			continue
+		}
+		item.releasable = true
+		j.releasable = append(j.releasable, inputID)
+	}
+}
+
+func (j *Joiner) compact(target int) []string {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if target < 0 {
+		target = 0
+	}
+	evicted := make([]string, 0)
+	for len(j.entries) > target && j.releaseHead < len(j.releasable) {
+		inputID := j.releasable[j.releaseHead]
+		j.releaseHead++
+		item := j.entries[inputID]
+		if item == nil || !item.releasable {
+			continue
+		}
+		delete(j.entries, inputID)
+		evicted = append(evicted, inputID)
+	}
+	if j.releaseHead == len(j.releasable) {
+		j.releasable = nil
+		j.releaseHead = 0
+	} else if j.releaseHead >= 1024 && j.releaseHead*2 >= len(j.releasable) {
+		j.releasable = append([]string(nil), j.releasable[j.releaseHead:]...)
+		j.releaseHead = 0
+	}
+	return evicted
 }
 
 func (j *Joiner) getOrCreate(inputID string) *entry {

--- a/pkg/alarmd/comparator/run.go
+++ b/pkg/alarmd/comparator/run.go
@@ -15,6 +15,8 @@ import (
 	"math"
 	"sync"
 	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 )
 
 var ErrRecordInFlight = errors.New("comparator: record is awaiting commit")
@@ -59,12 +61,13 @@ type streamPartition struct {
 }
 
 type preparedRecord struct {
-	token      uint64
-	stream     streamPartition
-	offset     int64
-	updates    []Update
-	coverage   map[string]*coverageEntry
-	observedAt time.Time
+	token          uint64
+	stream         streamPartition
+	offset         int64
+	updates        []Update
+	coverage       map[string]*coverageEntry
+	observedAt     time.Time
+	auditsPrepared bool
 }
 
 func (p *preparedRecord) hasPendingAuthoritative() bool {
@@ -86,6 +89,7 @@ type Run struct {
 	valid           bool
 	invalidErr      error
 	joiner          *Joiner
+	maxEntries      int
 	roleTopics      map[StreamRole]string
 	nextOffsets     map[streamPartition]int64
 	inflight        *preparedRecord
@@ -146,6 +150,7 @@ func NewRun(epoch string, maxEntries int, assignments []PartitionAssignment, opt
 		epoch:           epoch,
 		valid:           true,
 		joiner:          joiner,
+		maxEntries:      maxEntries,
 		roleTopics:      make(map[StreamRole]string, 3),
 		nextOffsets:     make(map[streamPartition]int64, len(assignments)),
 		coverageTimeout: configured.coverageTimeout,
@@ -211,6 +216,15 @@ func (r *Run) Prepare(record StreamRecord) (Prepared, error) {
 	if record.Offset == math.MaxInt64 {
 		return Prepared{}, r.invalidateLocked(fmt.Errorf("comparator: record offset is out of range"))
 	}
+	// Keep a bounded recent replay window and reserve one maximum wire batch.
+	// Only fully joined entries are compacted; partial joins remain fail-closed.
+	compactTarget := contract.MaxTriggerInputItemsV1
+	if reserveTarget := r.maxEntries - contract.MaxTriggerInputItemsV1; reserveTarget < compactTarget {
+		compactTarget = reserveTarget
+	}
+	for _, inputID := range r.joiner.compact(compactTarget) {
+		delete(r.coverage, inputID)
+	}
 
 	var (
 		updates []Update
@@ -267,6 +281,15 @@ func (r *Run) CommitSucceeded(prepared Prepared) ([]Update, error) {
 	inflight := r.inflight
 	if err := r.commitCoverageLocked(inflight); err != nil {
 		return nil, r.invalidateLocked(err)
+	}
+	if inflight.auditsPrepared {
+		releasable := make([]string, 0, len(inflight.coverage))
+		for inputID, item := range inflight.coverage {
+			if coverageEntryComplete(item) {
+				releasable = append(releasable, inputID)
+			}
+		}
+		r.joiner.markReleasable(releasable)
 	}
 	r.nextOffsets[inflight.stream] = inflight.offset + 1
 	r.inflight = nil

--- a/pkg/alarmd/contract/trigger_decision.go
+++ b/pkg/alarmd/contract/trigger_decision.go
@@ -108,36 +108,80 @@ func (i *TriggerInput) BuildTriggerDecisionBatch(decisions []TriggerDecision) (*
 	if i == nil || i.StrategyIR == nil || len(i.partitionKey) == 0 {
 		return nil, invalid("trigger_input", "must be produced by DecodeTriggerInput")
 	}
-	if len(i.DetectionOutcomes) == 0 || len(i.DetectionOutcomes) > MaxTriggerDecisionItemsV1 {
+	return BuildTriggerDecisionBatchFromOutcomes(
+		i.PartitionHashVersion,
+		i.StrategyIR,
+		i.DetectionOutcomes,
+		decisions,
+	)
+}
+
+// BuildTriggerDecisionBatchFromOutcomes builds the Kafka output contract from
+// validated in-process Detect results. It deliberately does not require a
+// TriggerInput wire round trip between Detect and Trigger.
+func BuildTriggerDecisionBatchFromOutcomes(
+	partitionHashVersion string,
+	strategy *TriggerStrategyIR,
+	outcomes []*DetectionOutcome,
+	decisions []TriggerDecision,
+) (*TriggerDecisionBatch, error) {
+	if strategy == nil {
+		return nil, invalid("trigger_decision_batch", "strategy must be non-null")
+	}
+	if err := strategy.Validate(); err != nil {
+		return nil, err
+	}
+	if partitionHashVersion != PartitionHashVersionV1 {
+		return nil, invalid("trigger_decision_batch.partition_hash_version", "unsupported version")
+	}
+	if len(outcomes) == 0 || len(outcomes) > MaxTriggerDecisionItemsV1 {
 		return nil, invalid("trigger_decision_batch.decisions", "source input must contain between 1 and 500 outcomes")
 	}
-	if len(decisions) != len(i.DetectionOutcomes) {
+	if len(decisions) != len(outcomes) {
 		return nil, invalid("trigger_decision_batch.decisions", "must match input outcome count")
 	}
+	batchID := ""
+	inputIDs := make(map[string]struct{}, len(outcomes))
 	for index, decision := range decisions {
-		source := i.DetectionOutcomes[index]
+		source := outcomes[index]
 		if source == nil {
 			return nil, invalid("trigger_decision_batch.decisions", "source outcome must be non-null")
 		}
+		if err := source.Validate(strategy); err != nil {
+			return nil, err
+		}
+		if index == 0 {
+			batchID = source.BatchID
+		} else if source.BatchID != batchID {
+			return nil, invalid("trigger_decision_batch.decisions", "source outcomes must share one batch_id")
+		}
+		if _, exists := inputIDs[source.InputID]; exists {
+			return nil, invalid("trigger_decision_batch.decisions", "source outcomes must not contain duplicate input_id")
+		}
+		inputIDs[source.InputID] = struct{}{}
 		if decision.InputID != source.InputID || decision.RecordID != source.Record.RecordID {
 			return nil, invalid("trigger_decision_batch.decisions", "must preserve input order and identity")
 		}
-		if err := validateDecisionAgainstSource(i.StrategyIR, source, decision); err != nil {
+		if err := validateDecisionAgainstSource(strategy, source, decision); err != nil {
 			return nil, err
 		}
 	}
 	batch := &TriggerDecisionBatch{
 		Schema:               Schema{Name: triggerDecisionBatchSchema, Major: schemaMajor, Minor: 0},
 		RequiredFeatures:     []string{},
-		PartitionHashVersion: i.PartitionHashVersion,
-		BatchID:              i.DetectionOutcomes[0].BatchID,
-		TenantID:             i.StrategyIR.TenantID,
-		Purpose:              i.StrategyIR.Purpose,
-		StrategyRef:          i.StrategyIR.StrategyRef,
+		PartitionHashVersion: partitionHashVersion,
+		BatchID:              batchID,
+		TenantID:             strategy.TenantID,
+		Purpose:              strategy.Purpose,
+		StrategyRef:          strategy.StrategyRef,
 		DecisionAlgorithm:    DecisionAlgorithmV1,
 		Decisions:            cloneTriggerDecisions(decisions),
-		partitionKey:         append([]byte(nil), i.partitionKey...),
 	}
+	partitionKey, err := TriggerPartitionKey(partitionHashVersion, strategy)
+	if err != nil {
+		return nil, err
+	}
+	batch.partitionKey = partitionKey
 	if err := batch.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/alarmd/contract/trigger_input.go
+++ b/pkg/alarmd/contract/trigger_input.go
@@ -119,12 +119,27 @@ func (i *TriggerInput) PartitionKey() ([]byte, error) {
 }
 
 func (i *TriggerInput) derivePartitionKey() ([]byte, error) {
-	return deriveTriggerPartitionKey(
+	return TriggerPartitionKey(
 		i.PartitionHashVersion,
-		i.StrategyIR.TenantID,
-		i.StrategyIR.Purpose,
-		i.StrategyIR.StrategyRef.StrategyID,
-		i.StrategyIR.StrategyRef.ItemID,
+		i.StrategyIR,
+	)
+}
+
+// TriggerPartitionKey derives the shared Detect, Trigger and Decision
+// partition key from a validated strategy without requiring a wire envelope.
+func TriggerPartitionKey(version string, strategy *TriggerStrategyIR) ([]byte, error) {
+	if strategy == nil {
+		return nil, invalid("trigger_input.partition_key", "strategy must be non-null")
+	}
+	if err := strategy.Validate(); err != nil {
+		return nil, err
+	}
+	return deriveTriggerPartitionKey(
+		version,
+		strategy.TenantID,
+		strategy.Purpose,
+		strategy.StrategyRef.StrategyID,
+		strategy.StrategyRef.ItemID,
 	)
 }
 

--- a/pkg/alarmd/detect/processor.go
+++ b/pkg/alarmd/detect/processor.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -63,85 +64,13 @@ func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
 		}
 		outcomes = append(outcomes, outcome)
 	}
-	triggerInputs, err := buildTriggerInputs(input.StrategyIR, outcomes)
-	if err != nil {
-		return fmt.Errorf("encode trigger input: %w", err)
-	}
-	return p.trigger.ProcessInputs(ctx, key, triggerInputs)
-}
-
-type triggerInputEnvelope struct {
-	Schema               contract.Schema             `json:"schema"`
-	RequiredFeatures     []string                    `json:"required_features"`
-	PartitionHashVersion string                      `json:"partition_hash_version"`
-	StrategyIR           *contract.TriggerStrategyIR `json:"strategy_ir"`
-	DetectionOutcomes    []json.RawMessage           `json:"detection_outcomes"`
-}
-
-func buildTriggerInputs(strategy *contract.TriggerStrategyIR, outcomes []*contract.DetectionOutcome) ([]*contract.TriggerInput, error) {
-	emptyPayload, err := encodeTriggerInputEnvelope(strategy, []json.RawMessage{})
-	if err != nil {
-		return nil, err
-	}
-	encodedOutcomes := make([]json.RawMessage, len(outcomes))
-	for index, outcome := range outcomes {
-		encoded, err := json.Marshal(outcome)
-		if err != nil {
-			return nil, err
-		}
-		encodedOutcomes[index] = encoded
-	}
-
-	chunks := make([][]json.RawMessage, 0, 1)
-	current := make([]json.RawMessage, 0, len(encodedOutcomes))
-	currentBytes := len(emptyPayload)
-	for _, outcome := range encodedOutcomes {
-		additional := len(outcome)
-		if len(current) > 0 {
-			additional++
-		}
-		if len(current) == contract.MaxTriggerInputItemsV1 || currentBytes+additional > contract.MaxTriggerInputBytesV1 {
-			if len(current) == 0 {
-				return nil, errors.New("single detection outcome exceeds trigger input byte limit")
-			}
-			chunks = append(chunks, current)
-			current = make([]json.RawMessage, 0, len(encodedOutcomes)-len(current))
-			currentBytes = len(emptyPayload)
-			additional = len(outcome)
-		}
-		if currentBytes+additional > contract.MaxTriggerInputBytesV1 {
-			return nil, errors.New("single detection outcome exceeds trigger input byte limit")
-		}
-		current = append(current, outcome)
-		currentBytes += additional
-	}
-	if len(current) > 0 {
-		chunks = append(chunks, current)
-	}
-
-	inputs := make([]*contract.TriggerInput, 0, len(chunks))
-	for _, chunk := range chunks {
-		payload, err := encodeTriggerInputEnvelope(strategy, chunk)
-		if err != nil {
-			return nil, err
-		}
-		input, err := contract.DecodeTriggerInput(payload)
-		if err != nil {
-			return nil, err
-		}
-		inputs = append(inputs, input)
-	}
-	return inputs, nil
-}
-
-func encodeTriggerInputEnvelope(strategy *contract.TriggerStrategyIR, outcomes []json.RawMessage) ([]byte, error) {
-	return json.Marshal(triggerInputEnvelope{
-		Schema:               contract.Schema{Name: "trigger-input", Major: 1, Minor: 0},
-		RequiredFeatures:     []string{},
-		PartitionHashVersion: contract.PartitionHashVersionV1,
-		StrategyIR:           strategy,
-		DetectionOutcomes:    outcomes,
-	})
+	return p.trigger.ProcessOutcomes(
+		ctx,
+		key,
+		input.PartitionHashVersion,
+		input.StrategyIR,
+		outcomes,
+	)
 }
 
 type thresholdPlan struct {
@@ -155,7 +84,9 @@ type thresholdLevel struct {
 }
 
 type thresholdAlgorithm struct {
-	groups [][]thresholdCondition
+	groups         [][]thresholdCondition
+	valueScale     float64
+	thresholdScale float64
 }
 
 type thresholdCondition struct {
@@ -165,7 +96,10 @@ type thresholdCondition struct {
 
 type legacyStrategy struct {
 	Items []struct {
-		ID         json.Number `json:"id"`
+		ID           json.Number `json:"id"`
+		QueryConfigs []struct {
+			Unit string `json:"unit"`
+		} `json:"query_configs"`
 		Algorithms []struct {
 			Level      int             `json:"level"`
 			Type       string          `json:"type"`
@@ -199,14 +133,15 @@ func loadThresholdPlan(strategy *contract.TriggerStrategyIR) (*thresholdPlan, er
 		if item.ID.String() != strategy.StrategyRef.ItemID {
 			continue
 		}
+		valueUnit := ""
+		if len(item.QueryConfigs) == 1 {
+			valueUnit = item.QueryConfigs[0].Unit
+		}
 		for _, algorithm := range item.Algorithms {
 			if algorithm.Type != "Threshold" {
 				return nil, fmt.Errorf("detect processor: unsupported algorithm %q", algorithm.Type)
 			}
-			if algorithm.UnitPrefix != "" {
-				return nil, errors.New("detect processor: threshold unit_prefix is not supported")
-			}
-			parsed, err := parseThresholdAlgorithm(algorithm.Config)
+			parsed, err := parseThresholdAlgorithm(algorithm.Config, valueUnit, algorithm.UnitPrefix)
 			if err != nil {
 				return nil, err
 			}
@@ -225,7 +160,7 @@ func loadThresholdPlan(strategy *contract.TriggerStrategyIR) (*thresholdPlan, er
 	return plan, nil
 }
 
-func parseThresholdAlgorithm(raw json.RawMessage) (thresholdAlgorithm, error) {
+func parseThresholdAlgorithm(raw json.RawMessage, valueUnit, thresholdSuffix string) (thresholdAlgorithm, error) {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	var outer []any
@@ -235,7 +170,12 @@ func parseThresholdAlgorithm(raw json.RawMessage) (thresholdAlgorithm, error) {
 	if _, flat := outer[0].(map[string]any); flat {
 		outer = []any{outer}
 	}
-	algorithm := thresholdAlgorithm{groups: make([][]thresholdCondition, 0, len(outer))}
+	valueScale, thresholdScale := thresholdUnitScales(valueUnit, thresholdSuffix)
+	algorithm := thresholdAlgorithm{
+		groups:         make([][]thresholdCondition, 0, len(outer)),
+		valueScale:     valueScale,
+		thresholdScale: thresholdScale,
+	}
 	for _, rawGroup := range outer {
 		groupValues, ok := rawGroup.([]any)
 		if !ok || len(groupValues) == 0 {
@@ -275,17 +215,14 @@ func (p *thresholdPlan) evaluate(input *contract.DetectInput, rawRecord json.Raw
 	decoder := json.NewDecoder(bytes.NewReader(rawRecord))
 	decoder.UseNumber()
 	var record struct {
-		RecordID string      `json:"record_id"`
-		Time     int64       `json:"time"`
-		Value    json.Number `json:"value"`
+		RecordID string          `json:"record_id"`
+		Time     int64           `json:"time"`
+		Value    json.RawMessage `json:"value"`
 	}
 	if err := decoder.Decode(&record); err != nil {
 		return nil, fmt.Errorf("detect processor: decode record: %w", err)
 	}
-	value, err := record.Value.Float64()
-	if err != nil {
-		return nil, errors.New("detect processor: record value must be numeric")
-	}
+	value, valueValid := thresholdRecordValue(record.Value)
 	parts := strings.Split(record.RecordID, ".")
 	if len(parts) != 2 {
 		return nil, errors.New("detect processor: invalid record_id")
@@ -309,7 +246,7 @@ func (p *thresholdPlan) evaluate(input *contract.DetectInput, rawRecord json.Raw
 	anomalous := false
 	for _, levelNumber := range p.strategy.RequiredLevels {
 		level := p.levels[levelNumber]
-		matched := level.matches(value)
+		matched := valueValid && level.matches(value)
 		evaluation := contract.Evaluation{Level: levelNumber, Result: contract.EvaluationNormal}
 		if matched {
 			anomalous = true
@@ -346,6 +283,20 @@ func (p *thresholdPlan) evaluate(input *contract.DetectInput, rawRecord json.Raw
 	return result, nil
 }
 
+// Python Threshold catches per-point algorithm exceptions and leaves that
+// point non-anomalous. DetectInput is emitted only after the Python batch is
+// finalized, so a missing or non-numeric value must not fail the Go consumer.
+func thresholdRecordValue(raw json.RawMessage) (float64, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var number json.Number
+	if err := decoder.Decode(&number); err != nil {
+		return 0, false
+	}
+	value, err := number.Float64()
+	return value, err == nil
+}
+
 func (l thresholdLevel) matches(value float64) bool {
 	if l.connector == "or" {
 		for _, algorithm := range l.algorithms {
@@ -364,9 +315,11 @@ func (l thresholdLevel) matches(value float64) bool {
 }
 
 func (a thresholdAlgorithm) matches(value float64) bool {
+	value = roundThresholdValue(value * a.valueScale)
 	for _, group := range a.groups {
 		matched := true
 		for _, condition := range group {
+			condition.threshold = roundThresholdValue(condition.threshold * a.thresholdScale)
 			if !condition.matches(value) {
 				matched = false
 				break
@@ -377,6 +330,99 @@ func (a thresholdAlgorithm) matches(value float64) bool {
 		}
 	}
 	return false
+}
+
+type thresholdUnitSpec struct {
+	suffixes      []string
+	defaultIndex  int
+	factor        float64
+	suffixFactors map[string]float64
+}
+
+func thresholdUnitScales(unitID, thresholdSuffix string) (float64, float64) {
+	spec, ok := thresholdUnitSpecFor(unitID)
+	if !ok || len(spec.suffixes) == 0 {
+		return 1, 1
+	}
+	valueScale := spec.scaleToBase(spec.defaultIndex)
+	thresholdIndex := -1
+	for index, suffix := range spec.suffixes {
+		if suffix == thresholdSuffix {
+			thresholdIndex = index
+			break
+		}
+	}
+	if thresholdIndex < 0 {
+		return valueScale, 1
+	}
+	return valueScale, spec.scaleToBase(thresholdIndex)
+}
+
+func thresholdUnitSpecFor(unitID string) (thresholdUnitSpec, bool) {
+	if parts := strings.Split(unitID, "||"); len(parts) == 2 {
+		unitID = parts[1]
+	}
+	spec := thresholdUnitSpec{}
+	switch unitID {
+	case "percent":
+		spec = thresholdUnitSpec{suffixes: []string{"%", "x100%"}, factor: 100}
+	case "percentunit":
+		spec = thresholdUnitSpec{suffixes: []string{"%", "x100%"}, defaultIndex: 1, factor: 100}
+	case "bits", "bytes":
+		spec = thresholdUnitSpec{suffixes: []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"}, factor: 1024}
+	case "kbytes":
+		spec = thresholdUnitSpec{suffixes: []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"}, defaultIndex: 1, factor: 1024}
+	case "mbytes":
+		spec = thresholdUnitSpec{suffixes: []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"}, defaultIndex: 2, factor: 1024}
+	case "gbytes":
+		spec = thresholdUnitSpec{suffixes: []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"}, defaultIndex: 3, factor: 1024}
+	case "tbytes":
+		spec = thresholdUnitSpec{suffixes: []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"}, defaultIndex: 4, factor: 1024}
+	case "pbytes":
+		spec = thresholdUnitSpec{suffixes: []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"}, defaultIndex: 5, factor: 1024}
+	case "decbits", "decbytes", "pps", "bps", "Bps", "hertz":
+		spec = thresholdUnitSpec{suffixes: []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}, factor: 1000}
+	case "deckbytes", "KBs", "Kbits":
+		spec = thresholdUnitSpec{suffixes: []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}, defaultIndex: 1, factor: 1000}
+	case "decmbytes", "MBs", "Mbits":
+		spec = thresholdUnitSpec{suffixes: []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}, defaultIndex: 2, factor: 1000}
+	case "decgbytes", "GBs", "Gbits":
+		spec = thresholdUnitSpec{suffixes: []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}, defaultIndex: 3, factor: 1000}
+	case "dectbytes", "TBs", "Tbits":
+		spec = thresholdUnitSpec{suffixes: []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}, defaultIndex: 4, factor: 1000}
+	case "decpbytes", "PBs", "Pbits":
+		spec = thresholdUnitSpec{suffixes: []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}, defaultIndex: 5, factor: 1000}
+	case "ns", "µs", "ms", "s", "m", "h", "d":
+		indexes := map[string]int{"ns": 0, "µs": 1, "ms": 2, "s": 3, "m": 4, "h": 5, "d": 6}
+		spec = thresholdUnitSpec{
+			suffixes:      []string{"ns", "µs", "ms", "s", "m", "h", "d"},
+			defaultIndex:  indexes[unitID],
+			factor:        1000,
+			suffixFactors: map[string]float64{"m": 60, "h": 60, "d": 24},
+		}
+	case "cps", "ops", "reqps", "rps", "wps", "iops", "cpm", "opm", "rpm", "wpm":
+		spec = thresholdUnitSpec{suffixes: []string{"", "K", "M", "B", "T"}, factor: 1000}
+	default:
+		return thresholdUnitSpec{}, false
+	}
+	return spec, true
+}
+
+func (s thresholdUnitSpec) scaleToBase(index int) float64 {
+	scale := 1.0
+	for index > 0 {
+		factor := s.factor
+		if value, ok := s.suffixFactors[s.suffixes[index]]; ok {
+			factor = value
+		}
+		scale *= factor
+		index--
+	}
+	return scale
+}
+
+func roundThresholdValue(value float64) float64 {
+	return math.RoundToEven(value*1_000_000) / 1_000_000
 }
 
 func (c thresholdCondition) matches(value float64) bool {

--- a/pkg/alarmd/detect/processor.go
+++ b/pkg/alarmd/detect/processor.go
@@ -63,23 +63,85 @@ func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
 		}
 		outcomes = append(outcomes, outcome)
 	}
-	triggerPayload, err := json.Marshal(struct {
-		Schema               contract.Schema              `json:"schema"`
-		RequiredFeatures     []string                     `json:"required_features"`
-		PartitionHashVersion string                       `json:"partition_hash_version"`
-		StrategyIR           *contract.TriggerStrategyIR  `json:"strategy_ir"`
-		DetectionOutcomes    []*contract.DetectionOutcome `json:"detection_outcomes"`
-	}{
-		Schema:               contract.Schema{Name: "trigger-input", Major: 1, Minor: 0},
-		RequiredFeatures:     []string{},
-		PartitionHashVersion: contract.PartitionHashVersionV1,
-		StrategyIR:           input.StrategyIR,
-		DetectionOutcomes:    outcomes,
-	})
+	triggerInputs, err := buildTriggerInputs(input.StrategyIR, outcomes)
 	if err != nil {
 		return fmt.Errorf("encode trigger input: %w", err)
 	}
-	return p.trigger.Process(ctx, key, triggerPayload)
+	return p.trigger.ProcessInputs(ctx, key, triggerInputs)
+}
+
+type triggerInputEnvelope struct {
+	Schema               contract.Schema             `json:"schema"`
+	RequiredFeatures     []string                    `json:"required_features"`
+	PartitionHashVersion string                      `json:"partition_hash_version"`
+	StrategyIR           *contract.TriggerStrategyIR `json:"strategy_ir"`
+	DetectionOutcomes    []json.RawMessage           `json:"detection_outcomes"`
+}
+
+func buildTriggerInputs(strategy *contract.TriggerStrategyIR, outcomes []*contract.DetectionOutcome) ([]*contract.TriggerInput, error) {
+	emptyPayload, err := encodeTriggerInputEnvelope(strategy, []json.RawMessage{})
+	if err != nil {
+		return nil, err
+	}
+	encodedOutcomes := make([]json.RawMessage, len(outcomes))
+	for index, outcome := range outcomes {
+		encoded, err := json.Marshal(outcome)
+		if err != nil {
+			return nil, err
+		}
+		encodedOutcomes[index] = encoded
+	}
+
+	chunks := make([][]json.RawMessage, 0, 1)
+	current := make([]json.RawMessage, 0, len(encodedOutcomes))
+	currentBytes := len(emptyPayload)
+	for _, outcome := range encodedOutcomes {
+		additional := len(outcome)
+		if len(current) > 0 {
+			additional++
+		}
+		if len(current) == contract.MaxTriggerInputItemsV1 || currentBytes+additional > contract.MaxTriggerInputBytesV1 {
+			if len(current) == 0 {
+				return nil, errors.New("single detection outcome exceeds trigger input byte limit")
+			}
+			chunks = append(chunks, current)
+			current = make([]json.RawMessage, 0, len(encodedOutcomes)-len(current))
+			currentBytes = len(emptyPayload)
+			additional = len(outcome)
+		}
+		if currentBytes+additional > contract.MaxTriggerInputBytesV1 {
+			return nil, errors.New("single detection outcome exceeds trigger input byte limit")
+		}
+		current = append(current, outcome)
+		currentBytes += additional
+	}
+	if len(current) > 0 {
+		chunks = append(chunks, current)
+	}
+
+	inputs := make([]*contract.TriggerInput, 0, len(chunks))
+	for _, chunk := range chunks {
+		payload, err := encodeTriggerInputEnvelope(strategy, chunk)
+		if err != nil {
+			return nil, err
+		}
+		input, err := contract.DecodeTriggerInput(payload)
+		if err != nil {
+			return nil, err
+		}
+		inputs = append(inputs, input)
+	}
+	return inputs, nil
+}
+
+func encodeTriggerInputEnvelope(strategy *contract.TriggerStrategyIR, outcomes []json.RawMessage) ([]byte, error) {
+	return json.Marshal(triggerInputEnvelope{
+		Schema:               contract.Schema{Name: "trigger-input", Major: 1, Minor: 0},
+		RequiredFeatures:     []string{},
+		PartitionHashVersion: contract.PartitionHashVersionV1,
+		StrategyIR:           strategy,
+		DetectionOutcomes:    outcomes,
+	})
 }
 
 type thresholdPlan struct {

--- a/pkg/alarmd/detect/processor_test.go
+++ b/pkg/alarmd/detect/processor_test.go
@@ -16,6 +16,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
@@ -87,5 +88,69 @@ func TestProcessorRunsThresholdDetectBeforeTrigger(t *testing.T) {
 	}
 	if len(second.AnomalyTimestamps) != 2 || second.AnomalyTimestamps[0] != 100 || second.AnomalyTimestamps[1] != 160 {
 		t.Fatalf("anomaly timestamps = %v", second.AnomalyTimestamps)
+	}
+}
+
+func TestProcessorSplitsExpandedTriggerInput(t *testing.T) {
+	legacy := []byte(`{"id":1,"update_time":1,"items":[{"id":2,"query_configs":[{"agg_interval":60}],"algorithms":[{"level":1,"type":"Threshold","config":[[{"method":"gte","threshold":50}]]}],"no_data_config":{"is_enabled":false}}],"detects":[{"level":1,"connector":"and","trigger_config":{"count":1,"check_window":1}}]}`)
+	digest := sha256.Sum256(legacy)
+	strategy := map[string]any{
+		"schema":                    map[string]any{"name": "trigger-strategy-ir", "major": 1, "minor": 0},
+		"required_features":         []string{"raw-strategy-bytes-v1"},
+		"tenant_id":                 "default",
+		"purpose":                   "DETECT",
+		"strategy_ref":              map[string]any{"strategy_id": "1", "item_id": "2", "generation": "1", "content_sha256": hex.EncodeToString(digest[:])},
+		"required_levels":           []int{1},
+		"check_window_unit_seconds": 60,
+		"trigger_configs":           []map[string]any{{"level": 1, "check_window_size": 1, "trigger_count": 1}},
+		"legacy_json_b64":           base64.StdEncoding.EncodeToString(legacy),
+	}
+
+	records := make([]map[string]any, 0, contract.MaxDetectInputRecordsV1)
+	for index := 0; index < contract.MaxDetectInputRecordsV1; index++ {
+		sourceTime := int64(100 + index*60)
+		records = append(records, map[string]any{
+			"record_id": "342a08e0f85f169a7e099c18db3708ed." + strconv.FormatInt(sourceTime, 10),
+			"time":      sourceTime,
+			"value":     60,
+		})
+	}
+	document := map[string]any{
+		"schema":                 map[string]any{"name": "detect-input", "major": 1, "minor": 0},
+		"required_features":      []string{},
+		"partition_hash_version": contract.PartitionHashVersionV1,
+		"strategy_ir":            strategy,
+		"batch_id":               strings.Repeat("batch", 250),
+		"records":                records,
+	}
+	payload, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) > contract.MaxDetectInputBytesV1 {
+		t.Fatalf("detect input bytes = %d, want <= %d", len(payload), contract.MaxDetectInputBytesV1)
+	}
+	input, err := contract.DecodeDetectInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeDetectInput() error = %v", err)
+	}
+	key, err := input.PartitionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sink := &recordingDecisionSink{}
+	if err := NewProcessor(sink).Process(context.Background(), key, payload); err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if len(sink.batches) < 2 {
+		t.Fatalf("batches = %d, want encoded-size split", len(sink.batches))
+	}
+	total := 0
+	for _, batch := range sink.batches {
+		total += len(batch.Decisions)
+	}
+	if total != contract.MaxDetectInputRecordsV1 {
+		t.Fatalf("decisions = %d, want %d", total, contract.MaxDetectInputRecordsV1)
 	}
 }

--- a/pkg/alarmd/detect/processor_test.go
+++ b/pkg/alarmd/detect/processor_test.go
@@ -91,7 +91,145 @@ func TestProcessorRunsThresholdDetectBeforeTrigger(t *testing.T) {
 	}
 }
 
-func TestProcessorSplitsExpandedTriggerInput(t *testing.T) {
+func TestProcessorMatchesPythonThresholdUnitConversion(t *testing.T) {
+	t.Parallel()
+
+	legacy := []byte(`{"id":1,"update_time":1,"items":[{"id":2,"query_configs":[{"agg_interval":60,"unit":"percentunit"}],"algorithms":[{"level":1,"type":"Threshold","unit_prefix":"%","config":[[{"method":"gte","threshold":80}]]}],"no_data_config":{"is_enabled":false}}],"detects":[{"level":1,"connector":"and","trigger_config":{"count":1,"check_window":1}}]}`)
+	digest := sha256.Sum256(legacy)
+	strategy := map[string]any{
+		"schema":                    map[string]any{"name": "trigger-strategy-ir", "major": 1, "minor": 0},
+		"required_features":         []string{"raw-strategy-bytes-v1"},
+		"tenant_id":                 "default",
+		"purpose":                   "DETECT",
+		"strategy_ref":              map[string]any{"strategy_id": "1", "item_id": "2", "generation": "1", "content_sha256": hex.EncodeToString(digest[:])},
+		"required_levels":           []int{1},
+		"check_window_unit_seconds": 60,
+		"trigger_configs":           []map[string]any{{"level": 1, "check_window_size": 1, "trigger_count": 1}},
+		"legacy_json_b64":           base64.StdEncoding.EncodeToString(legacy),
+	}
+	recordID := "342a08e0f85f169a7e099c18db3708ed.100"
+	invalidRecordID := "342a08e0f85f169a7e099c18db3708ed.160"
+	payload, err := json.Marshal(map[string]any{
+		"schema":                 map[string]any{"name": "detect-input", "major": 1, "minor": 0},
+		"required_features":      []string{},
+		"partition_hash_version": contract.PartitionHashVersionV1,
+		"strategy_ir":            strategy,
+		"batch_id":               "batch-1",
+		"records": []map[string]any{
+			{"record_id": recordID, "time": 100, "value": 0.8},
+			{"record_id": invalidRecordID, "time": 160, "value": nil},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := contract.DecodeDetectInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeDetectInput() error = %v", err)
+	}
+	key, err := input.PartitionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sink := &recordingDecisionSink{}
+	if err := NewProcessor(sink).Process(context.Background(), key, payload); err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	decision := sink.batches[0].Decisions[0]
+	if decision.Outcome != contract.DecisionOutcomeTrigger {
+		t.Fatalf("decision = %#v, want 0.8 percentunit to equal 80 percent", decision)
+	}
+	if decision := sink.batches[0].Decisions[1]; decision.Outcome != contract.DecisionOutcomeNoTrigger || decision.ReasonCode != contract.DecisionReasonInputNormal {
+		t.Fatalf("invalid-value decision = %#v, want Python-compatible INPUT_NORMAL", decision)
+	}
+}
+
+func TestThresholdUnitScalesMatchPythonBaseConversion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		unit            string
+		thresholdSuffix string
+		wantValue       float64
+		wantThreshold   float64
+	}{
+		{name: "percent unit", unit: "percentunit", thresholdSuffix: "%", wantValue: 100, wantThreshold: 1},
+		{name: "binary data", unit: "Data (IEC)||kbytes", thresholdSuffix: "Mi", wantValue: 1024, wantThreshold: 1024 * 1024},
+		{name: "decimal rate", unit: "MBs", thresholdSuffix: "k", wantValue: 1_000_000, wantThreshold: 1_000},
+		{name: "time", unit: "s", thresholdSuffix: "m", wantValue: 1_000_000_000, wantThreshold: 60_000_000_000},
+		{name: "unknown suffix", unit: "bytes", thresholdSuffix: "bogus", wantValue: 1, wantThreshold: 1},
+		{name: "fixed unit", unit: "celsius", thresholdSuffix: "", wantValue: 1, wantThreshold: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			value, threshold := thresholdUnitScales(test.unit, test.thresholdSuffix)
+			if value != test.wantValue || threshold != test.wantThreshold {
+				t.Fatalf("thresholdUnitScales(%q, %q) = (%v, %v), want (%v, %v)", test.unit, test.thresholdSuffix, value, threshold, test.wantValue, test.wantThreshold)
+			}
+		})
+	}
+}
+
+func TestProcessorDoesNotApplyTriggerWireLimitInsideTheProcess(t *testing.T) {
+	t.Parallel()
+
+	legacy := []byte(`{"id":1,"update_time":1,"items":[{"id":2,"query_configs":[{"agg_interval":60}],"algorithms":[{"level":1,"type":"Threshold","config":[[{"method":"gte","threshold":50}]]}],"no_data_config":{"is_enabled":false}}],"detects":[{"level":1,"connector":"and","trigger_config":{"count":1,"check_window":1}}]}`)
+	digest := sha256.Sum256(legacy)
+	strategy := map[string]any{
+		"schema":                    map[string]any{"name": "trigger-strategy-ir", "major": 1, "minor": 0},
+		"required_features":         []string{"raw-strategy-bytes-v1"},
+		"tenant_id":                 "default",
+		"purpose":                   "DETECT",
+		"strategy_ref":              map[string]any{"strategy_id": "1", "item_id": "2", "generation": "1", "content_sha256": hex.EncodeToString(digest[:])},
+		"required_levels":           []int{1},
+		"check_window_unit_seconds": 60,
+		"trigger_configs":           []map[string]any{{"level": 1, "check_window_size": 1, "trigger_count": 1}},
+		"legacy_json_b64":           base64.StdEncoding.EncodeToString(legacy),
+	}
+	recordID := "342a08e0f85f169a7e099c18db3708ed.100"
+	document := map[string]any{
+		"schema":                 map[string]any{"name": "detect-input", "major": 1, "minor": 0},
+		"required_features":      []string{},
+		"partition_hash_version": contract.PartitionHashVersionV1,
+		"strategy_ir":            strategy,
+		"batch_id":               "batch-1",
+		"records":                []map[string]any{{"record_id": recordID, "time": 100, "value": 60, "padding": ""}},
+	}
+	basePayload, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	padding := contract.MaxDetectInputBytesV1 - len(basePayload) - 16
+	document["records"].([]map[string]any)[0]["padding"] = strings.Repeat("x", padding)
+	payload, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) > contract.MaxDetectInputBytesV1 {
+		t.Fatalf("detect input bytes = %d, want <= %d", len(payload), contract.MaxDetectInputBytesV1)
+	}
+	input, err := contract.DecodeDetectInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeDetectInput() error = %v", err)
+	}
+	key, err := input.PartitionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sink := &recordingDecisionSink{}
+	if err := NewProcessor(sink).Process(context.Background(), key, payload); err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if len(sink.batches) != 1 || len(sink.batches[0].Decisions) != 1 {
+		t.Fatalf("batches = %#v, want one terminal decision", sink.batches)
+	}
+}
+
+func TestProcessorProcessesMaximumRecordCount(t *testing.T) {
 	legacy := []byte(`{"id":1,"update_time":1,"items":[{"id":2,"query_configs":[{"agg_interval":60}],"algorithms":[{"level":1,"type":"Threshold","config":[[{"method":"gte","threshold":50}]]}],"no_data_config":{"is_enabled":false}}],"detects":[{"level":1,"connector":"and","trigger_config":{"count":1,"check_window":1}}]}`)
 	digest := sha256.Sum256(legacy)
 	strategy := map[string]any{
@@ -142,9 +280,6 @@ func TestProcessorSplitsExpandedTriggerInput(t *testing.T) {
 	sink := &recordingDecisionSink{}
 	if err := NewProcessor(sink).Process(context.Background(), key, payload); err != nil {
 		t.Fatalf("Process() error = %v", err)
-	}
-	if len(sink.batches) < 2 {
-		t.Fatalf("batches = %d, want encoded-size split", len(sink.batches))
 	}
 	total := 0
 	for _, batch := range sink.batches {

--- a/pkg/alarmd/kafka/comparator_barrier.go
+++ b/pkg/alarmd/kafka/comparator_barrier.go
@@ -62,6 +62,7 @@ func (a *comparatorBarrierAdapter) CaptureOverdue(ctx context.Context) (int, err
 	if err != nil {
 		return 0, records.fail(err)
 	}
+	a.pruneLastCoverage(snapshots)
 	candidates := make([]comparator.CoverageSnapshot, 0, len(snapshots))
 	missingRoles := make(map[comparator.StreamRole]struct{}, 2)
 	for _, snapshot := range snapshots {
@@ -199,6 +200,18 @@ func (a *comparatorBarrierAdapter) publishChangedCoverage(ctx context.Context, s
 		a.lastCoverage[inputID] = signature
 	}
 	return nil
+}
+
+func (a *comparatorBarrierAdapter) pruneLastCoverage(snapshots []comparator.CoverageSnapshot) {
+	current := make(map[string]struct{}, len(snapshots))
+	for _, snapshot := range snapshots {
+		current[snapshot.InputID] = struct{}{}
+	}
+	for inputID := range a.lastCoverage {
+		if _, ok := current[inputID]; !ok {
+			delete(a.lastCoverage, inputID)
+		}
+	}
 }
 
 func coverageAuditSignature(snapshot comparator.CoverageSnapshot) string {

--- a/pkg/alarmd/kafka/comparator_barrier_test.go
+++ b/pkg/alarmd/kafka/comparator_barrier_test.go
@@ -97,6 +97,19 @@ func TestComparatorBarrierCapturesMissingPartitionsOnceAfterRunClock(t *testing.
 	}
 }
 
+func TestComparatorBarrierPrunesCoverageSignaturesAfterEntryCompaction(t *testing.T) {
+	t.Parallel()
+
+	adapter := &comparatorBarrierAdapter{lastCoverage: map[string]string{
+		"retained": "signature-1",
+		"removed":  "signature-2",
+	}}
+	adapter.pruneLastCoverage([]comparator.CoverageSnapshot{{InputID: "retained"}})
+	if len(adapter.lastCoverage) != 1 || adapter.lastCoverage["retained"] != "signature-1" {
+		t.Fatalf("lastCoverage = %#v, want only the current coverage signature", adapter.lastCoverage)
+	}
+}
+
 func TestComparatorBarrierSharesOneHWMVectorAcrossOverdueInputs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/alarmd/trigger/evaluator.go
+++ b/pkg/alarmd/trigger/evaluator.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 )
@@ -43,12 +44,23 @@ type stateKey struct {
 }
 
 type Evaluator struct {
-	mu      sync.Mutex
-	results map[stateKey]map[int64]bool
+	mu          sync.Mutex
+	results     map[stateKey]map[int64]bool
+	lastUpdated map[stateKey]time.Time
+	now         func() time.Time
 }
 
 func NewEvaluator() *Evaluator {
-	return &Evaluator{results: make(map[stateKey]map[int64]bool)}
+	return newEvaluatorWithClock(time.Now)
+
+}
+
+func newEvaluatorWithClock(now func() time.Time) *Evaluator {
+	return &Evaluator{
+		results:     make(map[stateKey]map[int64]bool),
+		lastUpdated: make(map[stateKey]time.Time),
+		now:         now,
+	}
 }
 
 func (e *Evaluator) Process(strategy *contract.TriggerStrategyIR, outcome *contract.DetectionOutcome) (*Decision, error) {
@@ -80,6 +92,9 @@ type evaluationTransaction struct {
 	evaluator *Evaluator
 	results   map[stateKey]map[int64]bool
 	latest    map[stateKey]int64
+	updated   map[stateKey]time.Time
+	expired   map[stateKey]struct{}
+	now       time.Time
 	closed    bool
 }
 
@@ -89,6 +104,9 @@ func (e *Evaluator) begin() *evaluationTransaction {
 		evaluator: e,
 		results:   make(map[stateKey]map[int64]bool),
 		latest:    make(map[stateKey]int64),
+		updated:   make(map[stateKey]time.Time),
+		expired:   make(map[stateKey]struct{}),
+		now:       e.now(),
 	}
 }
 
@@ -103,6 +121,7 @@ func (t *evaluationTransaction) record(strategy *StrategyHandle, outcome *contra
 	for _, evaluation := range outcome.Evaluations {
 		key := newStateKey(strategy, outcome, evaluation.Level)
 		t.resultsFor(key)[outcome.Record.SourceTime] = evaluation.Result == contract.EvaluationAnomalous
+		t.updated[key] = t.now
 		if latest, ok := t.latest[key]; !ok || outcome.Record.SourceTime > latest {
 			t.latest[key] = outcome.Record.SourceTime
 		}
@@ -110,9 +129,10 @@ func (t *evaluationTransaction) record(strategy *StrategyHandle, outcome *contra
 	return nil
 }
 
-// evict bounds overlay memory after every decision in the batch is materialized.
-// Window filtering already excludes out-of-window points, so eviction only has
-// to keep the newest window per state key.
+// evict bounds the points in active dimensions by event time and removes
+// inactive dimensions after a wall-clock retention period. A newer dimension
+// must not advance another dimension's event-time window because their records
+// can arrive with different delays.
 func (t *evaluationTransaction) evict(strategy *StrategyHandle) {
 	windowSizes := make(map[int]int, len(strategy.triggerConfigs))
 	for _, config := range strategy.triggerConfigs {
@@ -123,7 +143,17 @@ func (t *evaluationTransaction) evict(strategy *StrategyHandle) {
 		if !ok {
 			continue
 		}
-		prune(t.results[key], windowStart(latest, strategy.checkWindowUnitSeconds, windowSize))
+		prune(t.resultsFor(key), windowStart(latest, strategy.checkWindowUnitSeconds, windowSize))
+	}
+	retention := stateRetention(strategy)
+	for key, lastUpdated := range t.evaluator.lastUpdated {
+		if !stateKeyMatchesStrategy(key, strategy) {
+			continue
+		}
+		if _, updated := t.updated[key]; updated || t.now.Sub(lastUpdated) < retention {
+			continue
+		}
+		t.expired[key] = struct{}{}
 	}
 }
 
@@ -198,11 +228,54 @@ func (t *evaluationTransaction) commit() {
 	if t.closed {
 		return
 	}
+	for key := range t.expired {
+		delete(t.evaluator.results, key)
+		delete(t.evaluator.lastUpdated, key)
+	}
 	for key, results := range t.results {
-		t.evaluator.results[key] = results
+		if len(results) == 0 {
+			delete(t.evaluator.results, key)
+			delete(t.evaluator.lastUpdated, key)
+		} else {
+			t.evaluator.results[key] = results
+		}
+	}
+	for key, updated := range t.updated {
+		t.evaluator.lastUpdated[key] = updated
 	}
 	t.closed = true
 	t.evaluator.mu.Unlock()
+}
+
+func (e *Evaluator) retire(identity strategyIdentity) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for key := range e.results {
+		if stateKeyMatchesIdentity(key, identity) {
+			delete(e.results, key)
+			delete(e.lastUpdated, key)
+		}
+	}
+}
+
+// stateRetention mirrors the useful part of the Python CheckResult lifecycle
+// for Trigger: keep at least 30 data periods and at least twice the largest
+// trigger window, while active dimensions renew the retention on every record.
+func stateRetention(strategy *StrategyHandle) time.Duration {
+	points := int64(30)
+	for _, config := range strategy.triggerConfigs {
+		candidate := int64(config.CheckWindowSize) * 2
+		if candidate > points {
+			points = candidate
+		}
+	}
+	secondsPerPoint := int64(strategy.checkWindowUnitSeconds)
+	const maxDuration = time.Duration(1<<63 - 1)
+	maxSeconds := int64(maxDuration / time.Second)
+	if points > maxSeconds/secondsPerPoint {
+		return maxDuration
+	}
+	return time.Duration(points*secondsPerPoint) * time.Second
 }
 
 func (t *evaluationTransaction) discard() {
@@ -224,6 +297,24 @@ func newStateKey(strategy *StrategyHandle, outcome *contract.DetectionOutcome, l
 		dimensionsMD5: outcome.Record.DimensionsMD5,
 		level:         level,
 	}
+}
+
+func stateKeyMatchesStrategy(key stateKey, strategy *StrategyHandle) bool {
+	return key.tenantID == strategy.tenantID &&
+		key.purpose == strategy.purpose &&
+		key.strategyID == strategy.strategyRef.StrategyID &&
+		key.itemID == strategy.strategyRef.ItemID &&
+		key.generation == strategy.strategyRef.Generation &&
+		key.contentSHA256 == strategy.strategyRef.ContentSHA256
+}
+
+func stateKeyMatchesIdentity(key stateKey, identity strategyIdentity) bool {
+	return key.tenantID == identity.tenantID &&
+		key.purpose == identity.purpose &&
+		key.strategyID == identity.strategyID &&
+		key.itemID == identity.itemID &&
+		key.generation == identity.generation &&
+		key.contentSHA256 == identity.contentSHA
 }
 
 func windowStart(sourceTime int64, unitSeconds, windowSize int) int64 {

--- a/pkg/alarmd/trigger/evaluator_test.go
+++ b/pkg/alarmd/trigger/evaluator_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 )
@@ -159,6 +160,40 @@ func TestEvaluatorEvictsWindowAndDoesNotAdvanceOnError(t *testing.T) {
 	}
 	if decision == nil || decision.Outcome != DecisionNoTrigger {
 		t.Fatalf("Process(outside window) decision = %#v, want NO_TRIGGER", decision)
+	}
+}
+
+func TestEvaluatorRetainsDelayedDimensionUntilItsOwnInactivityExpires(t *testing.T) {
+	strategy := newStrategy(t, "generation-1", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 3, TriggerCount: 1}})
+	now := time.Unix(1_000, 0)
+	evaluator := newEvaluatorWithClock(func() time.Time { return now })
+	first := newOutcome(t, strategy, 100, map[int]bool{1: true})
+	if _, err := evaluator.Process(strategy, first); err != nil {
+		t.Fatalf("Process(first dimension) error = %v", err)
+	}
+	now = now.Add(10 * time.Second)
+	second := newOutcome(t, strategy, 140, map[int]bool{1: true})
+	setDimensions(t, second, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	if _, err := evaluator.Process(strategy, second); err != nil {
+		t.Fatalf("Process(second dimension) error = %v", err)
+	}
+	if len(evaluator.results) != 2 {
+		t.Fatalf("retained state keys = %d, want both dimensions before inactivity expiry", len(evaluator.results))
+	}
+
+	now = now.Add(stateRetention(newValidatedStrategyHandle(strategy)))
+	third := newOutcome(t, strategy, 150, map[int]bool{1: true})
+	setDimensions(t, third, second.Record.DimensionsMD5)
+	if _, err := evaluator.Process(strategy, third); err != nil {
+		t.Fatalf("Process(after expiry) error = %v", err)
+	}
+	if len(evaluator.results) != 1 {
+		t.Fatalf("retained state keys = %d, want only the renewed dimension", len(evaluator.results))
+	}
+	for key := range evaluator.results {
+		if key.dimensionsMD5 != second.Record.DimensionsMD5 {
+			t.Fatalf("retained dimensions = %q, want %q", key.dimensionsMD5, second.Record.DimensionsMD5)
+		}
 	}
 }
 

--- a/pkg/alarmd/trigger/processor.go
+++ b/pkg/alarmd/trigger/processor.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 )
@@ -40,14 +41,14 @@ type DecisionSink interface {
 type Processor struct {
 	evaluator  *Evaluator
 	sink       DecisionSink
-	strategies map[strategyIdentity][32]byte
+	strategies map[strategyIdentity]cachedStrategy
 }
 
 func NewProcessor(sink DecisionSink) *Processor {
 	return &Processor{
 		evaluator:  NewEvaluator(),
 		sink:       sink,
-		strategies: make(map[strategyIdentity][32]byte),
+		strategies: make(map[strategyIdentity]cachedStrategy),
 	}
 }
 
@@ -58,6 +59,12 @@ type strategyIdentity struct {
 	itemID     string
 	generation string
 	contentSHA string
+}
+
+type cachedStrategy struct {
+	executionFingerprint [32]byte
+	lastSeen             time.Time
+	retention            time.Duration
 }
 
 func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
@@ -71,26 +78,26 @@ func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
 	if err != nil {
 		return fmt.Errorf("decode trigger input: %w", err)
 	}
-	return p.ProcessInputs(ctx, key, []*contract.TriggerInput{input})
+	return p.ProcessOutcomes(
+		ctx,
+		key,
+		input.PartitionHashVersion,
+		input.StrategyIR,
+		input.DetectionOutcomes,
+	)
 }
 
-// ProcessInputs evaluates multiple wire-valid TriggerInput chunks as one state
-// transaction. Detect can therefore honor the per-message byte limit without
-// committing only a prefix of the original Kafka record.
+// ProcessInputs preserves the legacy TriggerInput entry point while evaluating
+// all chunks in one transaction.
 func (p *Processor) ProcessInputs(ctx context.Context, key []byte, inputs []*contract.TriggerInput) error {
-	if p == nil || p.sink == nil {
-		return errors.New("trigger processor: decision sink is required")
-	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	if len(inputs) == 0 {
 		return errors.New("trigger processor: inputs are required")
 	}
-
-	var handle *StrategyHandle
-	var identity strategyIdentity
+	var strategy *contract.TriggerStrategyIR
+	var executionFingerprint [32]byte
+	partitionHashVersion := ""
 	batchID := ""
+	outcomes := make([]*contract.DetectionOutcome, 0, contract.MaxTriggerInputItemsV1)
 	for index, input := range inputs {
 		if input == nil {
 			return errors.New("trigger processor: input is required")
@@ -102,20 +109,77 @@ func (p *Processor) ProcessInputs(ctx context.Context, key []byte, inputs []*con
 		if !bytes.Equal(key, expectedKey) {
 			return errors.New("trigger processor: partition key mismatch")
 		}
-		candidate := newValidatedStrategyHandle(input.StrategyIR)
-		candidateIdentity := identityForHandle(candidate)
 		candidateBatchID := input.DetectionOutcomes[0].BatchID
+		candidateFingerprint := newValidatedStrategyHandle(input.StrategyIR).executionFingerprint
 		if index == 0 {
-			handle = candidate
-			identity = candidateIdentity
+			strategy = input.StrategyIR
+			executionFingerprint = candidateFingerprint
+			partitionHashVersion = input.PartitionHashVersion
 			batchID = candidateBatchID
-			continue
-		}
-		if candidateIdentity != identity || candidate.executionFingerprint != handle.executionFingerprint || candidateBatchID != batchID {
+		} else if input.StrategyIR.StrategyRef != strategy.StrategyRef ||
+			input.StrategyIR.TenantID != strategy.TenantID ||
+			input.StrategyIR.Purpose != strategy.Purpose ||
+			input.PartitionHashVersion != partitionHashVersion ||
+			candidateFingerprint != executionFingerprint ||
+			candidateBatchID != batchID {
 			return errors.New("trigger processor: inputs must share one logical batch and execution plan")
 		}
+		outcomes = append(outcomes, input.DetectionOutcomes...)
+		if len(outcomes) > contract.MaxTriggerInputItemsV1 {
+			return errors.New("trigger processor: logical batch exceeds outcome count limit")
+		}
 	}
-	if previous, ok := p.strategies[identity]; ok && previous != handle.executionFingerprint {
+	return p.ProcessOutcomes(ctx, key, partitionHashVersion, strategy, outcomes)
+}
+
+// ProcessOutcomes is the in-process Detect to Trigger boundary. Wire limits are
+// applied only when decisions are emitted to Kafka.
+func (p *Processor) ProcessOutcomes(
+	ctx context.Context,
+	key []byte,
+	partitionHashVersion string,
+	strategy *contract.TriggerStrategyIR,
+	outcomes []*contract.DetectionOutcome,
+) error {
+	if p == nil || p.sink == nil {
+		return errors.New("trigger processor: decision sink is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(outcomes) == 0 || len(outcomes) > contract.MaxTriggerInputItemsV1 {
+		return errors.New("trigger processor: outcomes must contain between 1 and 500 items")
+	}
+	expectedKey, err := contract.TriggerPartitionKey(partitionHashVersion, strategy)
+	if err != nil {
+		return fmt.Errorf("derive trigger partition key: %w", err)
+	}
+	if !bytes.Equal(key, expectedKey) {
+		return errors.New("trigger processor: partition key mismatch")
+	}
+	batchID := ""
+	seenInputIDs := make(map[string]struct{}, len(outcomes))
+	for index, outcome := range outcomes {
+		if outcome == nil {
+			return errors.New("trigger processor: outcome is required")
+		}
+		if err := outcome.Validate(strategy); err != nil {
+			return fmt.Errorf("validate detection outcome: %w", err)
+		}
+		if index == 0 {
+			batchID = outcome.BatchID
+		} else if outcome.BatchID != batchID {
+			return errors.New("trigger processor: outcomes must share one batch_id")
+		}
+		if _, exists := seenInputIDs[outcome.InputID]; exists {
+			return errors.New("trigger processor: outcomes must not contain duplicate input_id")
+		}
+		seenInputIDs[outcome.InputID] = struct{}{}
+	}
+	handle := newValidatedStrategyHandle(strategy)
+	identity := identityForHandle(handle)
+	previous, hasPrevious := p.strategies[identity]
+	if hasPrevious && previous.executionFingerprint != handle.executionFingerprint {
 		return errors.New("trigger processor: conflicting execution plan for strategy identity")
 	}
 	transaction := p.evaluator.begin()
@@ -127,42 +191,36 @@ func (p *Processor) ProcessInputs(ctx context.Context, key []byte, inputs []*con
 	}()
 	// The whole logical batch is recorded before any decision so that records
 	// delivered out of source-time order still evaluate on event time.
-	for _, input := range inputs {
-		for _, outcome := range input.DetectionOutcomes {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			if err := recordOutcome(transaction, handle, outcome); err != nil {
-				return err
-			}
+	for _, outcome := range outcomes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := recordOutcome(transaction, handle, outcome); err != nil {
+			return err
 		}
 	}
-	terminalGroups := make([][]Terminal, len(inputs))
-	for inputIndex, input := range inputs {
-		terminals := make([]Terminal, 0, len(input.DetectionOutcomes))
-		for _, outcome := range input.DetectionOutcomes {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			terminal, err := p.decideOutcome(transaction, handle, outcome)
-			if err != nil {
-				return err
-			}
-			terminals = append(terminals, terminal)
+	terminals := make([]Terminal, 0, len(outcomes))
+	for _, outcome := range outcomes {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		terminalGroups[inputIndex] = terminals
+		terminal, err := p.decideOutcome(transaction, handle, outcome)
+		if err != nil {
+			return err
+		}
+		terminals = append(terminals, terminal)
 	}
 	transaction.evict(handle)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	batches := make([]*contract.TriggerDecisionBatch, len(inputs))
-	for index, input := range inputs {
-		batch, err := buildDecisionBatch(input, terminalGroups[index])
-		if err != nil {
-			return fmt.Errorf("build trigger decision batch: %w", err)
-		}
-		batches[index] = batch
+	decisions, err := buildDecisions(terminals)
+	if err != nil {
+		return fmt.Errorf("build trigger decisions: %w", err)
+	}
+	batches, err := buildDecisionBatches(partitionHashVersion, strategy, outcomes, decisions)
+	if err != nil {
+		return fmt.Errorf("build trigger decision batches: %w", err)
 	}
 	for _, batch := range batches {
 		if err := p.sink.WriteBatch(ctx, batch); err != nil {
@@ -171,7 +229,13 @@ func (p *Processor) ProcessInputs(ctx context.Context, key []byte, inputs []*con
 	}
 	transaction.commit()
 	committed = true
-	p.strategies[identity] = handle.executionFingerprint
+	now := p.evaluator.now()
+	p.strategies[identity] = cachedStrategy{
+		executionFingerprint: handle.executionFingerprint,
+		lastSeen:             now,
+		retention:            stateRetention(handle),
+	}
+	p.pruneStrategies(now, identity)
 	return nil
 }
 
@@ -183,6 +247,16 @@ func identityForHandle(handle *StrategyHandle) strategyIdentity {
 		itemID:     handle.strategyRef.ItemID,
 		generation: handle.strategyRef.Generation,
 		contentSHA: handle.strategyRef.ContentSHA256,
+	}
+}
+
+func (p *Processor) pruneStrategies(now time.Time, active strategyIdentity) {
+	for identity, strategy := range p.strategies {
+		if identity == active || now.Sub(strategy.lastSeen) < strategy.retention {
+			continue
+		}
+		p.evaluator.retire(identity)
+		delete(p.strategies, identity)
 	}
 }
 
@@ -243,7 +317,7 @@ func (p *Processor) decideOutcome(transaction *evaluationTransaction, handle *St
 	}
 }
 
-func buildDecisionBatch(input *contract.TriggerInput, terminals []Terminal) (*contract.TriggerDecisionBatch, error) {
+func buildDecisions(terminals []Terminal) ([]contract.TriggerDecision, error) {
 	decisions := make([]contract.TriggerDecision, 0, len(terminals))
 	for _, terminal := range terminals {
 		decisionID, err := contract.DeriveTriggerDecisionID(terminal.InputID)
@@ -265,5 +339,56 @@ func buildDecisionBatch(input *contract.TriggerInput, terminals []Terminal) (*co
 			AnomalyTimestamps: append([]int64{}, terminal.AnomalyTimestamps...),
 		})
 	}
-	return input.BuildTriggerDecisionBatch(decisions)
+	return decisions, nil
+}
+
+func buildDecisionBatches(
+	partitionHashVersion string,
+	strategy *contract.TriggerStrategyIR,
+	outcomes []*contract.DetectionOutcome,
+	decisions []contract.TriggerDecision,
+) ([]*contract.TriggerDecisionBatch, error) {
+	return appendDecisionBatches(nil, partitionHashVersion, strategy, outcomes, decisions)
+}
+
+func appendDecisionBatches(
+	batches []*contract.TriggerDecisionBatch,
+	partitionHashVersion string,
+	strategy *contract.TriggerStrategyIR,
+	outcomes []*contract.DetectionOutcome,
+	decisions []contract.TriggerDecision,
+) ([]*contract.TriggerDecisionBatch, error) {
+	batch, err := contract.BuildTriggerDecisionBatchFromOutcomes(
+		partitionHashVersion,
+		strategy,
+		outcomes,
+		decisions,
+	)
+	if err == nil {
+		_, err = contract.EncodeTriggerDecisionBatch(batch)
+	}
+	if err == nil {
+		return append(batches, batch), nil
+	}
+	if len(decisions) <= 1 {
+		return nil, err
+	}
+	middle := len(decisions) / 2
+	batches, err = appendDecisionBatches(
+		batches,
+		partitionHashVersion,
+		strategy,
+		outcomes[:middle],
+		decisions[:middle],
+	)
+	if err != nil {
+		return nil, err
+	}
+	return appendDecisionBatches(
+		batches,
+		partitionHashVersion,
+		strategy,
+		outcomes[middle:],
+		decisions[middle:],
+	)
 }

--- a/pkg/alarmd/trigger/processor.go
+++ b/pkg/alarmd/trigger/processor.go
@@ -71,22 +71,49 @@ func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
 	if err != nil {
 		return fmt.Errorf("decode trigger input: %w", err)
 	}
-	expectedKey, err := input.PartitionKey()
-	if err != nil {
-		return fmt.Errorf("derive trigger input partition key: %w", err)
+	return p.ProcessInputs(ctx, key, []*contract.TriggerInput{input})
+}
+
+// ProcessInputs evaluates multiple wire-valid TriggerInput chunks as one state
+// transaction. Detect can therefore honor the per-message byte limit without
+// committing only a prefix of the original Kafka record.
+func (p *Processor) ProcessInputs(ctx context.Context, key []byte, inputs []*contract.TriggerInput) error {
+	if p == nil || p.sink == nil {
+		return errors.New("trigger processor: decision sink is required")
 	}
-	if !bytes.Equal(key, expectedKey) {
-		return errors.New("trigger processor: partition key mismatch")
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(inputs) == 0 {
+		return errors.New("trigger processor: inputs are required")
 	}
 
-	handle := newValidatedStrategyHandle(input.StrategyIR)
-	identity := strategyIdentity{
-		tenantID:   handle.tenantID,
-		purpose:    handle.purpose,
-		strategyID: handle.strategyRef.StrategyID,
-		itemID:     handle.strategyRef.ItemID,
-		generation: handle.strategyRef.Generation,
-		contentSHA: handle.strategyRef.ContentSHA256,
+	var handle *StrategyHandle
+	var identity strategyIdentity
+	batchID := ""
+	for index, input := range inputs {
+		if input == nil {
+			return errors.New("trigger processor: input is required")
+		}
+		expectedKey, err := input.PartitionKey()
+		if err != nil {
+			return fmt.Errorf("derive trigger input partition key: %w", err)
+		}
+		if !bytes.Equal(key, expectedKey) {
+			return errors.New("trigger processor: partition key mismatch")
+		}
+		candidate := newValidatedStrategyHandle(input.StrategyIR)
+		candidateIdentity := identityForHandle(candidate)
+		candidateBatchID := input.DetectionOutcomes[0].BatchID
+		if index == 0 {
+			handle = candidate
+			identity = candidateIdentity
+			batchID = candidateBatchID
+			continue
+		}
+		if candidateIdentity != identity || candidate.executionFingerprint != handle.executionFingerprint || candidateBatchID != batchID {
+			return errors.New("trigger processor: inputs must share one logical batch and execution plan")
+		}
 	}
 	if previous, ok := p.strategies[identity]; ok && previous != handle.executionFingerprint {
 		return errors.New("trigger processor: conflicting execution plan for strategy identity")
@@ -98,42 +125,65 @@ func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
 			transaction.discard()
 		}
 	}()
-	// The whole micro-batch is recorded before any decision so that records
+	// The whole logical batch is recorded before any decision so that records
 	// delivered out of source-time order still evaluate on event time.
-	for _, outcome := range input.DetectionOutcomes {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if err := recordOutcome(transaction, handle, outcome); err != nil {
-			return err
+	for _, input := range inputs {
+		for _, outcome := range input.DetectionOutcomes {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := recordOutcome(transaction, handle, outcome); err != nil {
+				return err
+			}
 		}
 	}
-	terminals := make([]Terminal, 0, len(input.DetectionOutcomes))
-	for _, outcome := range input.DetectionOutcomes {
-		if err := ctx.Err(); err != nil {
-			return err
+	terminalGroups := make([][]Terminal, len(inputs))
+	for inputIndex, input := range inputs {
+		terminals := make([]Terminal, 0, len(input.DetectionOutcomes))
+		for _, outcome := range input.DetectionOutcomes {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			terminal, err := p.decideOutcome(transaction, handle, outcome)
+			if err != nil {
+				return err
+			}
+			terminals = append(terminals, terminal)
 		}
-		terminal, err := p.decideOutcome(transaction, handle, outcome)
-		if err != nil {
-			return err
-		}
-		terminals = append(terminals, terminal)
+		terminalGroups[inputIndex] = terminals
 	}
 	transaction.evict(handle)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	batch, err := buildDecisionBatch(input, terminals)
-	if err != nil {
-		return fmt.Errorf("build trigger decision batch: %w", err)
+	batches := make([]*contract.TriggerDecisionBatch, len(inputs))
+	for index, input := range inputs {
+		batch, err := buildDecisionBatch(input, terminalGroups[index])
+		if err != nil {
+			return fmt.Errorf("build trigger decision batch: %w", err)
+		}
+		batches[index] = batch
 	}
-	if err := p.sink.WriteBatch(ctx, batch); err != nil {
-		return fmt.Errorf("write trigger decision batch: %w", err)
+	for _, batch := range batches {
+		if err := p.sink.WriteBatch(ctx, batch); err != nil {
+			return fmt.Errorf("write trigger decision batch: %w", err)
+		}
 	}
 	transaction.commit()
 	committed = true
 	p.strategies[identity] = handle.executionFingerprint
 	return nil
+}
+
+func identityForHandle(handle *StrategyHandle) strategyIdentity {
+	return strategyIdentity{
+		tenantID:   handle.tenantID,
+		purpose:    handle.purpose,
+		strategyID: handle.strategyRef.StrategyID,
+		itemID:     handle.strategyRef.ItemID,
+		generation: handle.strategyRef.Generation,
+		contentSHA: handle.strategyRef.ContentSHA256,
+	}
 }
 
 // recordOutcome advances the window only for business outcomes. ERROR and

--- a/pkg/alarmd/trigger/processor_test.go
+++ b/pkg/alarmd/trigger/processor_test.go
@@ -236,10 +236,43 @@ func TestProcessorRollsBackWindowStateWhenSinkFails(t *testing.T) {
 	}
 }
 
+func TestProcessorRollsBackAllChunksWhenLaterSinkWriteFails(t *testing.T) {
+	t.Parallel()
+
+	strategy := newStrategy(t, "generation-1", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 2, TriggerCount: 2}})
+	newerPayload, key := triggerInputPayload(t, strategy, newOutcome(t, strategy, 110, map[int]bool{1: true}))
+	olderPayload, _ := triggerInputPayload(t, strategy, newOutcome(t, strategy, 100, map[int]bool{1: true}))
+	newer, err := contract.DecodeTriggerInput(newerPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	older, err := contract.DecodeTriggerInput(olderPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &recordingSink{err: errors.New("sink unavailable"), failAt: 2}
+	processor := NewProcessor(sink)
+
+	if err := processor.ProcessInputs(context.Background(), key, []*contract.TriggerInput{newer, older}); err == nil {
+		t.Fatal("ProcessInputs(first attempt) error = nil, want sink failure")
+	}
+	sink.err = nil
+	if err := processor.ProcessInputs(context.Background(), key, []*contract.TriggerInput{newer, older}); err != nil {
+		t.Fatalf("ProcessInputs(replay) error = %v", err)
+	}
+	if len(sink.payloads) != 4 || !reflect.DeepEqual(sink.payloads[0], sink.payloads[2]) || !reflect.DeepEqual(sink.payloads[1], sink.payloads[3]) {
+		t.Fatal("replayed chunked decisions changed after a partial sink failure")
+	}
+	if got := sink.batches[0].Decisions[0]; got.Outcome != DecisionTrigger || !reflect.DeepEqual(got.AnomalyTimestamps, []int64{100, 110}) {
+		t.Fatalf("newer chunk decision = %#v, want complete event-time window", got)
+	}
+}
+
 type recordingSink struct {
 	batches  []*contract.TriggerDecisionBatch
 	payloads [][]byte
 	err      error
+	failAt   int
 }
 
 func (s *recordingSink) WriteBatch(_ context.Context, batch *contract.TriggerDecisionBatch) error {
@@ -253,6 +286,9 @@ func (s *recordingSink) WriteBatch(_ context.Context, batch *contract.TriggerDec
 	}
 	s.payloads = append(s.payloads, append([]byte(nil), payload...))
 	s.batches = append(s.batches, copyOfBatch)
+	if s.err != nil && s.failAt > 0 && len(s.payloads) != s.failAt {
+		return nil
+	}
 	return s.err
 }
 

--- a/pkg/alarmd/trigger/processor_test.go
+++ b/pkg/alarmd/trigger/processor_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 )
@@ -185,6 +186,44 @@ func TestProcessorRejectsConflictingExecutionPlanForSameStrategyIdentity(t *test
 	}
 }
 
+func TestProcessorKeepsOverlappingStrategyGenerationsIsolated(t *testing.T) {
+	t.Parallel()
+
+	strategyV1 := newStrategy(t, "generation-1", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 3, TriggerCount: 1}})
+	strategyV2 := newStrategy(t, "generation-2", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 3, TriggerCount: 1}})
+	processor := NewProcessor(&recordingSink{})
+	for _, strategy := range []*contract.TriggerStrategyIR{strategyV1, strategyV2} {
+		payload, key := triggerInputPayload(t, strategy, newOutcome(t, strategy, 100, map[int]bool{1: true}))
+		if err := processor.Process(context.Background(), key, payload); err != nil {
+			t.Fatalf("Process(%s) error = %v", strategy.StrategyRef.Generation, err)
+		}
+	}
+	if len(processor.strategies) != 2 {
+		t.Fatalf("strategy handles = %d, want both generations inside the replay window", len(processor.strategies))
+	}
+}
+
+func TestProcessorRetiresExpiredStrategyGenerations(t *testing.T) {
+	strategyV1 := newStrategy(t, "generation-1", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 3, TriggerCount: 1}})
+	strategyV2 := newStrategy(t, "generation-2", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 3, TriggerCount: 1}})
+	now := time.Unix(1_000, 0)
+	processor := NewProcessor(&recordingSink{})
+	processor.evaluator = newEvaluatorWithClock(func() time.Time { return now })
+
+	payload, key := triggerInputPayload(t, strategyV1, newOutcome(t, strategyV1, 100, map[int]bool{1: true}))
+	if err := processor.Process(context.Background(), key, payload); err != nil {
+		t.Fatalf("Process(generation-1) error = %v", err)
+	}
+	now = now.Add(stateRetention(newValidatedStrategyHandle(strategyV1)))
+	payload, key = triggerInputPayload(t, strategyV2, newOutcome(t, strategyV2, 110, map[int]bool{1: true}))
+	if err := processor.Process(context.Background(), key, payload); err != nil {
+		t.Fatalf("Process(generation-2) error = %v", err)
+	}
+	if len(processor.strategies) != 1 || len(processor.evaluator.results) != 1 {
+		t.Fatalf("retained strategy/state counts = %d/%d, want 1/1", len(processor.strategies), len(processor.evaluator.results))
+	}
+}
+
 func TestProcessorRejectsPartitionKeyMismatchBeforeSink(t *testing.T) {
 	t.Parallel()
 
@@ -239,32 +278,61 @@ func TestProcessorRollsBackWindowStateWhenSinkFails(t *testing.T) {
 func TestProcessorRollsBackAllChunksWhenLaterSinkWriteFails(t *testing.T) {
 	t.Parallel()
 
-	strategy := newStrategy(t, "generation-1", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 2, TriggerCount: 2}})
-	newerPayload, key := triggerInputPayload(t, strategy, newOutcome(t, strategy, 110, map[int]bool{1: true}))
-	olderPayload, _ := triggerInputPayload(t, strategy, newOutcome(t, strategy, 100, map[int]bool{1: true}))
-	newer, err := contract.DecodeTriggerInput(newerPayload)
-	if err != nil {
-		t.Fatal(err)
+	strategy := newStrategy(t, "generation-1", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 500, TriggerCount: 1}})
+	outcomes := make([]*contract.DetectionOutcome, 0, contract.MaxTriggerInputItemsV1)
+	for index := 0; index < contract.MaxTriggerInputItemsV1; index++ {
+		outcomes = append(outcomes, newOutcome(t, strategy, int64(1_000_000+index), map[int]bool{1: true}))
 	}
-	older, err := contract.DecodeTriggerInput(olderPayload)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, key := triggerInputPayload(t, strategy, outcomes...)
 	sink := &recordingSink{err: errors.New("sink unavailable"), failAt: 2}
 	processor := NewProcessor(sink)
 
-	if err := processor.ProcessInputs(context.Background(), key, []*contract.TriggerInput{newer, older}); err == nil {
-		t.Fatal("ProcessInputs(first attempt) error = nil, want sink failure")
+	if err := processor.ProcessOutcomes(context.Background(), key, contract.PartitionHashVersionV1, strategy, outcomes); err == nil {
+		t.Fatal("ProcessOutcomes(first attempt) error = nil, want sink failure")
 	}
+	firstAttempt := append([][]byte(nil), sink.payloads...)
 	sink.err = nil
-	if err := processor.ProcessInputs(context.Background(), key, []*contract.TriggerInput{newer, older}); err != nil {
-		t.Fatalf("ProcessInputs(replay) error = %v", err)
+	if err := processor.ProcessOutcomes(context.Background(), key, contract.PartitionHashVersionV1, strategy, outcomes); err != nil {
+		t.Fatalf("ProcessOutcomes(replay) error = %v", err)
 	}
-	if len(sink.payloads) != 4 || !reflect.DeepEqual(sink.payloads[0], sink.payloads[2]) || !reflect.DeepEqual(sink.payloads[1], sink.payloads[3]) {
+	if len(firstAttempt) != 2 || len(sink.payloads) <= len(firstAttempt) {
+		t.Fatalf("payload counts = first:%d total:%d, want a later-write failure followed by a full replay", len(firstAttempt), len(sink.payloads))
+	}
+	if !reflect.DeepEqual(firstAttempt[0], sink.payloads[2]) || !reflect.DeepEqual(firstAttempt[1], sink.payloads[3]) {
 		t.Fatal("replayed chunked decisions changed after a partial sink failure")
 	}
-	if got := sink.batches[0].Decisions[0]; got.Outcome != DecisionTrigger || !reflect.DeepEqual(got.AnomalyTimestamps, []int64{100, 110}) {
-		t.Fatalf("newer chunk decision = %#v, want complete event-time window", got)
+}
+
+func TestProcessorSplitsDecisionBatchesByEncodedSize(t *testing.T) {
+	t.Parallel()
+
+	strategy := newStrategy(t, "generation-1", []contract.TriggerConfig{{Level: 1, CheckWindowSize: 500, TriggerCount: 1}})
+	outcomes := make([]*contract.DetectionOutcome, 0, contract.MaxTriggerInputItemsV1)
+	for index := 0; index < contract.MaxTriggerInputItemsV1; index++ {
+		outcomes = append(outcomes, newOutcome(t, strategy, int64(1_000_000+index), map[int]bool{1: true}))
+	}
+	payload, key := triggerInputPayload(t, strategy, outcomes...)
+	sink := &recordingSink{}
+
+	if err := NewProcessor(sink).Process(context.Background(), key, payload); err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if len(sink.batches) < 2 {
+		t.Fatalf("batches = %d, want encoded-size split", len(sink.batches))
+	}
+	total := 0
+	for _, batch := range sink.batches {
+		payload, err := contract.EncodeTriggerDecisionBatch(batch)
+		if err != nil {
+			t.Fatalf("EncodeTriggerDecisionBatch() error = %v", err)
+		}
+		if len(payload) > contract.MaxTriggerDecisionBytesV1 {
+			t.Fatalf("decision batch bytes = %d, want <= %d", len(payload), contract.MaxTriggerDecisionBytesV1)
+		}
+		total += len(batch.Decisions)
+	}
+	if total != len(outcomes) {
+		t.Fatalf("decisions = %d, want %d", total, len(outcomes))
 	}
 }
 

--- a/pkg/alarmd/trigger/strategy_handle.go
+++ b/pkg/alarmd/trigger/strategy_handle.go
@@ -16,9 +16,9 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 )
 
-// StrategyHandle is an immutable executable projection of one validated StrategyIR.
-// It is intentionally scoped to a self-contained TriggerInput record and does not
-// make correctness depend on a cross-message strategy cache.
+// StrategyHandle is an immutable executable projection of one validated
+// StrategyIR. Every input carries the full strategy snapshot, so correctness
+// does not depend on a separately populated strategy cache.
 type StrategyHandle struct {
 	tenantID               string
 	purpose                string


### PR DESCRIPTION
close #1010158081137445002

## 变更

- Detect→Trigger 改为同进程 typed 调用，移除内部 TriggerInput 编解码与 512 KiB 伪边界。
- Go Decision 在 Kafka 输出前按 500 条和精确编码大小拆包；任一 Sink 写失败时整批状态回滚。
- Threshold 对齐 Python 的单位换算、6 位精度以及缺失或非数值 value 的单点行为。
- Trigger 按维度独立事件时间裁剪，有限回收不活跃维度和过期策略 generation，同时保留重叠 generation 的重放隔离。
- Comparator 仅回收已审计并完成 broker 提交的完整三流 join；比较指标去重窗口和 coverage 签名同步有界化，未配对、missing、conflict、invalid 继续 fail-closed。

## 验证

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -count=1 -race ./detect ./trigger ./comparator ./kafka ./cmd/alarmd ./cmd/alarmd-comparator`
- `git diff --check`

## 边界

本 PR 只修复 Shadow 纵切，不修改生产主链、Topic、Chart 或环境 values。首次复验保持 Comparator `max_entries=1000`，用于测量完成态回收后的真实未完成工作集。