### PR TITLE
fix(alarmd): 隔离 Comparator 容量压力 --story=137462094

### DIFF
--- a/pkg/alarmd/cmd/alarmd-comparator/runtime.go
+++ b/pkg/alarmd/cmd/alarmd-comparator/runtime.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/comparator"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/config"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 	enginekafka "github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/kafka"
@@ -233,7 +234,7 @@ func runComparatorApplicationWithLogger(
 		return errors.Join(err, shutdownComparatorSink(sink, time.Now().Add(configuration.ShutdownTimeout.Duration())))
 	}
 	service, err := enginekafka.OpenComparatorService(
-		configuration.Kafka.ServiceCoordinates(),
+		withComparatorDiagnostics(configuration.Kafka.ServiceCoordinates(), eventLogger),
 		recordingSink,
 		configuration.ShutdownTimeout.Duration(),
 	)
@@ -335,6 +336,47 @@ func runComparatorApplicationWithLogger(
 		eventLogger.Error(observability.StageShutdown, shutdownResult, 0, time.Since(shutdownStarted))
 	}
 	return result
+}
+
+func withComparatorDiagnostics(
+	configuration enginekafka.ComparatorServiceConfig,
+	logger *observability.Logger,
+) enginekafka.ComparatorServiceConfig {
+	configuration.Diagnostics = enginekafka.ComparatorDiagnostics{
+		OnCapacityDrop: func(event enginekafka.ComparatorCapacityDrop) {
+			logger.Info(
+				observability.StageCapacityDrop, observability.ResultDropped, event.Dropped, 0,
+				slog.String("role", comparatorStreamRole(event.Role)),
+				slog.Int("partition", int(event.Partition)),
+				slog.Int64("offset", event.Offset),
+				slog.Int("max_entries", event.MaxEntries),
+			)
+		},
+		OnCoverageRelease: func(event enginekafka.ComparatorCoverageRelease) {
+			logger.Info(
+				observability.StageCoverageRelease, observability.ResultReleased, event.Entries, 0,
+				slog.Int("authoritative", event.Authoritative),
+				slog.Int("orphans", event.Orphans),
+				slog.Int("missing_input", event.MissingInput),
+				slog.Int("missing_go", event.MissingGo),
+				slog.Int("missing_python", event.MissingPython),
+			)
+		},
+	}
+	return configuration
+}
+
+func comparatorStreamRole(role comparator.StreamRole) string {
+	switch role {
+	case comparator.StreamInput:
+		return "input"
+	case comparator.StreamGo:
+		return "go"
+	case comparator.StreamPython:
+		return "python"
+	default:
+		return "unknown"
+	}
 }
 
 func shutdownComparatorSink(sink *enginekafka.ComparisonAuditKafkaSink, deadline time.Time) error {

--- a/pkg/alarmd/cmd/alarmd-comparator/runtime_test.go
+++ b/pkg/alarmd/cmd/alarmd-comparator/runtime_test.go
@@ -12,14 +12,53 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/comparator"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
+	enginekafka "github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/kafka"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/metric"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/observability"
 )
+
+func TestComparatorDiagnosticsLogCommittedCoverageLossWithoutInputIDs(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	configuration := withComparatorDiagnostics(
+		enginekafka.ComparatorServiceConfig{},
+		observability.New(observability.ComponentComparator, &output),
+	)
+	configuration.Diagnostics.OnCapacityDrop(enginekafka.ComparatorCapacityDrop{
+		Role: comparator.StreamGo, Partition: 2, Offset: 41, Dropped: 3, MaxEntries: 1000,
+	})
+	configuration.Diagnostics.OnCoverageRelease(enginekafka.ComparatorCoverageRelease{
+		Entries: 4, Authoritative: 3, Orphans: 1, MissingInput: 1, MissingGo: 2, MissingPython: 2,
+	})
+
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("diagnostic lines = %d, output=%s", len(lines), output.String())
+	}
+	for index, line := range lines {
+		var event map[string]any
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode line %d: %v", index, err)
+		}
+		if _, exists := event["input_id"]; exists {
+			t.Fatalf("diagnostic event leaked input_id: %#v", event)
+		}
+	}
+	if !strings.Contains(lines[0], `"stage":"capacity_drop"`) || !strings.Contains(lines[0], `"records":3`) || !strings.Contains(lines[0], `"max_entries":1000`) {
+		t.Fatalf("capacity log = %s", lines[0])
+	}
+	if !strings.Contains(lines[1], `"stage":"coverage_release"`) || !strings.Contains(lines[1], `"records":4`) || !strings.Contains(lines[1], `"orphans":1`) {
+		t.Fatalf("coverage log = %s", lines[1])
+	}
+}
 
 func TestComparisonResultLedgerCountsOneVerdictPerInput(t *testing.T) {
 	t.Parallel()

--- a/pkg/alarmd/comparator/coverage.go
+++ b/pkg/alarmd/comparator/coverage.go
@@ -39,6 +39,7 @@ type BarrierSnapshot struct {
 
 type CoverageSnapshot struct {
 	InputID               string
+	Authoritative         bool
 	Phase                 CoveragePhase
 	BarrierFrozen         bool
 	FirstSeenAt           time.Time
@@ -129,10 +130,10 @@ func (r *Run) FreezeBarrier(epoch, inputID string, snapshot BarrierSnapshot) err
 	if err != nil {
 		return r.invalidateLocked(err)
 	}
-	if !item.present[StreamInput] {
-		return fmt.Errorf("comparator: authoritative TriggerInput has not arrived")
+	deadline := r.coverageDeadlineLocked(item)
+	if deadline.IsZero() {
+		return r.invalidateLocked(fmt.Errorf("comparator: coverage deadline is unavailable"))
 	}
-	deadline := item.authoritativeAt.Add(r.coverageTimeout)
 	if snapshot.CaptureStartedAt.IsZero() {
 		return r.invalidateLocked(fmt.Errorf("comparator: barrier capture start must be non-zero"))
 	}
@@ -207,6 +208,9 @@ func (r *Run) prepareCoverageLocked(inflight *preparedRecord) error {
 	inflight.observedAt = observedAt
 	inflight.coverage = make(map[string]*coverageEntry)
 	for _, update := range inflight.updates {
+		if update.Disposition == DispositionCapacityDropped {
+			continue
+		}
 		item := inflight.coverage[update.InputID]
 		if item == nil {
 			item = cloneCoverageEntry(r.coverage[update.InputID])
@@ -315,6 +319,36 @@ func coverageEntryComplete(item *coverageEntry) bool {
 	return item != nil && item.present[StreamInput] && item.present[StreamGo] && item.present[StreamPython]
 }
 
+// ReleaseTerminalCoverage makes barrier-proven missing entries eligible for
+// bounded compaction. Authoritative entries are released only after their
+// missing audit is acknowledged; decision-only orphans have no audit payload
+// and are released after the same broker high-water proof.
+func (r *Run) ReleaseTerminalCoverage(epoch string, inputIDs []string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.requireCoverageLocked(epoch); err != nil {
+		return err
+	}
+	now, err := r.nowLocked()
+	if err != nil {
+		return r.invalidateLocked(err)
+	}
+	releasable := make([]string, 0, len(inputIDs))
+	for _, inputID := range inputIDs {
+		item := r.coverage[inputID]
+		if item == nil {
+			return r.invalidateLocked(fmt.Errorf("comparator: terminal coverage input is unknown"))
+		}
+		snapshot := r.coverageSnapshotLocked(inputID, item, now)
+		if !snapshot.BarrierFrozen || snapshot.Phase != CoverageMissingAtBarrier {
+			return r.invalidateLocked(fmt.Errorf("comparator: coverage is not terminal at barrier"))
+		}
+		releasable = append(releasable, inputID)
+	}
+	r.joiner.markReleasable(releasable)
+	return nil
+}
+
 func (r *Run) requireCoverageLocked(epoch string) error {
 	if err := r.requireEpochAndCommittedLocked(epoch); err != nil {
 		return err
@@ -344,10 +378,7 @@ func (r *Run) coverageSnapshotLocked(inputID string, item *coverageEntry, now ti
 		return !item.present[role] && item.missingAtBarrier[role]
 	})
 	phase := CoveragePending
-	deadline := time.Time{}
-	if !item.authoritativeAt.IsZero() {
-		deadline = item.authoritativeAt.Add(r.coverageTimeout)
-	}
+	deadline := r.coverageDeadlineLocked(item)
 	switch {
 	case len(missing) == 0:
 		phase = CoverageComplete
@@ -358,6 +389,7 @@ func (r *Run) coverageSnapshotLocked(inputID string, item *coverageEntry, now ti
 	}
 	return CoverageSnapshot{
 		InputID:               inputID,
+		Authoritative:         item.present[StreamInput],
 		Phase:                 phase,
 		BarrierFrozen:         item.barriers != nil,
 		FirstSeenAt:           item.firstSeen,
@@ -368,6 +400,20 @@ func (r *Run) coverageSnapshotLocked(inputID string, item *coverageEntry, now ti
 			return item.late[role]
 		}),
 	}
+}
+
+func (r *Run) coverageDeadlineLocked(item *coverageEntry) time.Time {
+	if item == nil {
+		return time.Time{}
+	}
+	anchor := item.authoritativeAt
+	if anchor.IsZero() {
+		anchor = item.firstSeen
+	}
+	if anchor.IsZero() {
+		return time.Time{}
+	}
+	return anchor.Add(r.coverageTimeout)
 }
 
 func (r *Run) refreshMissingAtBarrierLocked(item *coverageEntry) {

--- a/pkg/alarmd/comparator/coverage_test.go
+++ b/pkg/alarmd/comparator/coverage_test.go
@@ -50,26 +50,67 @@ func TestCoverageDeadlineStartsAtAuthoritativeCommit(t *testing.T) {
 	}
 	clock.Advance(11 * time.Second)
 	snapshot, ok, err = run.Coverage("run-1", inputID)
-	if err != nil || !ok || snapshot.Phase != CoveragePending || !snapshot.DeadlineAt.IsZero() || !slices.Equal(snapshot.MissingRoles, []StreamRole{StreamInput, StreamPython}) {
-		t.Fatalf("Coverage(orphan pending) = %#v, ok=%v, error=%v", snapshot, ok, err)
+	if err != nil || !ok || snapshot.Authoritative || snapshot.Phase != CoverageOverdue || snapshot.DeadlineAt.IsZero() || !slices.Equal(snapshot.MissingRoles, []StreamRole{StreamInput, StreamPython}) {
+		t.Fatalf("Coverage(orphan overdue) = %#v, ok=%v, error=%v", snapshot, ok, err)
 	}
 	snapshots, err := run.SweepCoverage("run-1")
-	if err != nil || len(snapshots) != 1 || snapshots[0].InputID != inputID || snapshots[0].Phase != CoveragePending {
+	if err != nil || len(snapshots) != 1 || snapshots[0].InputID != inputID || snapshots[0].Phase != CoverageOverdue {
 		t.Fatalf("SweepCoverage() = %#v, error=%v", snapshots, err)
-	}
-	if err := run.FreezeBarrier("run-1", inputID, capturedBarrier(clock)); err == nil {
-		t.Fatal("FreezeBarrier() accepted an orphan without TriggerInput")
-	}
-	if !run.Valid() {
-		t.Fatal("an orphan barrier invalidated the Run")
 	}
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: mustPartitionKey(t, input), Value: inputPayload})
 	snapshot, ok, err = run.Coverage("run-1", inputID)
-	if err != nil || !ok || snapshot.Phase != CoveragePending || !slices.Equal(snapshot.MissingRoles, []StreamRole{StreamPython}) {
+	if err != nil || !ok || !snapshot.Authoritative || snapshot.Phase != CoveragePending || !slices.Equal(snapshot.MissingRoles, []StreamRole{StreamPython}) {
 		t.Fatalf("Coverage(after authoritative input) = %#v, ok=%v, error=%v", snapshot, ok, err)
 	}
 	if want := clock.Now().Add(10 * time.Second); !snapshot.DeadlineAt.Equal(want) {
 		t.Fatalf("Coverage deadline = %s, want %s", snapshot.DeadlineAt, want)
+	}
+}
+
+func TestCoverageTerminalOrphanReleasesCapacity(t *testing.T) {
+	t.Parallel()
+
+	clock := &manualRunClock{now: time.Date(2026, time.August, 18, 0, 0, 0, 0, time.UTC)}
+	run, err := NewRun("run-1", 1, testAssignments(), WithCoverageTimeout(10*time.Second), withRunClock(clock.Now))
+	if err != nil {
+		t.Fatalf("NewRun() error = %v", err)
+	}
+	_, first := testTriggerInput(t, "normal")
+	firstID := first.DetectionOutcomes[0].InputID
+	commitStreamRecord(t, run, StreamRecord{
+		Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10,
+		Key: mustPartitionKey(t, first), Value: testDecisionBatch(t, first, contract.DecisionOutcomeNoTrigger),
+	})
+	clock.Advance(11 * time.Second)
+	if err := run.FreezeBarrier("run-1", firstID, capturedBarrier(
+		clock,
+		PartitionBarrier{Role: StreamInput, Topic: "input", Partition: 0, HighWater: 20},
+		PartitionBarrier{Role: StreamPython, Topic: "python", Partition: 0, HighWater: 30},
+	)); err != nil {
+		t.Fatalf("FreezeBarrier() error = %v", err)
+	}
+	snapshot, ok, err := run.Coverage("run-1", firstID)
+	if err != nil || !ok || snapshot.Authoritative || snapshot.Phase != CoverageMissingAtBarrier {
+		t.Fatalf("Coverage(orphan terminal) = %#v, ok=%v, error=%v", snapshot, ok, err)
+	}
+	if err := run.ReleaseTerminalCoverage("run-1", []string{firstID}); err != nil {
+		t.Fatalf("ReleaseTerminalCoverage() error = %v", err)
+	}
+
+	_, second := testTriggerInput(t, "anomalous")
+	prepared, err := run.Prepare(StreamRecord{
+		Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 11,
+		Key: mustPartitionKey(t, second), Value: testDecisionBatch(t, second, contract.DecisionOutcomeNoTrigger),
+	})
+	if err != nil {
+		t.Fatalf("Prepare(second) did not reuse terminal orphan capacity: %v", err)
+	}
+	updates, err := run.CommitSucceeded(prepared)
+	if err != nil || len(updates) != 1 || updates[0].Disposition != DispositionAccepted {
+		t.Fatalf("CommitSucceeded(second) updates=%#v error=%v", updates, err)
+	}
+	if _, ok, err := run.Coverage("run-1", firstID); err != nil || ok {
+		t.Fatalf("Coverage(evicted orphan) ok=%v error=%v", ok, err)
 	}
 }
 

--- a/pkg/alarmd/comparator/joiner.go
+++ b/pkg/alarmd/comparator/joiner.go
@@ -37,6 +37,7 @@ const (
 	DispositionReplay
 	DispositionConflict
 	DispositionInvalid
+	DispositionCapacityDropped
 )
 
 type JoinStatus uint8
@@ -194,13 +195,16 @@ func (j *Joiner) ObserveTriggerInput(runEpoch string, key, payload []byte) ([]Up
 	if err := j.requireEpoch(runEpoch); err != nil {
 		return nil, err
 	}
-	if err := j.requireCapacity(inputIDsFromSources(observations)); err != nil {
-		return nil, err
-	}
 	updates := make([]Update, 0, len(observations))
 	for index := range observations {
 		observation := &observations[index]
-		item := j.getOrCreate(observation.outcome.InputID)
+		item, admitted := j.getOrAdmit(observation.outcome.InputID)
+		if !admitted {
+			updates = append(updates, Update{
+				InputID: observation.outcome.InputID, Disposition: DispositionCapacityDropped,
+			})
+			continue
+		}
 		disposition := DispositionAccepted
 		switch {
 		case item.source == nil:
@@ -261,13 +265,16 @@ func (j *Joiner) ObserveDecisionBatch(runEpoch string, side DecisionSide, key, p
 	if err := j.requireEpoch(runEpoch); err != nil {
 		return nil, err
 	}
-	if err := j.requireCapacity(inputIDsFromDecisions(observations)); err != nil {
-		return nil, err
-	}
 	updates := make([]Update, 0, len(observations))
 	for index := range observations {
 		observation := &observations[index]
-		item := j.getOrCreate(observation.decision.InputID)
+		item, admitted := j.getOrAdmit(observation.decision.InputID)
+		if !admitted {
+			updates = append(updates, Update{
+				InputID: observation.decision.InputID, Disposition: DispositionCapacityDropped,
+			})
+			continue
+		}
 		disposition := j.storeDecision(item, side, observation)
 		updates = append(updates, Update{InputID: observation.decision.InputID, Disposition: disposition})
 	}
@@ -392,25 +399,9 @@ func (j *Joiner) requireEpoch(runEpoch string) error {
 	return nil
 }
 
-func (j *Joiner) requireCapacity(inputIDs []string) error {
-	newEntries := 0
-	for _, inputID := range inputIDs {
-		if _, exists := j.entries[inputID]; !exists {
-			newEntries++
-		}
-	}
-	if len(j.entries)+newEntries > j.maxEntries {
-		return fmt.Errorf(
-			"comparator: entry capacity exceeded: current=%d new=%d max=%d",
-			len(j.entries), newEntries, j.maxEntries,
-		)
-	}
-	return nil
-}
-
-// markReleasable records entries whose authoritative input and both decisions
-// have been audited and committed. They remain available for recent replay and
-// conflict detection until capacity is needed by a later stream record.
+// markReleasable records entries whose complete audit or terminal coverage gap
+// has been acknowledged. They remain available for recent replay and conflict
+// detection until capacity is needed by a later stream record.
 func (j *Joiner) markReleasable(inputIDs []string) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
@@ -451,13 +442,17 @@ func (j *Joiner) compact(target int) []string {
 	return evicted
 }
 
-func (j *Joiner) getOrCreate(inputID string) *entry {
+func (j *Joiner) getOrAdmit(inputID string) (*entry, bool) {
 	item := j.entries[inputID]
-	if item == nil {
-		item = &entry{}
-		j.entries[inputID] = item
+	if item != nil {
+		return item, true
 	}
-	return item
+	if len(j.entries) >= j.maxEntries {
+		return nil, false
+	}
+	item = &entry{}
+	j.entries[inputID] = item
+	return item, true
 }
 
 func (j *Joiner) storeDecision(item *entry, side DecisionSide, observation *decisionObservation) Disposition {
@@ -601,20 +596,4 @@ func cloneDecisionObservation(observation *decisionObservation) *decisionObserva
 	cloned := *observation
 	cloned.decision = cloneDecision(observation.decision)
 	return &cloned
-}
-
-func inputIDsFromSources(observations []sourceObservation) []string {
-	inputIDs := make([]string, 0, len(observations))
-	for index := range observations {
-		inputIDs = append(inputIDs, observations[index].outcome.InputID)
-	}
-	return inputIDs
-}
-
-func inputIDsFromDecisions(observations []decisionObservation) []string {
-	inputIDs := make([]string, 0, len(observations))
-	for index := range observations {
-		inputIDs = append(inputIDs, observations[index].decision.InputID)
-	}
-	return inputIDs
 }

--- a/pkg/alarmd/comparator/joiner_test.go
+++ b/pkg/alarmd/comparator/joiner_test.go
@@ -208,8 +208,11 @@ func TestJoinerReplayConflictCapacityAndEpochAreFailClosed(t *testing.T) {
 	}
 
 	_, second := testTriggerInput(t, "error-partial")
-	if _, err := joiner.ObserveDecisionBatch("run-1", DecisionSidePython, mustPartitionKey(t, second), testDecisionBatch(t, second, contract.OutcomeError)); err == nil {
-		t.Fatal("ObserveDecisionBatch() exceeded capacity")
+	updates, err = joiner.ObserveDecisionBatch(
+		"run-1", DecisionSidePython, mustPartitionKey(t, second), testDecisionBatch(t, second, contract.OutcomeError),
+	)
+	if err != nil || len(updates) != 1 || updates[0].Disposition != DispositionCapacityDropped {
+		t.Fatalf("capacity observation = %#v, error=%v, want one explicit drop", updates, err)
 	}
 	nextRun := mustJoiner(t, "run-2", 1)
 	if _, err := nextRun.ObserveTriggerInput("run-1", key, inputPayload); err == nil {
@@ -251,18 +254,23 @@ func TestJoinerMarksConflictsSymmetricallyForBothDecisionSides(t *testing.T) {
 	}
 }
 
-func TestJoinerRejectsOverCapacityBatchAtomically(t *testing.T) {
+func TestJoinerDropsOnlyNewEntriesBeyondCapacity(t *testing.T) {
 	t.Parallel()
 
 	payload, input := testTriggerInputMany(t, "anomalous", "normal")
 	joiner := mustJoiner(t, "run-1", 1)
-	if _, err := joiner.ObserveTriggerInput("run-1", mustPartitionKey(t, input), payload); err == nil {
-		t.Fatal("ObserveTriggerInput() accepted an over-capacity batch")
+	updates, err := joiner.ObserveTriggerInput("run-1", mustPartitionKey(t, input), payload)
+	if err != nil {
+		t.Fatalf("ObserveTriggerInput() error = %v", err)
 	}
-	for _, outcome := range input.DetectionOutcomes {
-		if _, ok, err := joiner.Assess("run-1", outcome.InputID, Gates{}); err != nil || ok {
-			t.Fatalf("Assess(%s) ok=%v error=%v, want no partial mutation", outcome.InputID, ok, err)
-		}
+	if len(updates) != 2 || updates[0].Disposition != DispositionAccepted || updates[1].Disposition != DispositionCapacityDropped {
+		t.Fatalf("updates = %#v, want accepted then capacity dropped", updates)
+	}
+	if _, ok, err := joiner.Assess("run-1", input.DetectionOutcomes[0].InputID, Gates{}); err != nil || !ok {
+		t.Fatalf("Assess(admitted) ok=%v error=%v", ok, err)
+	}
+	if _, ok, err := joiner.Assess("run-1", input.DetectionOutcomes[1].InputID, Gates{}); err != nil || ok {
+		t.Fatalf("Assess(dropped) ok=%v error=%v, want no retained entry", ok, err)
 	}
 }
 

--- a/pkg/alarmd/kafka/comparator_assignment.go
+++ b/pkg/alarmd/kafka/comparator_assignment.go
@@ -57,6 +57,7 @@ type comparatorAssignmentCoordinator struct {
 	roleTopics      map[comparator.StreamRole]string
 	maxEntries      int
 	coverageTimeout time.Duration
+	diagnostics     ComparatorDiagnostics
 	nextGeneration  uint64
 	current         *comparatorGeneration
 }

--- a/pkg/alarmd/kafka/comparator_barrier.go
+++ b/pkg/alarmd/kafka/comparator_barrier.go
@@ -38,7 +38,7 @@ func newComparatorBarrierAdapter(records *comparatorRecordCoordinator) (*compara
 }
 
 // CaptureOverdue freezes fresh broker high-water barriers for every overdue
-// authoritative input that has not already frozen one.
+// coverage entry that has not already frozen one.
 func (a *comparatorBarrierAdapter) CaptureOverdue(ctx context.Context) (int, error) {
 	if a == nil || a.records == nil || ctx == nil || a.beginCapture == nil {
 		return 0, errors.New("kafka comparator barrier: initialized adapter and context are required")
@@ -168,7 +168,9 @@ func (a *comparatorBarrierAdapter) CaptureOverdue(ctx context.Context) (int, err
 }
 
 func (a *comparatorBarrierAdapter) publishChangedCoverage(ctx context.Context, snapshots []comparator.CoverageSnapshot) error {
-	changedIDs := make([]string, 0)
+	authoritativeIDs := make([]string, 0)
+	terminalIDs := make([]string, 0)
+	terminalSnapshots := make([]comparator.CoverageSnapshot, 0)
 	signatures := make(map[string]string)
 	for _, snapshot := range snapshots {
 		if !snapshot.BarrierFrozen {
@@ -178,28 +180,64 @@ func (a *comparatorBarrierAdapter) publishChangedCoverage(ctx context.Context, s
 		if a.lastCoverage[snapshot.InputID] == signature {
 			continue
 		}
-		changedIDs = append(changedIDs, snapshot.InputID)
+		if snapshot.Authoritative {
+			authoritativeIDs = append(authoritativeIDs, snapshot.InputID)
+		}
+		if snapshot.Phase == comparator.CoverageMissingAtBarrier {
+			terminalIDs = append(terminalIDs, snapshot.InputID)
+			terminalSnapshots = append(terminalSnapshots, snapshot)
+		}
 		signatures[snapshot.InputID] = signature
 	}
-	if len(changedIDs) == 0 {
+	if len(signatures) == 0 {
 		return nil
 	}
-	batches, err := a.records.run.AuditBatches(a.records.epoch, changedIDs, comparator.Gates{StableEpoch: true})
-	if err != nil {
-		return err
-	}
-	if len(batches) == 0 {
-		return errors.New("kafka comparator barrier: changed coverage produced no audit")
-	}
-	for _, batch := range batches {
-		if err := a.records.audits.WriteBatch(ctx, batch); err != nil {
-			return fmt.Errorf("kafka comparator barrier: publish audit: %w", err)
+	if len(authoritativeIDs) > 0 {
+		batches, err := a.records.run.AuditBatches(a.records.epoch, authoritativeIDs, comparator.Gates{StableEpoch: true})
+		if err != nil {
+			return err
 		}
+		if len(batches) == 0 {
+			return errors.New("kafka comparator barrier: changed authoritative coverage produced no audit")
+		}
+		for _, batch := range batches {
+			if err := a.records.audits.WriteBatch(ctx, batch); err != nil {
+				return fmt.Errorf("kafka comparator barrier: publish audit: %w", err)
+			}
+		}
+	}
+	if len(terminalIDs) > 0 {
+		if err := a.records.run.ReleaseTerminalCoverage(a.records.epoch, terminalIDs); err != nil {
+			return err
+		}
+		a.records.diagnostics.coverageRelease(summarizeCoverageRelease(terminalSnapshots))
 	}
 	for inputID, signature := range signatures {
 		a.lastCoverage[inputID] = signature
 	}
 	return nil
+}
+
+func summarizeCoverageRelease(snapshots []comparator.CoverageSnapshot) ComparatorCoverageRelease {
+	event := ComparatorCoverageRelease{Entries: len(snapshots)}
+	for _, snapshot := range snapshots {
+		if snapshot.Authoritative {
+			event.Authoritative++
+		} else {
+			event.Orphans++
+		}
+		for _, role := range snapshot.MissingAtBarrierRoles {
+			switch role {
+			case comparator.StreamInput:
+				event.MissingInput++
+			case comparator.StreamGo:
+				event.MissingGo++
+			case comparator.StreamPython:
+				event.MissingPython++
+			}
+		}
+	}
+	return event
 }
 
 func (a *comparatorBarrierAdapter) pruneLastCoverage(snapshots []comparator.CoverageSnapshot) {
@@ -215,7 +253,7 @@ func (a *comparatorBarrierAdapter) pruneLastCoverage(snapshots []comparator.Cove
 }
 
 func coverageAuditSignature(snapshot comparator.CoverageSnapshot) string {
-	return fmt.Sprintf("%d|%t|%v|%v|%v", snapshot.Phase, snapshot.BarrierFrozen, snapshot.MissingRoles, snapshot.MissingAtBarrierRoles, snapshot.LateRoles)
+	return fmt.Sprintf("%t|%d|%t|%v|%v|%v", snapshot.Authoritative, snapshot.Phase, snapshot.BarrierFrozen, snapshot.MissingRoles, snapshot.MissingAtBarrierRoles, snapshot.LateRoles)
 }
 
 type barrierCoordinate struct {

--- a/pkg/alarmd/kafka/comparator_barrier_test.go
+++ b/pkg/alarmd/kafka/comparator_barrier_test.go
@@ -110,6 +110,67 @@ func TestComparatorBarrierPrunesCoverageSignaturesAfterEntryCompaction(t *testin
 	}
 }
 
+func TestComparatorBarrierReleasesDecisionOnlyOrphanWithoutAuditPayload(t *testing.T) {
+	t.Parallel()
+
+	metadata := newObservedBarrierMetadata(map[string][]int32{
+		"trigger-input": {0}, "go-decision": {0, 1}, "py-decision": {0},
+	})
+	metadata.fakeComparatorMetadata.offsets[metadataOffset{"trigger-input", 0, sarama.OffsetNewest}] = 10
+	metadata.fakeComparatorMetadata.offsets[metadataOffset{"py-decision", 0, sarama.OffsetNewest}] = 30
+	coordinator, run, epoch := setupComparatorBarrierCoordinator(t, metadata, time.Nanosecond)
+	auditCalls := 0
+	coordinator.audits = comparisonAuditSinkFunc(func(context.Context, *contract.ComparisonAuditBatch) error {
+		auditCalls++
+		return nil
+	})
+	var released ComparatorCoverageRelease
+	coordinator.diagnostics = ComparatorDiagnostics{OnCoverageRelease: func(event ComparatorCoverageRelease) {
+		released = event
+	}}
+	adapter, err := newComparatorBarrierAdapter(coordinator)
+	if err != nil {
+		t.Fatalf("newComparatorBarrierAdapter() error = %v", err)
+	}
+
+	firstPayload, _ := comparatorTriggerInputFixture(t, "normal")
+	firstInput, err := comparatorTriggerInputFromPayload(firstPayload)
+	if err != nil {
+		t.Fatalf("DecodeTriggerInput(first) error = %v", err)
+	}
+	firstDecision, firstDecisionKey := comparatorTriggerDecisionFixture(t, firstInput)
+	if _, err := coordinator.Process(context.Background(), consumer.Record{
+		Topic: "go-decision", Partition: 0, Offset: 20, Key: firstDecisionKey, Value: firstDecision,
+	}); err != nil {
+		t.Fatalf("Process(first decision) error = %v", err)
+	}
+	if frozen, err := adapter.CaptureOverdue(context.Background()); err != nil || frozen != 1 {
+		t.Fatalf("CaptureOverdue() frozen=%d error=%v", frozen, err)
+	}
+	if auditCalls != 0 {
+		t.Fatalf("audit calls = %d, want no fabricated source audit", auditCalls)
+	}
+	if released.Entries != 1 || released.Authoritative != 0 || released.Orphans != 1 || released.MissingInput != 1 || released.MissingPython != 1 {
+		t.Fatalf("coverage release = %#v", released)
+	}
+
+	secondPayload, _ := comparatorTriggerInputFixture(t, "anomalous")
+	secondInput, err := comparatorTriggerInputFromPayload(secondPayload)
+	if err != nil {
+		t.Fatalf("DecodeTriggerInput(second) error = %v", err)
+	}
+	secondDecision, secondKey := comparatorTriggerDecisionFixture(t, secondInput)
+	updates, err := coordinator.Process(context.Background(), consumer.Record{
+		Topic: "go-decision", Partition: 0, Offset: 21, Key: secondKey, Value: secondDecision,
+	})
+	if err != nil || len(updates) != 1 || updates[0].Disposition != comparator.DispositionAccepted {
+		t.Fatalf("Process(second decision) updates=%#v error=%v", updates, err)
+	}
+	if _, ok, err := run.Coverage(epoch, firstInput.DetectionOutcomes[0].InputID); err != nil || ok {
+		t.Fatalf("Coverage(evicted orphan) ok=%v error=%v", ok, err)
+	}
+}
+
 func TestComparatorBarrierSharesOneHWMVectorAcrossOverdueInputs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/alarmd/kafka/comparator_diagnostics.go
+++ b/pkg/alarmd/kafka/comparator_diagnostics.go
@@ -1,0 +1,48 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2017-2025 Tencent. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package kafka
+
+import "github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/comparator"
+
+// ComparatorDiagnostics reports bounded Shadow coverage loss after the
+// corresponding broker acknowledgement. Callbacks must not retain payloads.
+type ComparatorDiagnostics struct {
+	OnCapacityDrop    func(ComparatorCapacityDrop)
+	OnCoverageRelease func(ComparatorCoverageRelease)
+}
+
+type ComparatorCapacityDrop struct {
+	Role       comparator.StreamRole
+	Partition  int32
+	Offset     int64
+	Dropped    int
+	MaxEntries int
+}
+
+type ComparatorCoverageRelease struct {
+	Entries       int
+	Authoritative int
+	Orphans       int
+	MissingInput  int
+	MissingGo     int
+	MissingPython int
+}
+
+func (d ComparatorDiagnostics) capacityDrop(event ComparatorCapacityDrop) {
+	if d.OnCapacityDrop != nil {
+		d.OnCapacityDrop(event)
+	}
+}
+
+func (d ComparatorDiagnostics) coverageRelease(event ComparatorCoverageRelease) {
+	if d.OnCoverageRelease != nil {
+		d.OnCoverageRelease(event)
+	}
+}

--- a/pkg/alarmd/kafka/comparator_record_coordinator.go
+++ b/pkg/alarmd/kafka/comparator_record_coordinator.go
@@ -31,14 +31,15 @@ type ComparisonAuditSink interface {
 type comparatorRecordCoordinator struct {
 	mu sync.Mutex
 
-	assignment *comparatorAssignmentCoordinator
-	handle     *comparatorAssignmentHandle
-	session    sarama.ConsumerGroupSession
-	offsets    OffsetCommitter
-	audits     ComparisonAuditSink
-	run        *comparator.Run
-	epoch      string
-	failed     error
+	assignment  *comparatorAssignmentCoordinator
+	handle      *comparatorAssignmentHandle
+	session     sarama.ConsumerGroupSession
+	offsets     OffsetCommitter
+	audits      ComparisonAuditSink
+	run         *comparator.Run
+	epoch       string
+	diagnostics ComparatorDiagnostics
+	failed      error
 }
 
 func newComparatorRecordCoordinator(
@@ -72,13 +73,14 @@ func newComparatorRecordCoordinator(
 	generation.recordOwner = true
 	assignment.mu.Unlock()
 	return &comparatorRecordCoordinator{
-		assignment: assignment,
-		handle:     handle,
-		session:    session,
-		offsets:    offsets,
-		audits:     audits,
-		run:        run,
-		epoch:      epoch,
+		assignment:  assignment,
+		handle:      handle,
+		session:     session,
+		offsets:     offsets,
+		audits:      audits,
+		run:         run,
+		epoch:       epoch,
+		diagnostics: assignment.diagnostics,
 	}, nil
 }
 
@@ -144,6 +146,18 @@ func (c *comparatorRecordCoordinator) Process(ctx context.Context, record consum
 		return nil, c.fail(err)
 	}
 	c.session.MarkOffset(record.Topic, record.Partition, record.Offset+1, "")
+	dropped := 0
+	for _, update := range updates {
+		if update.Disposition == comparator.DispositionCapacityDropped {
+			dropped++
+		}
+	}
+	if dropped > 0 {
+		c.diagnostics.capacityDrop(ComparatorCapacityDrop{
+			Role: role, Partition: record.Partition, Offset: record.Offset,
+			Dropped: dropped, MaxEntries: c.assignment.maxEntries,
+		})
+	}
 	return updates, nil
 }
 

--- a/pkg/alarmd/kafka/comparator_record_coordinator_test.go
+++ b/pkg/alarmd/kafka/comparator_record_coordinator_test.go
@@ -161,7 +161,7 @@ func TestComparatorRecordCoordinatorPrepareFailureDoesNotCommit(t *testing.T) {
 	}
 }
 
-func TestComparatorRecordCoordinatorCapacityFailureDoesNotRotateRun(t *testing.T) {
+func TestComparatorRecordCoordinatorCommitsExplicitCapacityDrop(t *testing.T) {
 	t.Parallel()
 
 	commitCalls := 0
@@ -171,6 +171,11 @@ func TestComparatorRecordCoordinatorCapacityFailureDoesNotRotateRun(t *testing.T
 		return nil
 	})
 	coordinator, run, _, _ := setupComparatorRecordCoordinator(t, 1, committer, &events)
+	var capacityDrop ComparatorCapacityDrop
+	coordinator.diagnostics = ComparatorDiagnostics{OnCapacityDrop: func(event ComparatorCapacityDrop) {
+		capacityDrop = event
+		events = append(events, "capacity-drop")
+	}}
 	firstPayload, firstKey := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
 		Topic: "trigger-input", Partition: 0, Offset: 10, Key: firstKey, Value: firstPayload,
@@ -178,16 +183,23 @@ func TestComparatorRecordCoordinatorCapacityFailureDoesNotRotateRun(t *testing.T
 		t.Fatalf("Process(first) error = %v", err)
 	}
 	secondPayload, secondKey := comparatorTriggerInputFixture(t, "anomalous")
-	if _, err := coordinator.Process(context.Background(), consumer.Record{
+	updates, err := coordinator.Process(context.Background(), consumer.Record{
 		Topic: "trigger-input", Partition: 0, Offset: 11, Key: secondKey, Value: secondPayload,
-	}); err == nil {
-		t.Fatal("Process(second) accepted a new input beyond the Run capacity")
+	})
+	if err != nil {
+		t.Fatalf("Process(second) error = %v", err)
 	}
-	if run.Valid() {
-		t.Fatal("capacity failure silently rotated or retained a valid Run")
+	if len(updates) != 1 || updates[0].Disposition != comparator.DispositionCapacityDropped {
+		t.Fatalf("updates = %#v, want one explicit capacity drop", updates)
 	}
-	if commitCalls != 1 || len(events) != 1 || events[0] != "mark" {
-		t.Fatalf("commitCalls=%d events=%#v, want only the first record committed", commitCalls, events)
+	if !run.Valid() {
+		t.Fatal("capacity drop invalidated the Run")
+	}
+	if commitCalls != 2 || len(events) != 3 || events[0] != "mark" || events[1] != "mark" || events[2] != "capacity-drop" {
+		t.Fatalf("commitCalls=%d events=%#v, want both records committed", commitCalls, events)
+	}
+	if capacityDrop.Role != comparator.StreamInput || capacityDrop.Partition != 0 || capacityDrop.Offset != 11 || capacityDrop.Dropped != 1 || capacityDrop.MaxEntries != 1 {
+		t.Fatalf("capacity drop = %#v", capacityDrop)
 	}
 }
 

--- a/pkg/alarmd/kafka/comparator_service.go
+++ b/pkg/alarmd/kafka/comparator_service.go
@@ -19,8 +19,8 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/comparator"
 )
 
-// ComparatorServiceConfig contains the immutable coordinates for one
-// single-member, three-stream comparison run.
+// ComparatorServiceConfig contains the coordinates, bounds and diagnostics for
+// one single-member, three-stream comparison run.
 type ComparatorServiceConfig struct {
 	Brokers             []string
 	TriggerInputTopic   string
@@ -32,6 +32,7 @@ type ComparatorServiceConfig struct {
 	MaxEntries          int
 	CoverageTimeout     time.Duration
 	BarrierInterval     time.Duration
+	Diagnostics         ComparatorDiagnostics
 }
 
 func (c ComparatorServiceConfig) Topics() []string {
@@ -121,6 +122,7 @@ func OpenComparatorService(
 	if err != nil {
 		return nil, errors.Join(err, group.Close(), client.Close())
 	}
+	assignment.diagnostics = config.Diagnostics
 	service, err := newOwnedGroupService(
 		config.Topics(), group, client,
 		func(reportFatal func(error)) (serviceHandler, error) {

--- a/pkg/alarmd/observability/log.go
+++ b/pkg/alarmd/observability/log.go
@@ -20,12 +20,14 @@ const (
 	ComponentTrigger    = "trigger"
 	ComponentComparator = "comparator"
 
-	StageStartup       = "startup"
-	StageDetect        = "detect"
-	StageFatal         = "fatal"
-	StageShutdown      = "shutdown"
-	StageDecisionACK   = "go_decision_ack"
-	StageComparisonACK = "comparison_audit_ack"
+	StageStartup         = "startup"
+	StageDetect          = "detect"
+	StageFatal           = "fatal"
+	StageShutdown        = "shutdown"
+	StageDecisionACK     = "go_decision_ack"
+	StageComparisonACK   = "comparison_audit_ack"
+	StageCapacityDrop    = "capacity_drop"
+	StageCoverageRelease = "coverage_release"
 
 	ResultStarted   = "started"
 	ResultBrokerACK = "broker_ack"
@@ -33,6 +35,8 @@ const (
 	ResultFailed    = "failed"
 	ResultSkipped   = "skipped"
 	ResultTimeout   = "timeout"
+	ResultDropped   = "dropped"
+	ResultReleased  = "released"
 )
 
 // Logger emits the fixed event envelope used by alarmd. Metric labels remain


### PR DESCRIPTION
## 变更

- Comparator 容量满时继续补齐已有 input_id，仅对超出容量的新 input_id 返回显式 capacity drop；对应输入 offset 确认后输出聚合诊断日志，不生成伪比较结果。
- HWM barrier 已证明缺流的权威条目在审计 ACK 后转为可回收；decision-only orphan 不伪造审计，只在缺失流的高水位证据成立后回收。
- wire 解码、分区校验、审计发布与 offset 提交失败继续保持 assignment fail-closed。

## 验证

- go test -count=1 ./...
- go test -race -count=1 ./comparator ./kafka ./observability ./cmd/alarmd-comparator
- go vet ./...
- go mod verify
- git diff --check

## 运行边界

出现 capacity_drop 表示本轮存在可观测 coverage loss，不能作为有效的全量一致性结论。发布后仍需从协调一致的三流干净 offset 起点重新验证。