### PR TITLE
fix(alarmd): 隔离异常 Shadow 策略并补齐诊断日志 --story=137458754

### DIFF
--- a/pkg/alarmd/cmd/alarmd/runtime.go
+++ b/pkg/alarmd/cmd/alarmd/runtime.go
@@ -66,6 +66,7 @@ type recordingDecisionSink struct {
 type recordingProcessor struct {
 	recorder *metric.Recorder
 	next     consumer.Processor
+	logger   *observability.Logger
 }
 
 func newRecordingDecisionSink(recorder *metric.Recorder, next trigger.DecisionSink) *recordingDecisionSink {
@@ -84,7 +85,24 @@ func newRecordingDecisionSinkWithLogger(
 
 func (s *recordingDecisionSink) WriteBatch(ctx context.Context, batch *contract.TriggerDecisionBatch) error {
 	started := time.Now()
+	attrs := []slog.Attr{slog.String("operation", "write_batch")}
+	if batch.BatchID != "" {
+		attrs = append(attrs, slog.String("batch_id", batch.BatchID))
+	}
+	if batch.StrategyRef.StrategyID != "" {
+		attrs = append(attrs, slog.String("strategy_id", batch.StrategyRef.StrategyID))
+	}
+	if batch.StrategyRef.ItemID != "" {
+		attrs = append(attrs, slog.String("item_id", batch.StrategyRef.ItemID))
+	}
 	if err := s.next.WriteBatch(ctx, batch); err != nil {
+		s.logger.Error(
+			observability.StageDecisionACK,
+			observability.ResultFailed,
+			len(batch.Decisions),
+			time.Since(started),
+			append(attrs, slog.String("reason", "broker"))...,
+		)
 		return err
 	}
 	s.recorder.RecordRecords(
@@ -94,10 +112,6 @@ func (s *recordingDecisionSink) WriteBatch(ctx context.Context, batch *contract.
 		metric.RecordTriggerDecision,
 		float64(len(batch.Decisions)),
 	)
-	attrs := make([]slog.Attr, 0, 1)
-	if batch.BatchID != "" {
-		attrs = append(attrs, slog.String("batch_id", batch.BatchID))
-	}
 	s.logger.Info(
 		observability.StageDecisionACK,
 		observability.ResultBrokerACK,
@@ -109,13 +123,67 @@ func (s *recordingDecisionSink) WriteBatch(ctx context.Context, batch *contract.
 }
 
 func newRecordingProcessor(recorder *metric.Recorder, next consumer.Processor) *recordingProcessor {
-	return &recordingProcessor{recorder: recorder, next: next}
+	return newRecordingProcessorWithLogger(
+		recorder, next, observability.Discard(observability.ComponentTrigger),
+	)
+}
+
+func newRecordingProcessorWithLogger(
+	recorder *metric.Recorder,
+	next consumer.Processor,
+	logger *observability.Logger,
+) *recordingProcessor {
+	return &recordingProcessor{recorder: recorder, next: next, logger: logger}
 }
 
 func (p *recordingProcessor) Process(ctx context.Context, key, payload []byte) error {
 	started := time.Now()
 	err := p.next.Process(ctx, key, payload)
 	if err != nil {
+		var processing *detect.ProcessingError
+		if errors.As(err, &processing) {
+			code := metric.ErrorInvalidInput
+			if processing.Reason == "invalid_strategy" {
+				code = metric.ErrorUnsupported
+			} else if processing.Reason == "internal" {
+				code = metric.ErrorInternal
+			}
+			p.recorder.RecordProcess(metric.StageDetect, metric.ModeShadow, metric.StatusFailed, code, time.Since(started))
+			attrs := []slog.Attr{
+				slog.String("operation", processing.Operation),
+				slog.String("reason", processing.Reason),
+			}
+			if processing.StrategyID != "" {
+				attrs = append(attrs, slog.String("strategy_id", processing.StrategyID))
+			}
+			if processing.ItemID != "" {
+				attrs = append(attrs, slog.String("item_id", processing.ItemID))
+			}
+			if processing.BatchID != "" {
+				attrs = append(attrs, slog.String("batch_id", processing.BatchID))
+			}
+			if processing.RecordID != "" {
+				attrs = append(attrs, slog.String("record_id", processing.RecordID))
+			}
+			if processing.Err != nil {
+				attrs = append(attrs, slog.String("error", processing.Err.Error()))
+			}
+			result := observability.ResultFailed
+			if processing.Isolated {
+				result = observability.ResultSkipped
+			}
+			p.logger.Error(
+				observability.StageDetect,
+				result,
+				processing.Records,
+				time.Since(started),
+				attrs...,
+			)
+			if processing.Isolated {
+				return nil
+			}
+			return err
+		}
 		p.recorder.RecordProcess(metric.StageTrigger, metric.ModeShadow, metric.StatusFailed, metric.ErrorInternal, time.Since(started))
 		return err
 	}
@@ -167,7 +235,7 @@ func runApplication(ctx context.Context, cfg config.Config, recorder *metric.Rec
 	service, err := dependencies.openService(
 		cfg.Kafka,
 		func() consumer.Processor {
-			return newRecordingProcessor(recorder, detect.NewProcessor(recordingSink))
+			return newRecordingProcessorWithLogger(recorder, detect.NewProcessor(recordingSink), eventLogger)
 		},
 		cfg.ShutdownTimeout.Duration(),
 	)

--- a/pkg/alarmd/cmd/alarmd/runtime_test.go
+++ b/pkg/alarmd/cmd/alarmd/runtime_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/config"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/consumer"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/detect"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/lifecycle"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/metric"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/observability"
@@ -681,7 +682,11 @@ func TestRecordingDecisionSinkLogsOnlyAfterAcknowledgement(t *testing.T) {
 		next,
 		observability.New(observability.ComponentTrigger, &output),
 	)
-	batch := &contract.TriggerDecisionBatch{BatchID: "batch-1", Decisions: []contract.TriggerDecision{{}, {}}}
+	batch := &contract.TriggerDecisionBatch{
+		BatchID:     "batch-1",
+		StrategyRef: contract.StrategyRef{StrategyID: "1", ItemID: "2"},
+		Decisions:   []contract.TriggerDecision{{}, {}},
+	}
 	done := make(chan error, 1)
 	go func() { done <- sink.WriteBatch(context.Background(), batch) }()
 	<-started
@@ -694,7 +699,8 @@ func TestRecordingDecisionSinkLogsOnlyAfterAcknowledgement(t *testing.T) {
 	}
 	for _, want := range []string{
 		`"component":"trigger"`, `"stage":"go_decision_ack"`, `"result":"broker_ack"`,
-		`"records":2`, `"batch_id":"batch-1"`,
+		`"operation":"write_batch"`, `"records":2`, `"batch_id":"batch-1"`,
+		`"strategy_id":"1"`, `"item_id":"2"`,
 	} {
 		if !strings.Contains(output.String(), want) {
 			t.Fatalf("log = %q, want %q", output.String(), want)
@@ -710,7 +716,7 @@ func TestRecordingDecisionSinkDoesNotCountFailedOutput(t *testing.T) {
 
 	recorder := metric.NewRecorder(metric.BuildInfo{})
 	var output bytes.Buffer
-	want := errors.New("broker acknowledgement failed")
+	want := errors.New("broker acknowledgement failed at secret-broker")
 	next := &fakeDecisionSinkRuntime{
 		write:    func(context.Context, *contract.TriggerDecisionBatch) error { return want },
 		shutdown: func(context.Context) error { return nil },
@@ -718,7 +724,11 @@ func TestRecordingDecisionSinkDoesNotCountFailedOutput(t *testing.T) {
 	sink := newRecordingDecisionSinkWithLogger(
 		recorder, next, observability.New(observability.ComponentTrigger, &output),
 	)
-	batch := &contract.TriggerDecisionBatch{Decisions: []contract.TriggerDecision{{}, {}}}
+	batch := &contract.TriggerDecisionBatch{
+		BatchID:     "batch-1",
+		StrategyRef: contract.StrategyRef{StrategyID: "1", ItemID: "2"},
+		Decisions:   []contract.TriggerDecision{{}, {}},
+	}
 	if err := sink.WriteBatch(context.Background(), batch); !errors.Is(err, want) {
 		t.Fatalf("WriteBatch() error = %v, want %v", err, want)
 	}
@@ -727,8 +737,17 @@ func TestRecordingDecisionSinkDoesNotCountFailedOutput(t *testing.T) {
 	}); got != 0 {
 		t.Fatalf("output records after failed ACK = %v, want 0", got)
 	}
-	if output.Len() != 0 {
-		t.Fatalf("log after failed ACK = %q, want empty", output.String())
+	for _, want := range []string{
+		`"stage":"go_decision_ack"`, `"result":"failed"`, `"operation":"write_batch"`,
+		`"reason":"broker"`, `"records":2`, `"batch_id":"batch-1"`,
+		`"strategy_id":"1"`, `"item_id":"2"`,
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("log = %q, want %q", output.String(), want)
+		}
+	}
+	if strings.Contains(output.String(), "secret-broker") {
+		t.Fatalf("failed ACK log leaked broker detail: %q", output.String())
 	}
 }
 
@@ -778,6 +797,96 @@ func TestRecordingProcessorUsesBoundedSuccessAndFailureLabels(t *testing.T) {
 		"stage": "trigger", "mode": "shadow", "status": "failed", "error_code": "internal",
 	}); got != 1 {
 		t.Fatalf("failed process count = %v, want 1", got)
+	}
+}
+
+func TestRecordingProcessorSkipsAndLogsIsolatedStrategyError(t *testing.T) {
+	t.Parallel()
+
+	recorder := metric.NewRecorder(metric.BuildInfo{})
+	var output bytes.Buffer
+	calls := 0
+	next := consumer.ProcessorFunc(func(context.Context, []byte, []byte) error {
+		calls++
+		if calls > 1 {
+			return nil
+		}
+		return &detect.ProcessingError{
+			Operation:  "load_strategy",
+			Reason:     "invalid_strategy",
+			Isolated:   true,
+			StrategyID: "1",
+			ItemID:     "2",
+			BatchID:    "batch-1",
+			Records:    3,
+			Err:        errors.New("threshold value must be numeric"),
+		}
+	})
+	processor := newRecordingProcessorWithLogger(
+		recorder,
+		next,
+		observability.New(observability.ComponentTrigger, &output),
+	)
+	if err := processor.Process(context.Background(), nil, nil); err != nil {
+		t.Fatalf("Process() error = %v, want isolated record committed", err)
+	}
+	if err := processor.Process(context.Background(), nil, nil); err != nil {
+		t.Fatalf("Process() after isolated strategy error = %v, want next strategy processed", err)
+	}
+	for _, want := range []string{
+		`"stage":"detect"`, `"result":"skipped"`, `"operation":"load_strategy"`,
+		`"reason":"invalid_strategy"`, `"strategy_id":"1"`, `"item_id":"2"`,
+		`"batch_id":"batch-1"`, `"records":3`, `"error":"threshold value must be numeric"`,
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("log = %q, want %q", output.String(), want)
+		}
+	}
+	if got := counterValue(t, recorder, "bkmonitor_alarmd_process_total", map[string]string{
+		"stage": "detect", "mode": "shadow", "status": "failed", "error_code": "unsupported",
+	}); got != 1 {
+		t.Fatalf("isolated process count = %v, want 1", got)
+	}
+}
+
+func TestRecordingProcessorLogsAndReturnsNonIsolatedDetectError(t *testing.T) {
+	t.Parallel()
+
+	recorder := metric.NewRecorder(metric.BuildInfo{})
+	var output bytes.Buffer
+	want := errors.New("contract validation failed")
+	next := consumer.ProcessorFunc(func(context.Context, []byte, []byte) error {
+		return &detect.ProcessingError{
+			Operation:  "decode",
+			Reason:     "invalid_input",
+			StrategyID: "1",
+			ItemID:     "2",
+			BatchID:    "batch-1",
+			Records:    3,
+			Err:        want,
+		}
+	})
+	processor := newRecordingProcessorWithLogger(
+		recorder,
+		next,
+		observability.New(observability.ComponentTrigger, &output),
+	)
+	if err := processor.Process(context.Background(), nil, nil); !errors.Is(err, want) {
+		t.Fatalf("Process() error = %v, want fatal detect error", err)
+	}
+	for _, want := range []string{
+		`"stage":"detect"`, `"result":"failed"`, `"operation":"decode"`,
+		`"reason":"invalid_input"`, `"strategy_id":"1"`, `"item_id":"2"`,
+		`"batch_id":"batch-1"`, `"records":3`, `"error":"contract validation failed"`,
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("log = %q, want %q", output.String(), want)
+		}
+	}
+	if got := counterValue(t, recorder, "bkmonitor_alarmd_process_total", map[string]string{
+		"stage": "detect", "mode": "shadow", "status": "failed", "error_code": "invalid_input",
+	}); got != 1 {
+		t.Fatalf("fatal detect process count = %v, want 1", got)
 	}
 }
 

--- a/pkg/alarmd/detect/processor.go
+++ b/pkg/alarmd/detect/processor.go
@@ -27,6 +27,29 @@ type Processor struct {
 	trigger *trigger.Processor
 }
 
+// ProcessingError carries safe coordinates for a Detect processing failure.
+// Isolated is true only after an explicit Go terminal decision has been
+// acknowledged, so the runtime may commit that input and continue.
+type ProcessingError struct {
+	Operation  string
+	Reason     string
+	Isolated   bool
+	StrategyID string
+	ItemID     string
+	BatchID    string
+	RecordID   string
+	Records    int
+	Err        error
+}
+
+func (e *ProcessingError) Error() string {
+	return fmt.Sprintf("detect processor: %s: %v", e.Operation, e.Err)
+}
+
+func (e *ProcessingError) Unwrap() error {
+	return e.Err
+}
+
 func NewProcessor(sink trigger.DecisionSink) *Processor {
 	return &Processor{trigger: trigger.NewProcessor(sink)}
 }
@@ -40,18 +63,23 @@ func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
 	}
 	input, err := contract.DecodeDetectInput(payload)
 	if err != nil {
-		return fmt.Errorf("decode detect input: %w", err)
+		return payloadError(payload, "decode", "invalid_input", false, err)
 	}
 	expectedKey, err := input.PartitionKey()
 	if err != nil {
-		return fmt.Errorf("derive detect input partition key: %w", err)
+		return inputError(input, "partition", "invalid_input", false, err)
 	}
 	if !bytes.Equal(key, expectedKey) {
-		return errors.New("detect processor: partition key mismatch")
+		return inputError(input, "partition", "invalid_input", false, errors.New("partition key mismatch"))
 	}
 	plan, err := loadThresholdPlan(input.StrategyIR)
 	if err != nil {
-		return err
+		outcomes, outcomeErr := terminalOutcomes(input, contract.OutcomeUnsupported, "UNSUPPORTED_STRATEGY")
+		if outcomeErr != nil {
+			return inputError(input, "load_strategy", "internal", false, errors.Join(err, outcomeErr))
+		}
+		diagnostic := inputError(input, "load_strategy", "invalid_strategy", true, err)
+		return p.processOutcomes(ctx, key, input, outcomes, diagnostic)
 	}
 	outcomes := make([]*contract.DetectionOutcome, 0, len(input.Records))
 	for _, rawRecord := range input.Records {
@@ -60,17 +88,131 @@ func (p *Processor) Process(ctx context.Context, key, payload []byte) error {
 		}
 		outcome, err := plan.evaluate(input, rawRecord)
 		if err != nil {
-			return err
+			isolated := inputError(input, "evaluate", "invalid_record", true, err)
+			var record struct {
+				RecordID string `json:"record_id"`
+			}
+			if json.Unmarshal(rawRecord, &record) == nil {
+				isolated.RecordID = record.RecordID
+			}
+			terminal, outcomeErr := terminalOutcomes(input, contract.OutcomeError, "INVALID_INPUT")
+			if outcomeErr != nil {
+				return inputError(input, "evaluate", "internal", false, errors.Join(err, outcomeErr))
+			}
+			return p.processOutcomes(ctx, key, input, terminal, isolated)
 		}
 		outcomes = append(outcomes, outcome)
 	}
-	return p.trigger.ProcessOutcomes(
+	return p.processOutcomes(ctx, key, input, outcomes, nil)
+}
+
+func (p *Processor) processOutcomes(
+	ctx context.Context,
+	key []byte,
+	input *contract.DetectInput,
+	outcomes []*contract.DetectionOutcome,
+	diagnostic *ProcessingError,
+) error {
+	err := p.trigger.ProcessOutcomes(
 		ctx,
 		key,
 		input.PartitionHashVersion,
 		input.StrategyIR,
 		outcomes,
 	)
+	if err == nil {
+		if diagnostic == nil {
+			return nil
+		}
+		return diagnostic
+	}
+	return err
+}
+
+func terminalOutcomes(input *contract.DetectInput, outcome, errorCode string) ([]*contract.DetectionOutcome, error) {
+	results := make([]*contract.DetectionOutcome, 0, len(input.Records))
+	for _, rawRecord := range input.Records {
+		decoder := json.NewDecoder(bytes.NewReader(rawRecord))
+		decoder.UseNumber()
+		var record struct {
+			RecordID string `json:"record_id"`
+			Time     int64  `json:"time"`
+		}
+		if err := decoder.Decode(&record); err != nil {
+			return nil, fmt.Errorf("detect processor: decode terminal record: %w", err)
+		}
+		parts := strings.Split(record.RecordID, ".")
+		if len(parts) != 2 {
+			return nil, errors.New("detect processor: invalid terminal record_id")
+		}
+		inputID, err := contract.DeriveInputID(contract.InputIdentity{
+			TenantID:              input.StrategyIR.TenantID,
+			Purpose:               input.StrategyIR.Purpose,
+			StrategyID:            input.StrategyIR.StrategyRef.StrategyID,
+			ItemID:                input.StrategyIR.StrategyRef.ItemID,
+			StrategyContentSHA256: input.StrategyIR.StrategyRef.ContentSHA256,
+			RecordID:              record.RecordID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result := &contract.DetectionOutcome{
+			Schema:           contract.Schema{Name: "detection-outcome", Major: 1, Minor: 0},
+			RequiredFeatures: []string{"full-level-evaluations-v1", "raw-json-v1"},
+			InputID:          inputID,
+			BatchID:          input.BatchID,
+			TenantID:         input.StrategyIR.TenantID,
+			Purpose:          input.StrategyIR.Purpose,
+			StrategyRef:      input.StrategyIR.StrategyRef,
+			Record: contract.DetectionRecord{
+				RecordID:      record.RecordID,
+				SourceTime:    record.Time,
+				DimensionsMD5: parts[0],
+				DataRaw:       append(json.RawMessage(nil), rawRecord...),
+			},
+			Evaluations: []contract.Evaluation{},
+			Outcome:     outcome,
+			ErrorCode:   json.RawMessage(strconv.Quote(errorCode)),
+		}
+		if err := result.Validate(input.StrategyIR); err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func inputError(input *contract.DetectInput, operation, reason string, isolated bool, err error) *ProcessingError {
+	result := &ProcessingError{Operation: operation, Reason: reason, Isolated: isolated, Err: err}
+	if input == nil {
+		return result
+	}
+	result.BatchID = input.BatchID
+	result.Records = len(input.Records)
+	if input.StrategyIR != nil {
+		result.StrategyID = input.StrategyIR.StrategyRef.StrategyID
+		result.ItemID = input.StrategyIR.StrategyRef.ItemID
+	}
+	return result
+}
+
+func payloadError(payload []byte, operation, reason string, isolated bool, err error) *ProcessingError {
+	var envelope struct {
+		BatchID    string `json:"batch_id"`
+		StrategyIR struct {
+			StrategyRef contract.StrategyRef `json:"strategy_ref"`
+		} `json:"strategy_ir"`
+		Records []json.RawMessage `json:"records"`
+	}
+	_ = json.Unmarshal(payload, &envelope)
+	return &ProcessingError{
+		Operation: operation, Reason: reason, Isolated: isolated,
+		StrategyID: envelope.StrategyIR.StrategyRef.StrategyID,
+		ItemID:     envelope.StrategyIR.StrategyRef.ItemID,
+		BatchID:    envelope.BatchID,
+		Records:    len(envelope.Records),
+		Err:        err,
+	}
 }
 
 type thresholdPlan struct {
@@ -196,11 +338,7 @@ func parseThresholdAlgorithm(raw json.RawMessage, valueUnit, thresholdSuffix str
 			default:
 				return thresholdAlgorithm{}, fmt.Errorf("detect processor: unsupported threshold method %q", method)
 			}
-			number, ok := condition["threshold"].(json.Number)
-			if !ok {
-				return thresholdAlgorithm{}, errors.New("detect processor: threshold value must be numeric")
-			}
-			threshold, err := number.Float64()
+			threshold, err := thresholdValue(condition["threshold"])
 			if err != nil {
 				return thresholdAlgorithm{}, errors.New("detect processor: threshold value must be numeric")
 			}
@@ -209,6 +347,25 @@ func parseThresholdAlgorithm(raw json.RawMessage, valueUnit, thresholdSuffix str
 		algorithm.groups = append(algorithm.groups, group)
 	}
 	return algorithm, nil
+}
+
+func thresholdValue(raw any) (float64, error) {
+	var (
+		value float64
+		err   error
+	)
+	switch raw := raw.(type) {
+	case json.Number:
+		value, err = raw.Float64()
+	case string:
+		value, err = strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	default:
+		return 0, errors.New("threshold is not a number")
+	}
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, errors.New("threshold is not finite")
+	}
+	return value, nil
 }
 
 func (p *thresholdPlan) evaluate(input *contract.DetectInput, rawRecord json.RawMessage) (*contract.DetectionOutcome, error) {

--- a/pkg/alarmd/detect/processor_test.go
+++ b/pkg/alarmd/detect/processor_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
@@ -24,11 +25,12 @@ import (
 
 type recordingDecisionSink struct {
 	batches []*contract.TriggerDecisionBatch
+	err     error
 }
 
 func (s *recordingDecisionSink) WriteBatch(_ context.Context, batch *contract.TriggerDecisionBatch) error {
 	s.batches = append(s.batches, batch)
-	return nil
+	return s.err
 }
 
 func TestProcessorRunsThresholdDetectBeforeTrigger(t *testing.T) {
@@ -143,6 +145,131 @@ func TestProcessorMatchesPythonThresholdUnitConversion(t *testing.T) {
 	if decision := sink.batches[0].Decisions[1]; decision.Outcome != contract.DecisionOutcomeNoTrigger || decision.ReasonCode != contract.DecisionReasonInputNormal {
 		t.Fatalf("invalid-value decision = %#v, want Python-compatible INPUT_NORMAL", decision)
 	}
+}
+
+func TestProcessorAcceptsPythonNumericStringThreshold(t *testing.T) {
+	t.Parallel()
+
+	processor, key, payload, sink := thresholdProcessorFixture(t, `"50"`)
+	if err := processor.Process(context.Background(), key, payload); err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if len(sink.batches) != 1 || sink.batches[0].Decisions[0].Outcome != contract.DecisionOutcomeTrigger {
+		t.Fatalf("batches = %#v, want one TRIGGER decision", sink.batches)
+	}
+}
+
+func TestProcessorClassifiesInvalidStrategyAsIsolated(t *testing.T) {
+	t.Parallel()
+
+	processor, key, payload, sink := thresholdProcessorFixture(t, `"not-a-number"`)
+	err := processor.Process(context.Background(), key, payload)
+	var isolated *ProcessingError
+	if !errors.As(err, &isolated) {
+		t.Fatalf("Process() error = %v, want ProcessingError", err)
+	}
+	if !isolated.Isolated || isolated.Operation != "load_strategy" || isolated.Reason != "invalid_strategy" {
+		t.Fatalf("isolated error = %#v, want load_strategy/invalid_strategy", isolated)
+	}
+	if isolated.StrategyID != "1" || isolated.ItemID != "2" || isolated.BatchID != "batch-1" || isolated.Records != 1 {
+		t.Fatalf("isolated coordinates = %#v", isolated)
+	}
+	if len(sink.batches) != 1 || len(sink.batches[0].Decisions) != 1 {
+		t.Fatalf("batches = %#v, want one explicit unsupported decision", sink.batches)
+	}
+	decision := sink.batches[0].Decisions[0]
+	if decision.Outcome != contract.OutcomeUnsupported || decision.ReasonCode != "UNSUPPORTED_STRATEGY" {
+		t.Fatalf("decision = %#v, want UNSUPPORTED/UNSUPPORTED_STRATEGY", decision)
+	}
+}
+
+func TestProcessorDoesNotIsolateDecisionDeliveryFailure(t *testing.T) {
+	t.Parallel()
+
+	processor, key, payload, sink := thresholdProcessorFixture(t, `"not-a-number"`)
+	want := errors.New("broker unavailable")
+	sink.err = want
+	err := processor.Process(context.Background(), key, payload)
+	if !errors.Is(err, want) {
+		t.Fatalf("Process() error = %v, want delivery failure", err)
+	}
+	var isolated *ProcessingError
+	if errors.As(err, &isolated) {
+		t.Fatalf("Process() error = %v, must not isolate delivery failure", err)
+	}
+}
+
+func TestProcessorDoesNotCommitInputWithoutTerminalDecision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     func([]byte) []byte
+		payload func([]byte) []byte
+	}{
+		{name: "invalid envelope", key: func(key []byte) []byte { return key }, payload: func([]byte) []byte { return []byte(`{`) }},
+		{name: "partition mismatch", key: func([]byte) []byte { return []byte("wrong") }, payload: func(payload []byte) []byte { return payload }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			processor, key, payload, sink := thresholdProcessorFixture(t, `50`)
+			err := processor.Process(context.Background(), test.key(key), test.payload(payload))
+			var processing *ProcessingError
+			if !errors.As(err, &processing) || processing.Isolated {
+				t.Fatalf("Process() error = %#v, want non-isolated ProcessingError", err)
+			}
+			if len(sink.batches) != 0 {
+				t.Fatalf("batches = %#v, want none", sink.batches)
+			}
+		})
+	}
+}
+
+func thresholdProcessorFixture(
+	t *testing.T,
+	thresholdJSON string,
+) (*Processor, []byte, []byte, *recordingDecisionSink) {
+	t.Helper()
+	legacy := []byte(`{"id":1,"update_time":1,"items":[{"id":2,"query_configs":[{"agg_interval":60}],"algorithms":[{"level":1,"type":"Threshold","config":[[{"method":"gte","threshold":` + thresholdJSON + `}]]}],"no_data_config":{"is_enabled":false}}],"detects":[{"level":1,"connector":"and","trigger_config":{"count":1,"check_window":1}}]}`)
+	digest := sha256.Sum256(legacy)
+	strategy := map[string]any{
+		"schema":                    map[string]any{"name": "trigger-strategy-ir", "major": 1, "minor": 0},
+		"required_features":         []string{"raw-strategy-bytes-v1"},
+		"tenant_id":                 "default",
+		"purpose":                   "DETECT",
+		"strategy_ref":              map[string]any{"strategy_id": "1", "item_id": "2", "generation": "1", "content_sha256": hex.EncodeToString(digest[:])},
+		"required_levels":           []int{1},
+		"check_window_unit_seconds": 60,
+		"trigger_configs":           []map[string]any{{"level": 1, "check_window_size": 1, "trigger_count": 1}},
+		"legacy_json_b64":           base64.StdEncoding.EncodeToString(legacy),
+	}
+	payload, err := json.Marshal(map[string]any{
+		"schema":                 map[string]any{"name": "detect-input", "major": 1, "minor": 0},
+		"required_features":      []string{},
+		"partition_hash_version": contract.PartitionHashVersionV1,
+		"strategy_ir":            strategy,
+		"batch_id":               "batch-1",
+		"records": []map[string]any{{
+			"record_id": "342a08e0f85f169a7e099c18db3708ed.100",
+			"time":      100,
+			"value":     60,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := contract.DecodeDetectInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeDetectInput() error = %v", err)
+	}
+	key, err := input.PartitionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &recordingDecisionSink{}
+	return NewProcessor(sink), key, payload, sink
 }
 
 func TestThresholdUnitScalesMatchPythonBaseConversion(t *testing.T) {

--- a/pkg/alarmd/observability/log.go
+++ b/pkg/alarmd/observability/log.go
@@ -21,6 +21,7 @@ const (
 	ComponentComparator = "comparator"
 
 	StageStartup       = "startup"
+	StageDetect        = "detect"
 	StageFatal         = "fatal"
 	StageShutdown      = "shutdown"
 	StageDecisionACK   = "go_decision_ack"
@@ -30,11 +31,13 @@ const (
 	ResultBrokerACK = "broker_ack"
 	ResultSuccess   = "success"
 	ResultFailed    = "failed"
+	ResultSkipped   = "skipped"
 	ResultTimeout   = "timeout"
 )
 
-// Logger emits the fixed low-cardinality event envelope used by alarmd. Callers
-// may add only bounded aggregate fields or an already available batch ID.
+// Logger emits the fixed event envelope used by alarmd. Metric labels remain
+// bounded; diagnostic log attributes may include record coordinates and a
+// sanitized error, but never payloads or credentials.
 type Logger struct {
 	component string
 	next      *slog.Logger


### PR DESCRIPTION
close #1010158081137458754

## 问题

- Python Threshold 配置允许数值字符串，Go 仅接受 JSON number，单个策略会使 Shadow consumer 退出。
- 缺少策略、item、batch、record 和处理阶段坐标，错误只能定位到进程级 fatal；缺失 Go Decision 还会形成不可回收的 Comparator pending entry。

## 变更

- Threshold 同时接受有限数值和数值字符串，与 Python FloatField 主路径保持一致。
- 策略解析或单批计算失败时生成显式 UNSUPPORTED/ERROR Go 终态；仅在 Decision broker ACK 后隔离该输入并继续处理其他策略。
- DetectInput 解码、分区校验、内部错误及 Kafka 写入继续 fail-closed，禁止无终态提交 offset。
- 结构化日志补齐 operation、strategy_id、item_id、batch_id、record_id、records 和 error；Go Decision ACK 成败均记录阶段与安全原因，Broker 错误正文不进入结构化日志。

## 验证

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -count=1 -race ./detect ./trigger ./cmd/alarmd ./comparator`
- `go mod verify`
- `git diff --check`
- 独立评审：无剩余 P0/P1

## 边界

本 PR 只修复 alarmd Shadow 纵切，不修改 Python 生产主链、Topic、Chart 或环境 values。异常策略的终态用于形成可见、可回收的 invalid/unsupported 审计，不会伪造 match。