### PR TITLE
feat(alarmd): 收敛全量 Shadow 最终结果验证 --story=137469130

### DIFF
--- a/pkg/alarmd/cmd/alarmd-comparator/runtime.go
+++ b/pkg/alarmd/cmd/alarmd-comparator/runtime.go
@@ -209,7 +209,11 @@ func runComparatorApplicationWithLogger(
 		eventLogger = observability.Discard(observability.ComponentComparator)
 	}
 	applicationStarted := time.Now()
-	eventLogger.Info(observability.StageStartup, observability.ResultStarted, 0, 0)
+	eventLogger.Info(
+		observability.StageStartup, observability.ResultStarted, 0, 0,
+		slog.Int("max_entries", configuration.Kafka.MaxEntries),
+		slog.Int("consumer_buffer_bytes_per_partition", enginekafka.MaxConsumerBytesPerPartition()),
+	)
 	startupFailed := func(reason string) {
 		eventLogger.Error(
 			observability.StageStartup, observability.ResultFailed, 0, time.Since(applicationStarted),
@@ -362,7 +366,21 @@ func withComparatorDiagnostics(
 				slog.Int("missing_python", event.MissingPython),
 			)
 		},
+		OnEpochRollover: func(event enginekafka.ComparatorEpochRollover) {
+			logger.Info(
+				observability.StageCoverageReset, observability.ResultInvalidated, event.Entries, 0,
+				slog.Int("authoritative", event.Authoritative),
+			)
+		},
 	}
+	configuration.ConsumerDiagnostics = enginekafka.ConsumerDiagnostics{OnOffsetReset: func(event enginekafka.OffsetReset) {
+		logger.Info(
+			observability.StageOffsetReset, observability.ResultRecovered, 0, 0,
+			slog.String("topic", event.Topic),
+			slog.Int("partition", int(event.Partition)),
+			slog.Int64("offset", event.Offset),
+		)
+	}}
 	return configuration
 }
 

--- a/pkg/alarmd/cmd/alarmd-comparator/runtime_test.go
+++ b/pkg/alarmd/cmd/alarmd-comparator/runtime_test.go
@@ -38,9 +38,11 @@ func TestComparatorDiagnosticsLogCommittedCoverageLossWithoutInputIDs(t *testing
 	configuration.Diagnostics.OnCoverageRelease(enginekafka.ComparatorCoverageRelease{
 		Entries: 4, Authoritative: 3, Orphans: 1, MissingInput: 1, MissingGo: 2, MissingPython: 2,
 	})
+	configuration.Diagnostics.OnEpochRollover(enginekafka.ComparatorEpochRollover{Entries: 5, Authoritative: 4})
+	configuration.ConsumerDiagnostics.OnOffsetReset(enginekafka.OffsetReset{Topic: "detect-input", Partition: 3})
 
 	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
-	if len(lines) != 2 {
+	if len(lines) != 4 {
 		t.Fatalf("diagnostic lines = %d, output=%s", len(lines), output.String())
 	}
 	for index, line := range lines {
@@ -57,6 +59,12 @@ func TestComparatorDiagnosticsLogCommittedCoverageLossWithoutInputIDs(t *testing
 	}
 	if !strings.Contains(lines[1], `"stage":"coverage_release"`) || !strings.Contains(lines[1], `"records":4`) || !strings.Contains(lines[1], `"orphans":1`) {
 		t.Fatalf("coverage log = %s", lines[1])
+	}
+	if !strings.Contains(lines[2], `"stage":"coverage_reset"`) || !strings.Contains(lines[2], `"result":"invalidated"`) || !strings.Contains(lines[2], `"authoritative":4`) {
+		t.Fatalf("coverage reset log = %s", lines[2])
+	}
+	if !strings.Contains(lines[3], `"stage":"offset_reset"`) || !strings.Contains(lines[3], `"result":"recovered"`) || !strings.Contains(lines[3], `"partition":3`) {
+		t.Fatalf("offset reset log = %s", lines[3])
 	}
 }
 

--- a/pkg/alarmd/cmd/alarmd/main.go
+++ b/pkg/alarmd/cmd/alarmd/main.go
@@ -14,6 +14,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -97,10 +98,23 @@ func defaultApplicationDependencies(eventLogger *observability.Logger) applicati
 			newProcessor consumer.ProcessorFactory,
 			drainTimeout time.Duration,
 		) (serviceRuntime, error) {
-			return enginekafka.OpenService(cfg.ConsumerCoordinates(), newProcessor, drainTimeout)
+			coordinates := cfg.ConsumerCoordinates()
+			coordinates.Diagnostics = offsetResetDiagnostics(eventLogger)
+			return enginekafka.OpenService(coordinates, newProcessor, drainTimeout)
 		},
 		newHTTP: func(recorder *metric.Recorder, source lifecycle.Source) (httpRuntime, error) {
 			return httpservice.NewWithLifecycle(recorder, source)
 		},
 	}
+}
+
+func offsetResetDiagnostics(logger *observability.Logger) enginekafka.ConsumerDiagnostics {
+	return enginekafka.ConsumerDiagnostics{OnOffsetReset: func(event enginekafka.OffsetReset) {
+		logger.Info(
+			observability.StageOffsetReset, observability.ResultRecovered, 0, 0,
+			slog.String("topic", event.Topic),
+			slog.Int("partition", int(event.Partition)),
+			slog.Int64("offset", event.Offset),
+		)
+	}}
 }

--- a/pkg/alarmd/cmd/alarmd/runtime.go
+++ b/pkg/alarmd/cmd/alarmd/runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/consumer"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/contract"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/detect"
+	enginekafka "github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/kafka"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/lifecycle"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/metric"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/observability"
@@ -215,7 +216,10 @@ func runApplication(ctx context.Context, cfg config.Config, recorder *metric.Rec
 		eventLogger = observability.Discard(observability.ComponentTrigger)
 	}
 	applicationStarted := time.Now()
-	eventLogger.Info(observability.StageStartup, observability.ResultStarted, 0, 0)
+	eventLogger.Info(
+		observability.StageStartup, observability.ResultStarted, 0, 0,
+		slog.Int("consumer_buffer_bytes_per_partition", enginekafka.MaxConsumerBytesPerPartition()),
+	)
 	startupFailed := func(reason string) {
 		eventLogger.Error(
 			observability.StageStartup, observability.ResultFailed, 0, time.Since(applicationStarted),

--- a/pkg/alarmd/comparator/audit.go
+++ b/pkg/alarmd/comparator/audit.go
@@ -56,11 +56,14 @@ func (r *Run) PreviewAudits(prepared Prepared, gates Gates) ([]*contract.Compari
 		if !ok {
 			continue
 		}
+		if !terminalAudit(observation.assessment, coverage) {
+			continue
+		}
 		audit, err := buildComparisonAudit(observation, coverage)
 		if err != nil {
 			return nil, r.invalidateLocked(fmt.Errorf("comparator: preview audit: %w", err))
 		}
-		candidates = append(candidates, comparisonAuditCandidate{input: observation.input, audit: audit})
+		candidates = append(candidates, comparisonAuditCandidate{source: observation.source, audit: audit})
 	}
 	batches, err := buildComparisonAuditBatches(candidates)
 	if err != nil {
@@ -108,7 +111,10 @@ func (r *Run) AuditBatches(epoch string, inputIDs []string, gates Gates) ([]*con
 		if err != nil {
 			return nil, r.invalidateLocked(fmt.Errorf("comparator: audit snapshot: %w", err))
 		}
-		candidates = append(candidates, comparisonAuditCandidate{input: observation.input, audit: audit})
+		if !terminalAudit(observation.assessment, coverage) {
+			continue
+		}
+		candidates = append(candidates, comparisonAuditCandidate{source: observation.source, audit: audit})
 	}
 	batches, err := buildComparisonAuditBatches(candidates)
 	if err != nil {
@@ -118,8 +124,8 @@ func (r *Run) AuditBatches(epoch string, inputIDs []string, gates Gates) ([]*con
 }
 
 type comparisonAuditCandidate struct {
-	input *contract.TriggerInput
-	audit contract.ComparisonAudit
+	source *sourceObservation
+	audit  contract.ComparisonAudit
 }
 
 type comparisonAuditIdentity struct {
@@ -133,7 +139,7 @@ type comparisonAuditIdentity struct {
 }
 
 type comparisonAuditGroup struct {
-	input  *contract.TriggerInput
+	source *sourceObservation
 	audits []contract.ComparisonAudit
 }
 
@@ -141,19 +147,19 @@ func buildComparisonAuditBatches(candidates []comparisonAuditCandidate) ([]*cont
 	groups := make(map[comparisonAuditIdentity]*comparisonAuditGroup)
 	order := make([]comparisonAuditIdentity, 0)
 	for _, candidate := range candidates {
-		if candidate.input == nil {
-			return nil, fmt.Errorf("authoritative TriggerInput is required")
+		if candidate.source == nil || candidate.source.strategy == nil {
+			return nil, fmt.Errorf("authoritative DetectInput is required")
 		}
-		strategy := candidate.input.StrategyIR
+		strategy := candidate.source.strategy
 		identity := comparisonAuditIdentity{
-			partitionHashVersion: candidate.input.PartitionHashVersion,
+			partitionHashVersion: candidate.source.partitionHashVersion,
 			tenantID:             strategy.TenantID, purpose: strategy.Purpose,
 			strategyID: strategy.StrategyRef.StrategyID, itemID: strategy.StrategyRef.ItemID,
 			generation: strategy.StrategyRef.Generation, contentSHA256: strategy.StrategyRef.ContentSHA256,
 		}
 		group := groups[identity]
 		if group == nil {
-			group = &comparisonAuditGroup{input: candidate.input}
+			group = &comparisonAuditGroup{source: candidate.source}
 			groups[identity] = group
 			order = append(order, identity)
 		}
@@ -168,7 +174,7 @@ func buildComparisonAuditBatches(candidates []comparisonAuditCandidate) ([]*cont
 				end = len(group.audits)
 			}
 			var err error
-			batches, err = appendComparisonAuditChunks(batches, group.input, group.audits[start:end])
+			batches, err = appendComparisonAuditChunks(batches, group.source, group.audits[start:end])
 			if err != nil {
 				return nil, err
 			}
@@ -179,10 +185,10 @@ func buildComparisonAuditBatches(candidates []comparisonAuditCandidate) ([]*cont
 
 func appendComparisonAuditChunks(
 	batches []*contract.ComparisonAuditBatch,
-	input *contract.TriggerInput,
+	source *sourceObservation,
 	audits []contract.ComparisonAudit,
 ) ([]*contract.ComparisonAuditBatch, error) {
-	batch, err := buildComparisonAuditBatch(input, audits)
+	batch, err := buildComparisonAuditBatch(source, audits)
 	if err == nil {
 		_, err = contract.EncodeComparisonAuditBatch(batch)
 	}
@@ -193,17 +199,17 @@ func appendComparisonAuditChunks(
 		return nil, err
 	}
 	middle := len(audits) / 2
-	batches, leftErr := appendComparisonAuditChunks(batches, input, audits[:middle])
+	batches, leftErr := appendComparisonAuditChunks(batches, source, audits[:middle])
 	if leftErr != nil {
 		return nil, leftErr
 	}
-	return appendComparisonAuditChunks(batches, input, audits[middle:])
+	return appendComparisonAuditChunks(batches, source, audits[middle:])
 }
 
-func buildComparisonAuditBatch(input *contract.TriggerInput, audits []contract.ComparisonAudit) (*contract.ComparisonAuditBatch, error) {
-	strategy := input.StrategyIR
+func buildComparisonAuditBatch(source *sourceObservation, audits []contract.ComparisonAudit) (*contract.ComparisonAuditBatch, error) {
+	strategy := source.strategy
 	return contract.BuildComparisonAuditBatch(
-		input.PartitionHashVersion,
+		source.partitionHashVersion,
 		strategy.TenantID,
 		strategy.Purpose,
 		strategy.StrategyRef,
@@ -212,32 +218,35 @@ func buildComparisonAuditBatch(input *contract.TriggerInput, audits []contract.C
 }
 
 func buildComparisonAudit(observation auditObservation, coverage CoverageSnapshot) (contract.ComparisonAudit, error) {
-	errorCode := ""
-	if len(observation.outcome.ErrorCode) != 0 {
-		if err := json.Unmarshal(observation.outcome.ErrorCode, &errorCode); err != nil {
-			return contract.ComparisonAudit{}, err
+	sourceEvidence := contract.ComparisonSourceEvidence{
+		Kind: contract.ComparisonSourceDetectInput, SemanticSHA256: hex.EncodeToString(observation.sourceFingerprint[:]),
+	}
+	if observation.source.outcome != nil {
+		sourceEvidence.Kind = ""
+		sourceEvidence.Outcome = observation.source.outcome.Outcome
+		if len(observation.source.outcome.ErrorCode) != 0 {
+			if err := json.Unmarshal(observation.source.outcome.ErrorCode, &sourceEvidence.ErrorCode); err != nil {
+				return contract.ComparisonAudit{}, err
+			}
 		}
 	}
-	goDecision, err := comparisonDecisionEvidence(observation.goDecision, observation.input, observation.assessment.GoInvalid)
+	goDecision, err := comparisonDecisionEvidence(observation.goDecision, observation.source, observation.assessment.GoInvalid)
 	if err != nil {
 		return contract.ComparisonAudit{}, err
 	}
-	pythonDecision, err := comparisonDecisionEvidence(observation.pythonDecision, observation.input, observation.assessment.PythonInvalid)
+	pythonDecision, err := comparisonDecisionEvidence(observation.pythonDecision, observation.source, observation.assessment.PythonInvalid)
 	if err != nil {
 		return contract.ComparisonAudit{}, err
 	}
 	return contract.ComparisonAudit{
-		EventKind:   contract.ComparisonAuditEventSnapshot,
-		InputID:     observation.outcome.InputID,
-		RecordID:    observation.outcome.Record.RecordID,
-		SourceTime:  observation.outcome.Record.SourceTime,
-		JoinStatus:  comparisonJoin(observation.assessment.Join),
-		Eligibility: comparisonEligibility(observation.assessment.Eligibility),
-		Verdict:     comparisonVerdict(observation.assessment.Verdict),
-		Source: contract.ComparisonSourceEvidence{
-			Outcome: observation.outcome.Outcome, ErrorCode: errorCode,
-			SemanticSHA256: hex.EncodeToString(observation.sourceFingerprint[:]),
-		},
+		EventKind:      contract.ComparisonAuditEventSnapshot,
+		InputID:        observation.source.inputID,
+		RecordID:       observation.source.recordID,
+		SourceTime:     observation.source.sourceTime,
+		JoinStatus:     comparisonJoin(observation.assessment.Join),
+		Eligibility:    comparisonEligibility(observation.assessment.Eligibility),
+		Verdict:        comparisonVerdict(observation.assessment.Verdict),
+		Source:         sourceEvidence,
 		GoDecision:     goDecision,
 		PythonDecision: pythonDecision,
 		Coverage:       comparisonCoverage(coverage),
@@ -251,7 +260,7 @@ func buildComparisonAudit(observation auditObservation, coverage CoverageSnapsho
 
 func comparisonDecisionEvidence(
 	observation *decisionObservation,
-	input *contract.TriggerInput,
+	source *sourceObservation,
 	invalidSide bool,
 ) (*contract.ComparisonDecisionEvidence, error) {
 	if observation == nil {
@@ -275,7 +284,7 @@ func comparisonDecisionEvidence(
 	invalidReason := ""
 	mismatchFields := []string{}
 	if invalidSide {
-		invalidReason, mismatchFields, err = comparisonDecisionInvalidEvidence(input, observation)
+		invalidReason, mismatchFields, err = comparisonDecisionInvalidEvidence(source, observation)
 		if err != nil {
 			return nil, err
 		}
@@ -290,24 +299,24 @@ func comparisonDecisionEvidence(
 }
 
 func comparisonDecisionInvalidEvidence(
-	input *contract.TriggerInput,
+	source *sourceObservation,
 	observation *decisionObservation,
 ) (string, []string, error) {
-	if input == nil || input.StrategyIR == nil || observation == nil {
+	if source == nil || source.strategy == nil || observation == nil {
 		return "", nil, fmt.Errorf("comparator: invalid decision evidence requires authoritative input and decision")
 	}
 	want := decisionBatchIdentity{
-		PartitionHashVersion: input.PartitionHashVersion,
-		TenantID:             input.StrategyIR.TenantID,
-		Purpose:              input.StrategyIR.Purpose,
-		StrategyRef:          input.StrategyIR.StrategyRef,
+		PartitionHashVersion: source.partitionHashVersion,
+		TenantID:             source.strategy.TenantID,
+		Purpose:              source.strategy.Purpose,
+		StrategyRef:          source.strategy.StrategyRef,
 		DecisionAlgorithm:    contract.DecisionAlgorithmV1,
 	}
 	mismatchFields := comparisonDecisionIdentityMismatchFields(want, observation.batch)
 	if len(mismatchFields) != 0 {
 		return contract.ComparisonDecisionInvalidBatchIdentity, mismatchFields, nil
 	}
-	err := input.ValidateTriggerDecision(observation.decision)
+	err := validateDecisionAgainstInput(source, observation)
 	if err == nil {
 		return "", nil, fmt.Errorf("comparator: decision marked invalid without contradictory evidence")
 	}
@@ -327,6 +336,10 @@ func comparisonDecisionInvalidEvidence(
 	default:
 		return contract.ComparisonDecisionInvalidOther, []string{}, nil
 	}
+}
+
+func terminalAudit(_ Assessment, coverage CoverageSnapshot) bool {
+	return coverage.Phase == CoverageComplete || coverage.Phase == CoverageMissingAtBarrier
 }
 
 func comparisonDecisionIdentityMismatchFields(want, got decisionBatchIdentity) []string {

--- a/pkg/alarmd/comparator/audit_test.go
+++ b/pkg/alarmd/comparator/audit_test.go
@@ -21,11 +21,11 @@ func TestRunPreviewsCompleteAuditBeforeOffsetCommit(t *testing.T) {
 	t.Parallel()
 
 	run, _ := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
 	decisionPayload := testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)
 	commitStreamRecord(t, run, StreamRecord{
-		Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload,
+		Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input),
 	})
 	commitStreamRecord(t, run, StreamRecord{
 		Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10, Key: key, Value: decisionPayload,
@@ -41,7 +41,10 @@ func TestRunPreviewsCompleteAuditBeforeOffsetCommit(t *testing.T) {
 		t.Fatalf("Assess() error = %v, want record in flight", err)
 	}
 
-	batches, err := run.PreviewAudits(prepared, Gates{StableEpoch: true})
+	batches, err := run.PreviewAudits(prepared, Gates{
+		StableEpoch:          true,
+		EpochStartSourceTime: int64Pointer(input.DetectionOutcomes[0].Record.SourceTime - 300),
+	})
 	if err != nil || len(batches) != 1 {
 		t.Fatalf("PreviewAudits() batches=%d error=%v", len(batches), err)
 	}
@@ -66,6 +69,80 @@ func TestRunPreviewsCompleteAuditBeforeOffsetCommit(t *testing.T) {
 	}
 }
 
+func TestRunDoesNotPublishIntermediateAuditSnapshots(t *testing.T) {
+	t.Parallel()
+
+	run, _ := mustCoverageRun(t, testAssignments())
+	_, triggerInput := testTriggerInput(t, "normal")
+	detectPayload, detectInput := testDetectInputFromTrigger(t, triggerInput)
+	key, err := detectInput.PartitionKey()
+	if err != nil {
+		t.Fatalf("PartitionKey() error = %v", err)
+	}
+	prepared, err := run.Prepare(StreamRecord{
+		Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: detectPayload,
+	})
+	if err != nil {
+		t.Fatalf("Prepare(input) error = %v", err)
+	}
+	batches, err := run.PreviewAudits(prepared, Gates{StableEpoch: true})
+	if err != nil {
+		t.Fatalf("PreviewAudits() error = %v", err)
+	}
+	if len(batches) != 0 {
+		t.Fatalf("PreviewAudits() batches=%d, want no intermediate audit", len(batches))
+	}
+}
+
+func TestTerminalAuditWaitsForCoverageEvenWhenJoinIsSticky(t *testing.T) {
+	t.Parallel()
+
+	for _, join := range []JoinStatus{JoinInvalid, JoinConflict} {
+		if terminalAudit(Assessment{Join: join}, CoverageSnapshot{Phase: CoveragePending}) {
+			t.Fatalf("terminalAudit(%v, pending) = true, want false", join)
+		}
+		if !terminalAudit(Assessment{Join: join}, CoverageSnapshot{Phase: CoverageComplete}) {
+			t.Fatalf("terminalAudit(%v, complete) = false, want true", join)
+		}
+		if !terminalAudit(Assessment{Join: join}, CoverageSnapshot{Phase: CoverageMissingAtBarrier}) {
+			t.Fatalf("terminalAudit(%v, missing at barrier) = false, want true", join)
+		}
+	}
+}
+
+func TestRunPublishesWarmupAsTerminalAudit(t *testing.T) {
+	t.Parallel()
+
+	run, _ := mustCoverageRun(t, testAssignments())
+	_, input := testTriggerInput(t, "anomalous")
+	key := mustPartitionKey(t, input)
+	decisionPayload := testDecisionBatch(t, input, contract.DecisionOutcomeTrigger)
+	commitStreamRecord(t, run, StreamRecord{
+		Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input),
+	})
+	commitStreamRecord(t, run, StreamRecord{
+		Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10, Key: key, Value: decisionPayload,
+	})
+	prepared, err := run.Prepare(StreamRecord{
+		Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: decisionPayload,
+	})
+	if err != nil {
+		t.Fatalf("Prepare(python) error = %v", err)
+	}
+	batches, err := run.PreviewAudits(prepared, Gates{
+		StableEpoch:          true,
+		EpochStartSourceTime: int64Pointer(input.DetectionOutcomes[0].Record.SourceTime),
+	})
+	if err != nil || len(batches) != 1 || len(batches[0].Audits) != 1 {
+		t.Fatalf("PreviewAudits() batches=%d error=%v, want one terminal warmup audit", len(batches), err)
+	}
+	audit := batches[0].Audits[0]
+	if audit.JoinStatus != contract.ComparisonJoinComplete ||
+		audit.Eligibility != contract.ComparisonEligibilityWarmup || audit.Verdict != contract.ComparisonVerdictNone {
+		t.Fatalf("PreviewAudits() audit=%#v, want complete warmup without verdict", audit)
+	}
+}
+
 func TestComparisonAuditBatchesRespectCountAndEncodedByteLimits(t *testing.T) {
 	t.Parallel()
 
@@ -83,7 +160,10 @@ func TestComparisonAuditBatchesRespectCountAndEncodedByteLimits(t *testing.T) {
 			t.Fatalf("DeriveInputID() error = %v", err)
 		}
 		candidates = append(candidates, comparisonAuditCandidate{
-			input: input,
+			source: &sourceObservation{
+				partitionHashVersion: input.PartitionHashVersion, strategy: input.StrategyIR,
+				inputID: inputID, recordID: recordID, sourceTime: sourceTime,
+			},
 			audit: contract.ComparisonAudit{
 				EventKind: contract.ComparisonAuditEventSnapshot,
 				InputID:   inputID, RecordID: recordID, SourceTime: sourceTime,
@@ -120,14 +200,14 @@ func TestRunCompactsTwoLargeValidDecisionsIntoOneAudit(t *testing.T) {
 	t.Parallel()
 
 	run, _ := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "anomalous")
+	_, input := testTriggerInput(t, "anomalous")
 	key := mustPartitionKey(t, input)
 	decisionPayload := largeAuditDecisionBatch(t, input, 60000)
 	if len(decisionPayload) >= contract.MaxTriggerDecisionBytesV1 {
 		t.Fatalf("decision payload bytes = %d, want a valid decision wire", len(decisionPayload))
 	}
 	commitStreamRecord(t, run, StreamRecord{
-		Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload,
+		Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input),
 	})
 	commitStreamRecord(t, run, StreamRecord{
 		Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10, Key: key, Value: decisionPayload,
@@ -139,7 +219,10 @@ func TestRunCompactsTwoLargeValidDecisionsIntoOneAudit(t *testing.T) {
 		t.Fatalf("Prepare(python) error = %v", err)
 	}
 
-	batches, err := run.PreviewAudits(prepared, Gates{StableEpoch: true})
+	batches, err := run.PreviewAudits(prepared, Gates{
+		StableEpoch:          true,
+		EpochStartSourceTime: int64Pointer(input.DetectionOutcomes[0].Record.SourceTime - 300),
+	})
 	if err != nil || len(batches) != 1 {
 		t.Fatalf("PreviewAudits() batches=%d error=%v, want one compact audit", len(batches), err)
 	}

--- a/pkg/alarmd/comparator/coverage.go
+++ b/pkg/alarmd/comparator/coverage.go
@@ -52,7 +52,7 @@ type CoverageSnapshot struct {
 type coverageEntry struct {
 	firstSeen time.Time
 	// authoritativeAt is the deadline anchor and is only set once the
-	// authoritative TriggerInput record has a broker acknowledgement.
+	// authoritative DetectInput record has a broker acknowledgement.
 	authoritativeAt      time.Time
 	pendingAuthoritative bool
 	present              map[StreamRole]bool
@@ -243,7 +243,7 @@ func (r *Run) prepareCoverageLocked(inflight *preparedRecord) error {
 }
 
 // commitCoverageLocked anchors the coverage deadline at the moment the
-// authoritative TriggerInput offset is acknowledged, not when it was prepared.
+// authoritative DetectInput offset is acknowledged, not when it was prepared.
 // Audit and offset acknowledgements can outlast the coverage timeout, and an
 // anchor taken at prepare time would report a just-acknowledged input as overdue.
 func (r *Run) commitCoverageLocked(inflight *preparedRecord) error {

--- a/pkg/alarmd/comparator/coverage_test.go
+++ b/pkg/alarmd/comparator/coverage_test.go
@@ -23,7 +23,7 @@ func TestCoverageDeadlineStartsAtAuthoritativeCommit(t *testing.T) {
 	t.Parallel()
 
 	run, clock := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	inputID := input.DetectionOutcomes[0].InputID
 	prepared, err := run.Prepare(StreamRecord{
 		Epoch:     "run-1",
@@ -57,7 +57,7 @@ func TestCoverageDeadlineStartsAtAuthoritativeCommit(t *testing.T) {
 	if err != nil || len(snapshots) != 1 || snapshots[0].InputID != inputID || snapshots[0].Phase != CoverageOverdue {
 		t.Fatalf("SweepCoverage() = %#v, error=%v", snapshots, err)
 	}
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: mustPartitionKey(t, input), Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: mustPartitionKey(t, input), Value: mustDetectInputPayload(t, input)})
 	snapshot, ok, err = run.Coverage("run-1", inputID)
 	if err != nil || !ok || !snapshot.Authoritative || snapshot.Phase != CoveragePending || !slices.Equal(snapshot.MissingRoles, []StreamRole{StreamPython}) {
 		t.Fatalf("Coverage(after authoritative input) = %#v, ok=%v, error=%v", snapshot, ok, err)
@@ -118,7 +118,7 @@ func TestCoverageDeadlineExcludesPrepareToCommitDelay(t *testing.T) {
 	t.Parallel()
 
 	run, clock := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	inputID := input.DetectionOutcomes[0].InputID
 	prepared, err := run.Prepare(StreamRecord{
 		Epoch:     "run-1",
@@ -127,7 +127,7 @@ func TestCoverageDeadlineExcludesPrepareToCommitDelay(t *testing.T) {
 		Partition: 0,
 		Offset:    20,
 		Key:       mustPartitionKey(t, input),
-		Value:     inputPayload,
+		Value:     mustDetectInputPayload(t, input),
 	})
 	if err != nil {
 		t.Fatalf("Prepare() error = %v", err)
@@ -151,10 +151,10 @@ func TestCoverageBarrierMarksMissingAndLateRecovery(t *testing.T) {
 	t.Parallel()
 
 	run, clock := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "anomalous")
+	_, input := testTriggerInput(t, "anomalous")
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 
 	barrier := capturedBarrier(clock, PartitionBarrier{Role: StreamGo, Topic: "go", Partition: 0, HighWater: 12})
@@ -232,10 +232,10 @@ func TestCoverageBarrierRejectsFutureCapture(t *testing.T) {
 	t.Parallel()
 
 	run, clock := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	clock.Advance(11 * time.Second)
 	barrier := BarrierSnapshot{
@@ -272,10 +272,10 @@ func TestCoverageRecordAfterBarrierWithOffsetGapIsLate(t *testing.T) {
 	t.Parallel()
 
 	run, clock := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	clock.Advance(11 * time.Second)
 	if err := run.FreezeBarrier("run-1", inputID, capturedBarrier(clock, PartitionBarrier{Role: StreamGo, Topic: "go", Partition: 0, HighWater: 12})); err != nil {
@@ -301,10 +301,10 @@ func TestCoverageLateRecordUsesItsOwnPartitionBarrier(t *testing.T) {
 
 	assignments := append(testAssignments(), PartitionAssignment{Role: StreamGo, Topic: "go", Partition: 1, NextOffset: 40})
 	run, clock := mustCoverageRun(t, assignments)
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	clock.Advance(11 * time.Second)
 	if err := run.FreezeBarrier("run-1", inputID, capturedBarrier(clock,
@@ -361,10 +361,10 @@ func TestCoverageBarrierRequiresEveryMissingPartition(t *testing.T) {
 
 	assignments := append(testAssignments(), PartitionAssignment{Role: StreamGo, Topic: "go", Partition: 1, NextOffset: 40})
 	run, clock := mustCoverageRun(t, assignments)
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	clock.Advance(11 * time.Second)
 	if err := run.FreezeBarrier("old-run", inputID, capturedBarrier(clock)); err == nil {
@@ -385,10 +385,10 @@ func TestCoverageBarrierRejectsHighWaterBehindCommittedProgress(t *testing.T) {
 	t.Parallel()
 
 	run, clock := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	clock.Advance(11 * time.Second)
 	if err := run.FreezeBarrier("run-1", inputID, capturedBarrier(clock, PartitionBarrier{Role: StreamGo, Topic: "go", Partition: 0, HighWater: 9})); err == nil {
@@ -403,10 +403,10 @@ func TestCoverageBarrierIsCopiedAndImmutable(t *testing.T) {
 	t.Parallel()
 
 	run, clock := mustCoverageRun(t, testAssignments())
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
-	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	clock.Advance(11 * time.Second)
 	barrier := capturedBarrier(clock, PartitionBarrier{Role: StreamGo, Topic: "go", Partition: 0, HighWater: 12})
@@ -487,12 +487,12 @@ func TestCoverageCapacityReusesCompletedEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRun() error = %v", err)
 	}
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	key := mustPartitionKey(t, input)
-	commitAuditedStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	commitAuditedStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	commitAuditedStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
 	commitAuditedStreamRecord(t, run, StreamRecord{Epoch: "run-1", Role: StreamPython, Topic: "python", Partition: 0, Offset: 30, Key: key, Value: testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)})
-	secondPayload, second := testTriggerInput(t, "anomalous")
+	_, second := testTriggerInput(t, "anomalous")
 	prepared, err := run.Prepare(StreamRecord{
 		Epoch:     "run-1",
 		Role:      StreamInput,
@@ -500,7 +500,7 @@ func TestCoverageCapacityReusesCompletedEntries(t *testing.T) {
 		Partition: 0,
 		Offset:    21,
 		Key:       mustPartitionKey(t, second),
-		Value:     secondPayload,
+		Value:     mustDetectInputPayload(t, second),
 	})
 	if err != nil {
 		t.Fatalf("Prepare() did not reuse completed capacity: %v", err)

--- a/pkg/alarmd/comparator/joiner.go
+++ b/pkg/alarmd/comparator/joiner.go
@@ -7,7 +7,7 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-// Package comparator joins authoritative TriggerInput records with Go and
+// Package comparator joins authoritative DetectInput records with Go and
 // Python terminal decisions. It deliberately contains no transport, timeout,
 // watermark, persistence or metric policy.
 package comparator
@@ -121,10 +121,15 @@ type entry struct {
 }
 
 type sourceObservation struct {
-	input       *contract.TriggerInput
-	outcome     *contract.DetectionOutcome
-	fingerprint [sha256.Size]byte
-	maxWindow   int64
+	partitionHashVersion string
+	strategy             *contract.TriggerStrategyIR
+	inputID              string
+	recordID             string
+	sourceTime           int64
+	triggerInput         *contract.TriggerInput
+	outcome              *contract.DetectionOutcome
+	fingerprint          [sha256.Size]byte
+	maxWindow            int64
 }
 
 type decisionObservation struct {
@@ -143,11 +148,52 @@ type decisionBatchIdentity struct {
 
 type auditObservation struct {
 	assessment        Assessment
-	input             *contract.TriggerInput
-	outcome           contract.DetectionOutcome
+	source            *sourceObservation
 	sourceFingerprint [sha256.Size]byte
 	goDecision        *decisionObservation
 	pythonDecision    *decisionObservation
+}
+
+func (j *Joiner) ObserveDetectInput(runEpoch string, key, payload []byte) ([]Update, error) {
+	input, err := contract.DecodeDetectInput(payload)
+	if err != nil {
+		return nil, err
+	}
+	expectedKey, err := input.PartitionKey()
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(key, expectedKey) {
+		return nil, fmt.Errorf("comparator: detect input partition key mismatch")
+	}
+	observations := make([]sourceObservation, 0, len(input.Records))
+	for _, rawRecord := range input.Records {
+		var record struct {
+			RecordID string `json:"record_id"`
+			Time     int64  `json:"time"`
+		}
+		if err := json.Unmarshal(rawRecord, &record); err != nil {
+			return nil, fmt.Errorf("comparator: decode detect input record: %w", err)
+		}
+		inputID, err := contract.DeriveInputID(contract.InputIdentity{
+			TenantID: input.StrategyIR.TenantID, Purpose: input.StrategyIR.Purpose,
+			StrategyID: input.StrategyIR.StrategyRef.StrategyID, ItemID: input.StrategyIR.StrategyRef.ItemID,
+			StrategyContentSHA256: input.StrategyIR.StrategyRef.ContentSHA256, RecordID: record.RecordID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		fingerprint, err := detectSourceFingerprint(input, rawRecord)
+		if err != nil {
+			return nil, err
+		}
+		observations = append(observations, sourceObservation{
+			partitionHashVersion: input.PartitionHashVersion, strategy: input.StrategyIR,
+			inputID: inputID, recordID: record.RecordID, sourceTime: record.Time,
+			fingerprint: fingerprint, maxWindow: maximumWindow(input.StrategyIR),
+		})
+	}
+	return j.observeSources(runEpoch, observations)
 }
 
 func NewJoiner(runEpoch string, maxEntries int) (*Joiner, error) {
@@ -164,6 +210,8 @@ func NewJoiner(runEpoch string, maxEntries int) (*Joiner, error) {
 	}, nil
 }
 
+// ObserveTriggerInput remains for frozen v1 Golden compatibility. Runtime
+// comparison uses ObserveDetectInput as its authoritative source stream.
 func (j *Joiner) ObserveTriggerInput(runEpoch string, key, payload []byte) ([]Update, error) {
 	input, err := contract.DecodeTriggerInput(payload)
 	if err != nil {
@@ -183,13 +231,21 @@ func (j *Joiner) ObserveTriggerInput(runEpoch string, key, payload []byte) ([]Up
 			return nil, err
 		}
 		observations[index] = sourceObservation{
-			input:       input,
-			outcome:     outcome,
-			fingerprint: fingerprint,
-			maxWindow:   maximumWindow(input.StrategyIR),
+			partitionHashVersion: input.PartitionHashVersion,
+			strategy:             input.StrategyIR,
+			inputID:              outcome.InputID,
+			recordID:             outcome.Record.RecordID,
+			sourceTime:           outcome.Record.SourceTime,
+			triggerInput:         input,
+			outcome:              outcome,
+			fingerprint:          fingerprint,
+			maxWindow:            maximumWindow(input.StrategyIR),
 		}
 	}
+	return j.observeSources(runEpoch, observations)
+}
 
+func (j *Joiner) observeSources(runEpoch string, observations []sourceObservation) ([]Update, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if err := j.requireEpoch(runEpoch); err != nil {
@@ -198,10 +254,10 @@ func (j *Joiner) ObserveTriggerInput(runEpoch string, key, payload []byte) ([]Up
 	updates := make([]Update, 0, len(observations))
 	for index := range observations {
 		observation := &observations[index]
-		item, admitted := j.getOrAdmit(observation.outcome.InputID)
+		item, admitted := j.getOrAdmit(observation.inputID)
 		if !admitted {
 			updates = append(updates, Update{
-				InputID: observation.outcome.InputID, Disposition: DispositionCapacityDropped,
+				InputID: observation.inputID, Disposition: DispositionCapacityDropped,
 			})
 			continue
 		}
@@ -216,7 +272,7 @@ func (j *Joiner) ObserveTriggerInput(runEpoch string, key, payload []byte) ([]Up
 			item.sourceConflict = true
 			disposition = DispositionConflict
 		}
-		updates = append(updates, Update{InputID: observation.outcome.InputID, Disposition: disposition})
+		updates = append(updates, Update{InputID: observation.inputID, Disposition: disposition})
 	}
 	return updates, nil
 }
@@ -311,8 +367,7 @@ func (j *Joiner) auditObservation(runEpoch, inputID string, gates Gates) (auditO
 	}
 	return auditObservation{
 		assessment:        assessment,
-		input:             item.source.input,
-		outcome:           *item.source.outcome,
+		source:            cloneSourceObservation(item.source),
 		sourceFingerprint: item.source.fingerprint,
 		goDecision:        cloneDecisionObservation(item.goDecision),
 		pythonDecision:    cloneDecisionObservation(item.pythonDecision),
@@ -332,7 +387,7 @@ func (j *Joiner) firstSourceTime(runEpoch string, inputIDs []string) (int64, boo
 		if item == nil || item.source == nil {
 			continue
 		}
-		sourceTime := item.source.outcome.Record.SourceTime
+		sourceTime := item.source.sourceTime
 		if !found || sourceTime < first {
 			first, found = sourceTime, true
 		}
@@ -376,7 +431,7 @@ func assessEntry(inputID string, item *entry, gates Gates) (Assessment, error) {
 	if assessment.Join != JoinComplete {
 		return assessment, nil
 	}
-	eligibilityValue, err := eligibility(item.source, gates)
+	eligibilityValue, err := eligibility(item.source, item.goDecision, item.pythonDecision, gates)
 	if err != nil {
 		return Assessment{}, err
 	}
@@ -489,9 +544,9 @@ func (j *Joiner) validateStoredDecisions(item *entry) {
 }
 
 func validateDecisionAgainstInput(source *sourceObservation, observation *decisionObservation) error {
-	strategy := source.input.StrategyIR
+	strategy := source.strategy
 	want := decisionBatchIdentity{
-		PartitionHashVersion: source.input.PartitionHashVersion,
+		PartitionHashVersion: source.partitionHashVersion,
 		TenantID:             strategy.TenantID,
 		Purpose:              strategy.Purpose,
 		StrategyRef:          strategy.StrategyRef,
@@ -500,15 +555,27 @@ func validateDecisionAgainstInput(source *sourceObservation, observation *decisi
 	if observation.batch != want {
 		return fmt.Errorf("comparator: decision envelope contradicts authoritative input")
 	}
-	return source.input.ValidateTriggerDecision(observation.decision)
+	if observation.decision.InputID != source.inputID || observation.decision.RecordID != source.recordID {
+		return fmt.Errorf("comparator: decision record contradicts authoritative input")
+	}
+	if source.triggerInput != nil {
+		return source.triggerInput.ValidateTriggerDecision(observation.decision)
+	}
+	return nil
 }
 
-func eligibility(source *sourceObservation, gates Gates) (Eligibility, error) {
-	switch source.outcome.Outcome {
-	case contract.OutcomeError:
-		return EligibilitySourceError, nil
-	case contract.OutcomeUnsupported:
-		return EligibilityUnsupported, nil
+func eligibility(
+	source *sourceObservation,
+	goDecision, pythonDecision *decisionObservation,
+	gates Gates,
+) (Eligibility, error) {
+	if source.outcome != nil {
+		switch source.outcome.Outcome {
+		case contract.OutcomeError:
+			return EligibilitySourceError, nil
+		case contract.OutcomeUnsupported:
+			return EligibilityUnsupported, nil
+		}
 	}
 	if !gates.StableEpoch {
 		return EligibilityEpochUnstable, nil
@@ -516,7 +583,12 @@ func eligibility(source *sourceObservation, gates Gates) (Eligibility, error) {
 	if !gates.CoverageComplete {
 		return EligibilityCoverageGap, nil
 	}
-	if source.outcome.Outcome == contract.OutcomeAnomalous {
+	requiresWarmup := source.outcome != nil && source.outcome.Outcome == contract.OutcomeAnomalous
+	if source.outcome == nil {
+		requiresWarmup = goDecision.decision.Outcome == contract.DecisionOutcomeTrigger ||
+			pythonDecision.decision.Outcome == contract.DecisionOutcomeTrigger
+	}
+	if requiresWarmup {
 		if gates.EpochStartSourceTime == nil {
 			return EligibilityNone, fmt.Errorf("comparator: epoch start source time is required for anomalous input")
 		}
@@ -528,7 +600,7 @@ func eligibility(source *sourceObservation, gates Gates) (Eligibility, error) {
 			return EligibilityNone, fmt.Errorf("comparator: warmup boundary exceeds int64")
 		}
 		warmupEnd := epochStart + source.maxWindow - 1
-		if source.outcome.Record.SourceTime < warmupEnd {
+		if source.sourceTime < warmupEnd {
 			return EligibilityWarmup, nil
 		}
 	}
@@ -557,6 +629,18 @@ func sourceFingerprint(input *contract.TriggerInput, outcome *contract.Detection
 		PartitionHashVersion: input.PartitionHashVersion,
 		StrategyIR:           input.StrategyIR,
 		Outcome:              cloned,
+	})
+}
+
+func detectSourceFingerprint(input *contract.DetectInput, record json.RawMessage) ([sha256.Size]byte, error) {
+	return semanticFingerprint(struct {
+		PartitionHashVersion string                      `json:"partition_hash_version"`
+		StrategyIR           *contract.TriggerStrategyIR `json:"strategy_ir"`
+		Record               json.RawMessage             `json:"record"`
+	}{
+		PartitionHashVersion: input.PartitionHashVersion,
+		StrategyIR:           input.StrategyIR,
+		Record:               append(json.RawMessage(nil), record...),
 	})
 }
 
@@ -595,5 +679,13 @@ func cloneDecisionObservation(observation *decisionObservation) *decisionObserva
 	}
 	cloned := *observation
 	cloned.decision = cloneDecision(observation.decision)
+	return &cloned
+}
+
+func cloneSourceObservation(observation *sourceObservation) *sourceObservation {
+	if observation == nil {
+		return nil
+	}
+	cloned := *observation
 	return &cloned
 }

--- a/pkg/alarmd/comparator/joiner_test.go
+++ b/pkg/alarmd/comparator/joiner_test.go
@@ -60,6 +60,36 @@ func TestJoinerAlignsThreeStreamsByInputID(t *testing.T) {
 	}
 }
 
+func TestJoinerUsesDetectInputAsAuthoritativeComparisonSource(t *testing.T) {
+	t.Parallel()
+
+	_, triggerInput := testTriggerInput(t, "normal")
+	detectPayload, detectInput := testDetectInputFromTrigger(t, triggerInput)
+	decisionPayload := testDecisionBatch(t, triggerInput, contract.DecisionOutcomeNoTrigger)
+	key, err := detectInput.PartitionKey()
+	if err != nil {
+		t.Fatalf("PartitionKey() error = %v", err)
+	}
+	inputID := triggerInput.DetectionOutcomes[0].InputID
+	joiner := mustJoiner(t, "run-1", 10)
+
+	if _, err := joiner.ObserveDetectInput("run-1", key, detectPayload); err != nil {
+		t.Fatalf("ObserveDetectInput() error = %v", err)
+	}
+	if _, err := joiner.ObserveDecisionBatch("run-1", DecisionSideGo, key, decisionPayload); err != nil {
+		t.Fatalf("ObserveDecisionBatch(go) error = %v", err)
+	}
+	if _, err := joiner.ObserveDecisionBatch("run-1", DecisionSidePython, key, decisionPayload); err != nil {
+		t.Fatalf("ObserveDecisionBatch(python) error = %v", err)
+	}
+	assessment, ok, err := joiner.Assess("run-1", inputID, Gates{
+		StableEpoch: true, CoverageComplete: true, EpochStartSourceTime: int64Pointer(0),
+	})
+	if err != nil || !ok || assessment.Join != JoinComplete || assessment.Verdict != VerdictMatch {
+		t.Fatalf("Assessment = %#v, ok=%v, error=%v", assessment, ok, err)
+	}
+}
+
 func TestJoinerProducesSameAssessmentForEveryArrivalOrder(t *testing.T) {
 	t.Parallel()
 
@@ -466,6 +496,36 @@ func testTriggerInputMany(t *testing.T, names ...string) ([]byte, *contract.Trig
 		t.Fatalf("DecodeTriggerInput() error = %v", err)
 	}
 	return inputPayload, input
+}
+
+func testDetectInputFromTrigger(t *testing.T, input *contract.TriggerInput) ([]byte, *contract.DetectInput) {
+	t.Helper()
+	records := make([]json.RawMessage, 0, len(input.DetectionOutcomes))
+	for _, outcome := range input.DetectionOutcomes {
+		records = append(records, append(json.RawMessage(nil), outcome.Record.DataRaw...))
+	}
+	payload, err := json.Marshal(map[string]any{
+		"schema":                 map[string]any{"name": "detect-input", "major": 1, "minor": 0},
+		"required_features":      []string{},
+		"partition_hash_version": input.PartitionHashVersion,
+		"strategy_ir":            input.StrategyIR,
+		"batch_id":               "detect-batch",
+		"records":                records,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(detect input) error = %v", err)
+	}
+	decoded, err := contract.DecodeDetectInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeDetectInput() error = %v", err)
+	}
+	return payload, decoded
+}
+
+func mustDetectInputPayload(t *testing.T, input *contract.TriggerInput) []byte {
+	t.Helper()
+	payload, _ := testDetectInputFromTrigger(t, input)
+	return payload
 }
 
 func testFullDecisionBatch(t *testing.T, input *contract.TriggerInput) *contract.TriggerDecisionBatch {

--- a/pkg/alarmd/comparator/run.go
+++ b/pkg/alarmd/comparator/run.go
@@ -103,6 +103,26 @@ type Run struct {
 
 type RunOption func(*runOptions) error
 
+// CoverageCounts returns the in-memory work that would be discarded if the
+// current assignment epoch ended now.
+func (r *Run) CoverageCounts(epoch string) (entries int, authoritative int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.requireValidLocked(); err != nil {
+		return 0, 0, err
+	}
+	if epoch != r.epoch {
+		return 0, 0, fmt.Errorf("comparator: run epoch mismatch")
+	}
+	for _, item := range r.coverage {
+		entries++
+		if item.present[StreamInput] {
+			authoritative++
+		}
+	}
+	return entries, authoritative, nil
+}
+
 type runOptions struct {
 	coverageTimeout time.Duration
 	now             func() time.Time
@@ -218,8 +238,8 @@ func (r *Run) Prepare(record StreamRecord) (Prepared, error) {
 	}
 	// Keep a bounded recent replay window and reserve one maximum wire batch.
 	// Only fully joined entries are compacted; partial joins remain fail-closed.
-	compactTarget := contract.MaxTriggerInputItemsV1
-	if reserveTarget := r.maxEntries - contract.MaxTriggerInputItemsV1; reserveTarget < compactTarget {
+	compactTarget := contract.MaxDetectInputRecordsV1
+	if reserveTarget := r.maxEntries - contract.MaxDetectInputRecordsV1; reserveTarget < compactTarget {
 		compactTarget = reserveTarget
 	}
 	for _, inputID := range r.joiner.compact(compactTarget) {
@@ -232,7 +252,7 @@ func (r *Run) Prepare(record StreamRecord) (Prepared, error) {
 	)
 	switch record.Role {
 	case StreamInput:
-		updates, err = r.joiner.ObserveTriggerInput(r.epoch, record.Key, record.Value)
+		updates, err = r.joiner.ObserveDetectInput(r.epoch, record.Key, record.Value)
 	case StreamGo:
 		updates, err = r.joiner.ObserveDecisionBatch(r.epoch, DecisionSideGo, record.Key, record.Value)
 	case StreamPython:

--- a/pkg/alarmd/comparator/run_test.go
+++ b/pkg/alarmd/comparator/run_test.go
@@ -20,7 +20,7 @@ func TestRunExposesObservationsOnlyAfterOffsetCommit(t *testing.T) {
 	t.Parallel()
 
 	run := mustRun(t)
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	decisionPayload := testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)
 	key := mustPartitionKey(t, input)
 	inputID := input.DetectionOutcomes[0].InputID
@@ -40,7 +40,7 @@ func TestRunExposesObservationsOnlyAfterOffsetCommit(t *testing.T) {
 		t.Fatalf("Assess(after go) = %#v, ok=%v, error=%v", assessment, ok, err)
 	}
 
-	inputPrepared, err := run.Prepare(StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload})
+	inputPrepared, err := run.Prepare(StreamRecord{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)})
 	if err != nil {
 		t.Fatalf("Prepare(input) error = %v", err)
 	}
@@ -54,7 +54,10 @@ func TestRunExposesObservationsOnlyAfterOffsetCommit(t *testing.T) {
 	if _, err := run.CommitSucceeded(pythonPrepared); err != nil {
 		t.Fatalf("CommitSucceeded(python) error = %v", err)
 	}
-	assessment, ok, err = run.Assess("run-1", inputID, Gates{StableEpoch: true, CoverageComplete: true})
+	assessment, ok, err = run.Assess("run-1", inputID, Gates{
+		StableEpoch: true, CoverageComplete: true,
+		EpochStartSourceTime: int64Pointer(input.DetectionOutcomes[0].Record.SourceTime - 299),
+	})
 	if err != nil || !ok || assessment.Join != JoinComplete || assessment.Verdict != VerdictMatch {
 		t.Fatalf("Assess(complete) = %#v, ok=%v, error=%v", assessment, ok, err)
 	}
@@ -138,11 +141,11 @@ func TestRunConcurrentPrepareReturnsBusyWithoutInvalidating(t *testing.T) {
 	t.Parallel()
 
 	run := mustRun(t)
-	inputPayload, input := testTriggerInput(t, "normal")
+	_, input := testTriggerInput(t, "normal")
 	decisionPayload := testDecisionBatch(t, input, contract.DecisionOutcomeNoTrigger)
 	key := mustPartitionKey(t, input)
 	records := []StreamRecord{
-		{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: inputPayload},
+		{Epoch: "run-1", Role: StreamInput, Topic: "input", Partition: 0, Offset: 20, Key: key, Value: mustDetectInputPayload(t, input)},
 		{Epoch: "run-1", Role: StreamGo, Topic: "go", Partition: 0, Offset: 10, Key: key, Value: decisionPayload},
 	}
 	type result struct {

--- a/pkg/alarmd/config/comparator.go
+++ b/pkg/alarmd/config/comparator.go
@@ -25,7 +25,7 @@ import (
 
 type ComparatorKafkaConfig struct {
 	Brokers                  []string `yaml:"brokers"`
-	TriggerInputTopic        string   `yaml:"trigger_input_topic"`
+	DetectInputTopic         string   `yaml:"detect_input_topic"`
 	GoDecisionTopic          string   `yaml:"go_decision_topic"`
 	PythonDecisionTopic      string   `yaml:"python_decision_topic"`
 	AuditOutputTopic         string   `yaml:"audit_output_topic"`
@@ -33,6 +33,7 @@ type ComparatorKafkaConfig struct {
 	GroupID                  string   `yaml:"group_id"`
 	ClientID                 string   `yaml:"client_id"`
 	BrokerVersion            string   `yaml:"broker_version"`
+	InitialOffset            string   `yaml:"initial_offset"`
 	MaxEntries               int      `yaml:"max_entries"`
 	CoverageTimeout          Duration `yaml:"coverage_timeout"`
 	BarrierInterval          Duration `yaml:"barrier_interval"`
@@ -41,12 +42,13 @@ type ComparatorKafkaConfig struct {
 func (c ComparatorKafkaConfig) ServiceCoordinates() enginekafka.ComparatorServiceConfig {
 	return enginekafka.ComparatorServiceConfig{
 		Brokers:             append([]string(nil), c.Brokers...),
-		TriggerInputTopic:   c.TriggerInputTopic,
+		DetectInputTopic:    c.DetectInputTopic,
 		GoDecisionTopic:     c.GoDecisionTopic,
 		PythonDecisionTopic: c.PythonDecisionTopic,
 		GroupID:             c.GroupID,
 		ClientID:            c.ClientID,
 		BrokerVersion:       c.BrokerVersion,
+		InitialOffset:       c.InitialOffset,
 		MaxEntries:          c.MaxEntries,
 		CoverageTimeout:     c.CoverageTimeout.Duration(),
 		BarrierInterval:     c.BarrierInterval.Duration(),

--- a/pkg/alarmd/config/comparator_test.go
+++ b/pkg/alarmd/config/comparator_test.go
@@ -25,7 +25,7 @@ http:
   listen: 127.0.0.1:8081
 kafka:
   brokers: [127.0.0.1:9092]
-  trigger_input_topic: trigger-input
+  detect_input_topic: detect-input
   go_decision_topic: go-decision
   python_decision_topic: python-decision
   audit_output_topic: comparison-audit
@@ -33,6 +33,7 @@ kafka:
   group_id: alarmd-comparator
   client_id: alarmd-comparator
   broker_version: 2.6.0
+  initial_offset: latest
   max_entries: 1000
   coverage_timeout: 1m
   barrier_interval: 1s
@@ -45,10 +46,10 @@ shutdown_timeout: 10s
 	if err != nil {
 		t.Fatalf("LoadComparator() error = %v", err)
 	}
-	if got, want := config.Kafka.ServiceCoordinates().Topics(), []string{"trigger-input", "go-decision", "python-decision"}; !reflect.DeepEqual(got, want) {
+	if got, want := config.Kafka.ServiceCoordinates().Topics(), []string{"detect-input", "go-decision", "python-decision"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("service topics = %v, want %v", got, want)
 	}
-	if got := config.Kafka.AuditSinkCoordinates(); got.OutputTopic != "comparison-audit" || !reflect.DeepEqual(got.InputTopics, []string{"trigger-input", "go-decision", "python-decision"}) {
+	if got := config.Kafka.AuditSinkCoordinates(); got.OutputTopic != "comparison-audit" || !reflect.DeepEqual(got.InputTopics, []string{"detect-input", "go-decision", "python-decision"}) {
 		t.Fatalf("audit coordinates = %#v", got)
 	}
 }

--- a/pkg/alarmd/config/config.go
+++ b/pkg/alarmd/config/config.go
@@ -52,6 +52,7 @@ type KafkaConfig struct {
 	GroupID             string   `yaml:"group_id"`
 	ClientID            string   `yaml:"client_id"`
 	BrokerVersion       string   `yaml:"broker_version"`
+	InitialOffset       string   `yaml:"initial_offset"`
 }
 
 func (c KafkaConfig) ConsumerCoordinates() enginekafka.Config {
@@ -61,6 +62,7 @@ func (c KafkaConfig) ConsumerCoordinates() enginekafka.Config {
 		GroupID:       c.GroupID,
 		ClientID:      c.ClientID,
 		BrokerVersion: c.BrokerVersion,
+		InitialOffset: c.InitialOffset,
 	}
 }
 

--- a/pkg/alarmd/contract/comparison_audit.go
+++ b/pkg/alarmd/contract/comparison_audit.go
@@ -26,6 +26,7 @@ const (
 	comparisonDecisionTimestampsVersionV1 = "comparison-decision-timestamps-v1"
 
 	ComparisonAuditEventSnapshot = "ASSESSMENT_SNAPSHOT"
+	ComparisonSourceDetectInput  = "DETECT_INPUT"
 
 	ComparisonJoinPendingInput  = "PENDING_INPUT"
 	ComparisonJoinPendingBoth   = "PENDING_BOTH"
@@ -89,7 +90,8 @@ var comparisonDecisionIdentityFields = map[string]struct{}{
 }
 
 type ComparisonSourceEvidence struct {
-	Outcome   string `json:"outcome"`
+	Kind      string `json:"kind,omitempty"`
+	Outcome   string `json:"outcome,omitempty"`
 	ErrorCode string `json:"error_code,omitempty"`
 	// SemanticSHA256 is the exact fingerprint retained by Comparator.
 	SemanticSHA256 string `json:"semantic_sha256"`
@@ -210,7 +212,7 @@ func BuildComparisonAuditBatch(
 		owned[index].AuditID = auditID
 	}
 	batch := &ComparisonAuditBatch{
-		Schema:               Schema{Name: comparisonAuditBatchSchema, Major: schemaMajor, Minor: 0},
+		Schema:               Schema{Name: comparisonAuditBatchSchema, Major: schemaMajor, Minor: 1},
 		RequiredFeatures:     []string{},
 		PartitionHashVersion: partitionHashVersion,
 		TenantID:             tenantID,
@@ -311,7 +313,7 @@ func DecodeComparisonAuditBatch(payload []byte) (*ComparisonAuditBatch, error) {
 	}
 	audits := make([]ComparisonAudit, 0, len(header.Audits))
 	for _, rawAudit := range header.Audits {
-		audit, err := decodeComparisonAudit(rawAudit, allowUnknown)
+		audit, err := decodeComparisonAudit(rawAudit, schema.Minor, allowUnknown)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +340,7 @@ func DecodeComparisonAuditBatch(payload []byte) (*ComparisonAuditBatch, error) {
 	return batch, nil
 }
 
-func decodeComparisonAudit(payload []byte, allowUnknown bool) (ComparisonAudit, error) {
+func decodeComparisonAudit(payload []byte, schemaMinor int, allowUnknown bool) (ComparisonAudit, error) {
 	required := []string{
 		"audit_id", "event_kind", "input_id", "record_id", "source_time", "join_status", "eligibility", "verdict",
 		"source", "coverage", "source_conflict", "go_conflict", "python_conflict", "go_invalid", "python_invalid",
@@ -349,8 +351,12 @@ func decodeComparisonAudit(payload []byte, allowUnknown bool) (ComparisonAudit, 
 	if err != nil {
 		return ComparisonAudit{}, err
 	}
+	sourceOptional := []string{"outcome", "error_code"}
+	if schemaMinor >= 1 {
+		sourceOptional = append(sourceOptional, "kind")
+	}
 	sourceObject, err := validateJSONObjectFields(
-		object["source"], "comparison_audit.source", []string{"outcome", "semantic_sha256"}, []string{"error_code"}, allowUnknown,
+		object["source"], "comparison_audit.source", []string{"semantic_sha256"}, sourceOptional, allowUnknown,
 	)
 	if err != nil {
 		return ComparisonAudit{}, err
@@ -397,6 +403,12 @@ func decodeComparisonAudit(payload []byte, allowUnknown bool) (ComparisonAudit, 
 	var audit ComparisonAudit
 	if err := decodeJSONObject(payload, &audit); err != nil {
 		return ComparisonAudit{}, err
+	}
+	if _, present := sourceObject["kind"]; present && audit.Source.Kind == "" {
+		return ComparisonAudit{}, invalid("comparison_audit.source.kind", "must be a non-empty string when present")
+	}
+	if _, present := sourceObject["outcome"]; present && audit.Source.Outcome == "" {
+		return ComparisonAudit{}, invalid("comparison_audit.source.outcome", "must be a non-empty string when present")
 	}
 	if _, present := sourceObject["error_code"]; present && audit.Source.ErrorCode == "" {
 		return ComparisonAudit{}, invalid("comparison_audit.source.error_code", "must be a non-empty string when present")
@@ -617,22 +629,29 @@ func (a *ComparisonAudit) validateCompleteOutcome() error {
 	if _, ok := validEligibility[a.Eligibility]; !ok {
 		return invalid("comparison_audit.eligibility", "unsupported complete eligibility")
 	}
-	switch a.Source.Outcome {
-	case OutcomeError:
-		if a.Eligibility != ComparisonEligibilitySourceError {
-			return invalid("comparison_audit.eligibility", "ERROR source requires SOURCE_ERROR")
-		}
-	case OutcomeUnsupported:
-		if a.Eligibility != ComparisonEligibilityUnsupported {
-			return invalid("comparison_audit.eligibility", "UNSUPPORTED source requires UNSUPPORTED")
-		}
-	case OutcomeNormal:
-		if a.Eligibility == ComparisonEligibilityWarmup || a.Eligibility == ComparisonEligibilitySourceError || a.Eligibility == ComparisonEligibilityUnsupported {
-			return invalid("comparison_audit.eligibility", "does not match NORMAL source")
-		}
-	case OutcomeAnomalous:
+	switch a.Source.Kind {
+	case ComparisonSourceDetectInput:
 		if a.Eligibility == ComparisonEligibilitySourceError || a.Eligibility == ComparisonEligibilityUnsupported {
-			return invalid("comparison_audit.eligibility", "does not match ANOMALOUS source")
+			return invalid("comparison_audit.eligibility", "DetectInput source cannot assert Detect outcome eligibility")
+		}
+	default:
+		switch a.Source.Outcome {
+		case OutcomeError:
+			if a.Eligibility != ComparisonEligibilitySourceError {
+				return invalid("comparison_audit.eligibility", "ERROR source requires SOURCE_ERROR")
+			}
+		case OutcomeUnsupported:
+			if a.Eligibility != ComparisonEligibilityUnsupported {
+				return invalid("comparison_audit.eligibility", "UNSUPPORTED source requires UNSUPPORTED")
+			}
+		case OutcomeNormal:
+			if a.Eligibility == ComparisonEligibilityWarmup || a.Eligibility == ComparisonEligibilitySourceError || a.Eligibility == ComparisonEligibilityUnsupported {
+				return invalid("comparison_audit.eligibility", "does not match NORMAL source")
+			}
+		case OutcomeAnomalous:
+			if a.Eligibility == ComparisonEligibilitySourceError || a.Eligibility == ComparisonEligibilityUnsupported {
+				return invalid("comparison_audit.eligibility", "does not match ANOMALOUS source")
+			}
 		}
 	}
 	if a.Eligibility == ComparisonEligibilityEligible {
@@ -665,6 +684,15 @@ func (a *ComparisonAudit) validateCompleteOutcome() error {
 func (s ComparisonSourceEvidence) validate() error {
 	if !sha256Pattern.MatchString(s.SemanticSHA256) {
 		return invalid("comparison_audit.source.semantic_sha256", "must be 64 lowercase hexadecimal characters")
+	}
+	if s.Kind == ComparisonSourceDetectInput {
+		if s.Outcome != "" || s.ErrorCode != "" {
+			return invalid("comparison_audit.source", "DetectInput evidence must not assert a detection outcome")
+		}
+		return nil
+	}
+	if s.Kind != "" {
+		return invalid("comparison_audit.source.kind", "unsupported source kind")
 	}
 	switch s.Outcome {
 	case OutcomeNormal, OutcomeAnomalous:

--- a/pkg/alarmd/contract/comparison_audit_test.go
+++ b/pkg/alarmd/contract/comparison_audit_test.go
@@ -306,9 +306,16 @@ func TestComparisonAuditDecoderNegotiatesStrictEnvelope(t *testing.T) {
 	}{
 		{name: "unknown major", mutate: func(d map[string]any) { d["schema"].(map[string]any)["major"] = 2 }, wantErr: true},
 		{name: "unknown feature", mutate: func(d map[string]any) { d["required_features"] = []string{"future-required"} }, wantErr: true},
-		{name: "minor zero unknown field", mutate: func(d map[string]any) { d["future_optional"] = true }, wantErr: true},
-		{name: "higher minor optional field", mutate: func(d map[string]any) { d["schema"].(map[string]any)["minor"] = 1; d["future_optional"] = true }},
-		{name: "nested unknown field", mutate: func(d map[string]any) { d["audits"].([]any)[0].(map[string]any)["future_optional"] = true }, wantErr: true},
+		{name: "minor zero unknown field", mutate: func(d map[string]any) { d["schema"].(map[string]any)["minor"] = 0; d["future_optional"] = true }, wantErr: true},
+		{name: "higher minor optional field", mutate: func(d map[string]any) { d["schema"].(map[string]any)["minor"] = 2; d["future_optional"] = true }},
+		{name: "nested unknown field", mutate: func(d map[string]any) {
+			d["schema"].(map[string]any)["minor"] = 0
+			d["audits"].([]any)[0].(map[string]any)["future_optional"] = true
+		}, wantErr: true},
+		{name: "minor zero detect input source kind", mutate: func(d map[string]any) {
+			d["schema"].(map[string]any)["minor"] = 0
+			d["audits"].([]any)[0].(map[string]any)["source"].(map[string]any)["kind"] = ComparisonSourceDetectInput
+		}, wantErr: true},
 		{name: "case collision", mutate: func(d map[string]any) { d["Audits"] = d["audits"] }, wantErr: true},
 	}
 	for _, test := range tests {

--- a/pkg/alarmd/kafka/comparator_assignment.go
+++ b/pkg/alarmd/kafka/comparator_assignment.go
@@ -24,7 +24,10 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/comparator"
 )
 
-var errComparatorAssignmentEnded = errors.New("kafka comparator assignment: session ended")
+var (
+	errComparatorAssignmentEnded       = errors.New("kafka comparator assignment: session ended")
+	errComparatorSymbolicInitialOffset = errors.New("kafka comparator assignment: symbolic initial offset")
+)
 
 type comparatorMetadata interface {
 	RefreshMetadata(topics ...string) error
@@ -44,6 +47,9 @@ type comparatorGeneration struct {
 	err         error
 	inflight    int
 	recordOwner bool
+	lostEntries int
+	lostInputs  int
+	lossKnown   bool
 }
 
 type comparatorAssignmentHandle struct {
@@ -319,21 +325,14 @@ func (c *comparatorAssignmentCoordinator) Cleanup(
 
 func (c *comparatorAssignmentCoordinator) resolveInitialOffset(claim sarama.ConsumerGroupClaim) (int64, error) {
 	initial := claim.InitialOffset()
-	var next int64
-	switch {
-	case initial >= 0:
-		next = initial
-	case initial == sarama.OffsetOldest:
-		resolved, err := c.metadata.GetOffset(claim.Topic(), claim.Partition(), sarama.OffsetOldest)
-		if err != nil {
-			return 0, fmt.Errorf("kafka comparator assignment: resolve oldest offset: %w", err)
-		}
-		next = resolved
-	case initial == sarama.OffsetNewest:
-		return 0, errors.New("kafka comparator assignment: OffsetNewest cannot be resolved after claim creation")
-	default:
-		return 0, fmt.Errorf("kafka comparator assignment: unsupported initial offset %d", initial)
+	if initial < 0 {
+		return 0, fmt.Errorf(
+			"%w %d; offset repair must commit a numeric offset before Consume",
+			errComparatorSymbolicInitialOffset,
+			initial,
+		)
 	}
+	next := initial
 	highWater, err := c.metadata.GetOffset(claim.Topic(), claim.Partition(), sarama.OffsetNewest)
 	if err != nil {
 		return 0, fmt.Errorf("kafka comparator assignment: resolve newest offset: %w", err)
@@ -397,8 +396,27 @@ func (c *comparatorAssignmentCoordinator) invalidateGenerationIfIdleLocked(gener
 		return
 	}
 	if generation.run != nil && generation.run.Valid() {
+		generation.lostEntries, generation.lostInputs, _ = generation.run.CoverageCounts(generation.epoch)
+		generation.lossKnown = true
 		_ = generation.run.Invalidate(generation.epoch, generationError(generation))
 	}
+}
+
+func (c *comparatorAssignmentCoordinator) epochRollover(
+	handle *comparatorAssignmentHandle,
+) (ComparatorEpochRollover, bool) {
+	if c == nil || handle == nil || handle.generation == nil {
+		return ComparatorEpochRollover{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	generation := handle.generation
+	if !generation.lossKnown {
+		return ComparatorEpochRollover{}, false
+	}
+	return ComparatorEpochRollover{
+		Entries: generation.lostEntries, Authoritative: generation.lostInputs,
+	}, true
 }
 
 func (c *comparatorAssignmentCoordinator) closeReadyLocked(generation *comparatorGeneration) {

--- a/pkg/alarmd/kafka/comparator_assignment_test.go
+++ b/pkg/alarmd/kafka/comparator_assignment_test.go
@@ -160,7 +160,6 @@ func TestComparatorAssignmentCreatesOneRunAfterEveryClaimRegisters(t *testing.T)
 		"go-decision":   {0},
 		"py-decision":   {0},
 	})
-	metadata.offsets[metadataOffset{"trigger-input", 1, sarama.OffsetOldest}] = 11
 	assignment := mustComparatorAssignment(t, metadata)
 	events := []string{}
 	session := newFakeSession(context.Background(), &events)
@@ -174,7 +173,7 @@ func TestComparatorAssignmentCreatesOneRunAfterEveryClaimRegisters(t *testing.T)
 
 	claims := []*fakeClaim{
 		{topic: "trigger-input", partition: 0, initial: 10, highWater: 100},
-		{topic: "trigger-input", partition: 1, initial: sarama.OffsetOldest, highWater: 100},
+		{topic: "trigger-input", partition: 1, initial: 11, highWater: 100},
 		{topic: "go-decision", partition: 0, initial: 20, highWater: 100},
 		{topic: "py-decision", partition: 0, initial: 30, highWater: 100},
 	}
@@ -212,7 +211,6 @@ func TestComparatorAssignmentCreatesOneRunAfterEveryClaimRegisters(t *testing.T)
 	}
 	metadata.assertOffsetCalls(t, []metadataOffset{
 		{"trigger-input", 0, sarama.OffsetNewest},
-		{"trigger-input", 1, sarama.OffsetOldest},
 		{"trigger-input", 1, sarama.OffsetNewest},
 		{"go-decision", 0, sarama.OffsetNewest},
 		{"py-decision", 0, sarama.OffsetNewest},
@@ -255,7 +253,6 @@ func TestComparatorAssignmentRejectsUnsafeInitialOffsets(t *testing.T) {
 		newest      int64
 		newestErr   error
 	}{
-		{name: "newest", initial: sarama.OffsetNewest, newest: 100},
 		{name: "unknown value", initial: -3, newest: 100},
 		{name: "oldest resolver failure", initial: sarama.OffsetOldest, resolverErr: want, newest: 100},
 		{name: "newest resolver failure", initial: 10, newestErr: want},
@@ -295,6 +292,20 @@ func TestComparatorAssignmentRejectsUnsafeInitialOffsets(t *testing.T) {
 				t.Fatal("WaitReady() accepted a failed assignment")
 			}
 		})
+	}
+}
+
+func TestComparatorAssignmentRejectsUnresolvedNewestInitialOffset(t *testing.T) {
+	t.Parallel()
+
+	metadata := newFakeComparatorMetadata(map[string][]int32{
+		"trigger-input": {0}, "go-decision": {0}, "py-decision": {0},
+	})
+	assignment := mustComparatorAssignment(t, metadata)
+	claim := &fakeClaim{topic: "trigger-input", partition: 0, initial: sarama.OffsetNewest}
+
+	if _, err := assignment.resolveInitialOffset(claim); err == nil {
+		t.Fatal("resolveInitialOffset() accepted an unresolved symbolic offset")
 	}
 }
 

--- a/pkg/alarmd/kafka/comparator_barrier.go
+++ b/pkg/alarmd/kafka/comparator_barrier.go
@@ -180,7 +180,7 @@ func (a *comparatorBarrierAdapter) publishChangedCoverage(ctx context.Context, s
 		if a.lastCoverage[snapshot.InputID] == signature {
 			continue
 		}
-		if snapshot.Authoritative {
+		if snapshot.Authoritative && snapshot.Phase == comparator.CoverageMissingAtBarrier {
 			authoritativeIDs = append(authoritativeIDs, snapshot.InputID)
 		}
 		if snapshot.Phase == comparator.CoverageMissingAtBarrier {
@@ -196,9 +196,6 @@ func (a *comparatorBarrierAdapter) publishChangedCoverage(ctx context.Context, s
 		batches, err := a.records.run.AuditBatches(a.records.epoch, authoritativeIDs, comparator.Gates{StableEpoch: true})
 		if err != nil {
 			return err
-		}
-		if len(batches) == 0 {
-			return errors.New("kafka comparator barrier: changed authoritative coverage produced no audit")
 		}
 		for _, batch := range batches {
 			if err := a.records.audits.WriteBatch(ctx, batch); err != nil {

--- a/pkg/alarmd/kafka/comparator_barrier_test.go
+++ b/pkg/alarmd/kafka/comparator_barrier_test.go
@@ -54,7 +54,7 @@ func TestComparatorBarrierCapturesMissingPartitionsOnceAfterRunClock(t *testing.
 	}
 	decisionPayload, decisionKey := comparatorTriggerDecisionFixture(t, input)
 	for _, record := range []consumer.Record{
-		{Topic: "trigger-input", Partition: 0, Offset: 10, Key: inputKey, Value: inputPayload},
+		{Topic: "trigger-input", Partition: 0, Offset: 10, Key: inputKey, Value: comparatorDetectInputPayload(t, inputPayload)},
 		{Topic: "py-decision", Partition: 0, Offset: 30, Key: decisionKey, Value: decisionPayload},
 	} {
 		if _, err := coordinator.Process(context.Background(), record); err != nil {
@@ -77,17 +77,8 @@ func TestComparatorBarrierCapturesMissingPartitionsOnceAfterRunClock(t *testing.
 	if err != nil || !ok || snapshot.Phase != comparator.CoverageOverdue || !snapshot.BarrierFrozen {
 		t.Fatalf("Coverage() = %#v, ok=%v error=%v", snapshot, ok, err)
 	}
-	audited := 0
-	for _, batch := range auditBatches {
-		for _, audit := range batch.Audits {
-			if !audit.Coverage.BarrierFrozen {
-				t.Fatalf("barrier audit = %#v", audit)
-			}
-			audited++
-		}
-	}
-	if audited != len(input.DetectionOutcomes) {
-		t.Fatalf("barrier audit batches = %#v", auditBatches)
+	if len(auditBatches) != 0 {
+		t.Fatalf("barrier freeze published an intermediate audit: %#v", auditBatches)
 	}
 	if frozen, err := adapter.CaptureOverdue(context.Background()); err != nil || frozen != 0 {
 		t.Fatalf("CaptureOverdue(repeat) frozen=%d error=%v, want no-op", frozen, err)
@@ -195,7 +186,7 @@ func TestComparatorBarrierSharesOneHWMVectorAcrossOverdueInputs(t *testing.T) {
 		}
 		inputIDs = append(inputIDs, input.DetectionOutcomes[0].InputID)
 		if _, err := coordinator.Process(context.Background(), consumer.Record{
-			Topic: "trigger-input", Partition: 0, Offset: int64(10 + index), Key: key, Value: payload,
+			Topic: "trigger-input", Partition: 0, Offset: int64(10 + index), Key: key, Value: comparatorDetectInputPayload(t, payload),
 		}); err != nil {
 			t.Fatalf("Process(%s) error = %v", name, err)
 		}
@@ -236,7 +227,7 @@ func TestComparatorBarrierHWMFailureStopsAssignmentBeforeAnyRetry(t *testing.T) 
 	}
 	payload, key := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process() error = %v", err)
 	}
@@ -278,7 +269,7 @@ func TestComparatorBarrierSerializesHWMFreezeBeforeNextRecord(t *testing.T) {
 		t.Fatalf("DecodeTriggerInput() error = %v", err)
 	}
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: inputKey, Value: inputPayload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: inputKey, Value: comparatorDetectInputPayload(t, inputPayload),
 	}); err != nil {
 		t.Fatalf("Process(input) error = %v", err)
 	}
@@ -354,7 +345,7 @@ func TestComparatorBarrierSessionCancellationDuringHWMStopsBeforeFreeze(t *testi
 		t.Fatalf("DecodeTriggerInput() error = %v", err)
 	}
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process() error = %v", err)
 	}
@@ -424,7 +415,7 @@ func TestComparatorBarrierCleanupDuringLastHWMStopsBeforeFreeze(t *testing.T) {
 		t.Fatalf("DecodeTriggerInput() error = %v", err)
 	}
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process() error = %v", err)
 	}
@@ -474,7 +465,7 @@ func TestComparatorBarrierPreCanceledCallerReadsNoHWM(t *testing.T) {
 	}
 	payload, key := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process() error = %v", err)
 	}
@@ -512,7 +503,7 @@ func TestComparatorBarrierRejectsUnsafeHighWater(t *testing.T) {
 			}
 			payload, key := comparatorTriggerInputFixture(t, "normal")
 			if _, err := coordinator.Process(context.Background(), consumer.Record{
-				Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+				Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 			}); err != nil {
 				t.Fatalf("Process() error = %v", err)
 			}

--- a/pkg/alarmd/kafka/comparator_diagnostics.go
+++ b/pkg/alarmd/kafka/comparator_diagnostics.go
@@ -16,6 +16,7 @@ import "github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/comparator"
 type ComparatorDiagnostics struct {
 	OnCapacityDrop    func(ComparatorCapacityDrop)
 	OnCoverageRelease func(ComparatorCoverageRelease)
+	OnEpochRollover   func(ComparatorEpochRollover)
 }
 
 type ComparatorCapacityDrop struct {
@@ -35,6 +36,11 @@ type ComparatorCoverageRelease struct {
 	MissingPython int
 }
 
+type ComparatorEpochRollover struct {
+	Entries       int
+	Authoritative int
+}
+
 func (d ComparatorDiagnostics) capacityDrop(event ComparatorCapacityDrop) {
 	if d.OnCapacityDrop != nil {
 		d.OnCapacityDrop(event)
@@ -44,5 +50,11 @@ func (d ComparatorDiagnostics) capacityDrop(event ComparatorCapacityDrop) {
 func (d ComparatorDiagnostics) coverageRelease(event ComparatorCoverageRelease) {
 	if d.OnCoverageRelease != nil {
 		d.OnCoverageRelease(event)
+	}
+}
+
+func (d ComparatorDiagnostics) epochRollover(event ComparatorEpochRollover) {
+	if d.OnEpochRollover != nil {
+		d.OnEpochRollover(event)
 	}
 }

--- a/pkg/alarmd/kafka/comparator_e2e_test.go
+++ b/pkg/alarmd/kafka/comparator_e2e_test.go
@@ -53,7 +53,7 @@ func TestComparatorKafkaEndToEnd(t *testing.T) {
 		t.Fatalf("OpenComparisonAuditSink() error = %v", err)
 	}
 	service, err := OpenComparatorService(ComparatorServiceConfig{
-		Brokers: []string{broker}, TriggerInputTopic: topics[0], GoDecisionTopic: topics[1], PythonDecisionTopic: topics[2],
+		Brokers: []string{broker}, DetectInputTopic: topics[0], GoDecisionTopic: topics[1], PythonDecisionTopic: topics[2],
 		GroupID: prefix + "-group", ClientID: prefix + "-consumer", BrokerVersion: "2.1.0",
 		MaxEntries: 100, CoverageTimeout: 200 * time.Millisecond, BarrierInterval: 50 * time.Millisecond,
 	}, sink, 5*time.Second)
@@ -93,9 +93,9 @@ func TestComparatorKafkaEndToEnd(t *testing.T) {
 	}
 	for _, message := range []*sarama.ProducerMessage{
 		{Topic: topics[2], Key: sarama.ByteEncoder(decisionKey), Value: sarama.ByteEncoder(decisionPayload)},
-		{Topic: topics[0], Key: sarama.ByteEncoder(inputKey), Value: sarama.ByteEncoder(inputPayload)},
+		{Topic: topics[0], Key: sarama.ByteEncoder(inputKey), Value: sarama.ByteEncoder(comparatorDetectInputPayload(t, inputPayload))},
 		{Topic: topics[1], Key: sarama.ByteEncoder(decisionKey), Value: sarama.ByteEncoder(decisionPayload)},
-		{Topic: topics[0], Key: sarama.ByteEncoder(missingKey), Value: sarama.ByteEncoder(missingPayload)},
+		{Topic: topics[0], Key: sarama.ByteEncoder(missingKey), Value: sarama.ByteEncoder(comparatorDetectInputPayload(t, missingPayload))},
 	} {
 		if _, _, err := producer.SendMessage(message); err != nil {
 			t.Fatalf("SendMessage(%q) error = %v", message.Topic, err)

--- a/pkg/alarmd/kafka/comparator_handler.go
+++ b/pkg/alarmd/kafka/comparator_handler.go
@@ -20,8 +20,6 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/alarmd/consumer"
 )
 
-var errComparatorRunRebalanced = errors.New("kafka comparator handler: finite comparison run cannot span assignments")
-
 type comparatorHandlerSession struct {
 	handle         *comparatorAssignmentHandle
 	initOnce       sync.Once
@@ -46,7 +44,6 @@ type comparatorHandler struct {
 
 	mu               sync.Mutex
 	state            *comparatorHandlerSession
-	runStarted       bool
 	ready            bool
 	draining         bool
 	inflightRecords  int
@@ -83,12 +80,10 @@ func (h *comparatorHandler) Setup(session sarama.ConsumerGroupSession) error {
 		h.mu.Unlock()
 		return errors.New("kafka comparator handler: handler is draining")
 	}
-	if h.runStarted {
+	if h.state != nil {
 		h.mu.Unlock()
-		h.fatal(errComparatorRunRebalanced)
-		return errComparatorRunRebalanced
+		return errors.New("kafka comparator handler: another session is active")
 	}
-	h.runStarted = true
 	h.mu.Unlock()
 	handle, err := h.assignment.Setup(session)
 	if err != nil {
@@ -119,6 +114,9 @@ func (h *comparatorHandler) Cleanup(session sarama.ConsumerGroupSession) error {
 		return nil
 	}
 	barrierStarted := h.signalStopBarrier(state)
+	h.mu.Lock()
+	processShutdown := h.draining
+	h.mu.Unlock()
 	err := h.assignment.Cleanup(state.handle, session)
 	if barrierStarted {
 		<-state.barrierDone
@@ -129,6 +127,11 @@ func (h *comparatorHandler) Cleanup(session sarama.ConsumerGroupSession) error {
 		h.state = nil
 	}
 	h.mu.Unlock()
+	if !processShutdown {
+		if event, ok := h.assignment.epochRollover(state.handle); ok {
+			h.assignment.diagnostics.epochRollover(event)
+		}
+	}
 	return err
 }
 

--- a/pkg/alarmd/kafka/comparator_handler_test.go
+++ b/pkg/alarmd/kafka/comparator_handler_test.go
@@ -62,7 +62,7 @@ func TestComparatorHandlerJoinsThreeClaimsIntoAudit(t *testing.T) {
 	decisionPayload, decisionKey := comparatorTriggerDecisionFixture(t, input)
 	claims := []*fakeClaim{
 		newFakeClaim("py-decision", 0, []*sarama.ConsumerMessage{{Topic: "py-decision", Partition: 0, Offset: 0, Key: decisionKey, Value: decisionPayload}}),
-		newFakeClaim("trigger-input", 0, []*sarama.ConsumerMessage{{Topic: "trigger-input", Partition: 0, Offset: 0, Key: inputKey, Value: inputPayload}}),
+		newFakeClaim("trigger-input", 0, []*sarama.ConsumerMessage{{Topic: "trigger-input", Partition: 0, Offset: 0, Key: inputKey, Value: comparatorDetectInputPayload(t, inputPayload)}}),
 		newFakeClaim("go-decision", 0, []*sarama.ConsumerMessage{{Topic: "go-decision", Partition: 0, Offset: 0, Key: decisionKey, Value: decisionPayload}}),
 	}
 	var wait sync.WaitGroup
@@ -103,7 +103,7 @@ func TestComparatorHandlerJoinsThreeClaimsIntoAudit(t *testing.T) {
 	}
 }
 
-func TestComparatorHandlerRejectsAssignmentAfterReadyRunEnds(t *testing.T) {
+func TestComparatorHandlerStartsFreshRunAfterAssignmentEnds(t *testing.T) {
 	t.Parallel()
 
 	metadata := newFakeComparatorMetadata(map[string][]int32{
@@ -120,6 +120,10 @@ func TestComparatorHandlerRejectsAssignmentAfterReadyRunEnds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newComparatorAssignmentCoordinator() error = %v", err)
 	}
+	var rollover *ComparatorEpochRollover
+	assignment.diagnostics = ComparatorDiagnostics{OnEpochRollover: func(event ComparatorEpochRollover) {
+		rollover = &event
+	}}
 	var fatalErr error
 	handler, err := newComparatorHandler(
 		assignment,
@@ -166,21 +170,27 @@ func TestComparatorHandlerRejectsAssignmentAfterReadyRunEnds(t *testing.T) {
 	if err := handler.Cleanup(first); err != nil {
 		t.Fatalf("Cleanup(first) error = %v", err)
 	}
+	if rollover == nil || rollover.Entries != 0 || rollover.Authoritative != 0 {
+		t.Fatalf("epoch rollover = %#v, want an explicit empty-window reset", rollover)
+	}
 
 	second := newFakeSession(context.Background(), &[]string{})
 	second.generation = 2
 	second.claims = first.claims
-	if err := handler.Setup(second); err == nil {
-		t.Fatal("Setup(second) accepted a new assignment after the finite run became ready")
+	if err := handler.Setup(second); err != nil {
+		t.Fatalf("Setup(second) error = %v", err)
 	}
-	if fatalErr == nil {
-		t.Fatal("Setup(second) did not fail the finite run")
+	if fatalErr != nil {
+		t.Fatalf("Setup(second) fatal error = %v", fatalErr)
 	}
-	if assignment.nextGeneration != 1 {
-		t.Fatalf("assignment generations = %d, want exactly one finite-run epoch", assignment.nextGeneration)
+	if assignment.nextGeneration != 2 {
+		t.Fatalf("assignment generations = %d, want a fresh comparison epoch", assignment.nextGeneration)
 	}
 	if handler.Ready() {
-		t.Fatal("handler remained ready after the rebalance was rejected")
+		t.Fatal("handler became ready before the second assignment claims initialized")
+	}
+	if err := handler.Cleanup(second); err != nil {
+		t.Fatalf("Cleanup(second) error = %v", err)
 	}
 }
 
@@ -207,8 +217,13 @@ func TestComparatorHandlerDrainWaitsForActiveBarrier(t *testing.T) {
 		},
 		{
 			name: "audit acknowledgement",
-			block: func(t *testing.T, _ *observedBarrierMetadata, records *comparatorRecordCoordinator) (<-chan struct{}, func()) {
+			block: func(t *testing.T, metadata *observedBarrierMetadata, records *comparatorRecordCoordinator) (<-chan struct{}, func()) {
 				t.Helper()
+				metadata.fakeComparatorMetadata.mu.Lock()
+				metadata.fakeComparatorMetadata.offsets[metadataOffset{"go-decision", 0, sarama.OffsetNewest}] = 20
+				metadata.fakeComparatorMetadata.offsets[metadataOffset{"go-decision", 1, sarama.OffsetNewest}] = 40
+				metadata.fakeComparatorMetadata.offsets[metadataOffset{"py-decision", 0, sarama.OffsetNewest}] = 30
+				metadata.fakeComparatorMetadata.mu.Unlock()
 				started := make(chan struct{})
 				release := make(chan struct{})
 				records.audits = comparisonAuditSinkFunc(func(context.Context, *contract.ComparisonAuditBatch) error {
@@ -229,7 +244,7 @@ func TestComparatorHandlerDrainWaitsForActiveBarrier(t *testing.T) {
 			records, _, _ := setupComparatorBarrierCoordinator(t, metadata, time.Nanosecond)
 			payload, key := comparatorTriggerInputFixture(t, "normal")
 			if _, err := records.Process(context.Background(), consumer.Record{
-				Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+				Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 			}); err != nil {
 				t.Fatalf("Process(input) error = %v", err)
 			}
@@ -286,7 +301,7 @@ func TestComparatorHandlerCleanupWaitsForActiveBarrier(t *testing.T) {
 	records, _, _ := setupComparatorBarrierCoordinator(t, metadata, time.Nanosecond)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
 	if _, err := records.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process(input) error = %v", err)
 	}

--- a/pkg/alarmd/kafka/comparator_record_coordinator_test.go
+++ b/pkg/alarmd/kafka/comparator_record_coordinator_test.go
@@ -53,7 +53,7 @@ func TestComparatorRecordCoordinatorCommitsBrokerThenRunThenLocalOffset(t *testi
 	}
 	payload, key := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process() error = %v", err)
 	}
@@ -62,7 +62,7 @@ func TestComparatorRecordCoordinatorCommitsBrokerThenRunThenLocalOffset(t *testi
 	}
 }
 
-func TestComparatorRecordCoordinatorAcknowledgesAuditBeforeInputOffset(t *testing.T) {
+func TestComparatorRecordCoordinatorAcknowledgesTerminalAuditBeforeSourceOffset(t *testing.T) {
 	t.Parallel()
 
 	events := []string{}
@@ -79,13 +79,27 @@ func TestComparatorRecordCoordinatorAcknowledgesAuditBeforeInputOffset(t *testin
 	})
 	coordinator, _, _, _ := setupComparatorRecordCoordinatorWithAudit(t, 100, committer, audits, &events)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
+	input, err := contract.DecodeTriggerInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeTriggerInput() error = %v", err)
+	}
+	decisionPayload, decisionKey := comparatorTriggerDecisionFixture(t, input)
+	for _, record := range []consumer.Record{
+		{Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload)},
+		{Topic: "go-decision", Partition: 0, Offset: 20, Key: decisionKey, Value: decisionPayload},
+	} {
+		if _, err := coordinator.Process(context.Background(), record); err != nil {
+			t.Fatalf("Process(%s) error = %v", record.Topic, err)
+		}
+	}
+	events = nil
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "py-decision", Partition: 0, Offset: 30, Key: decisionKey, Value: decisionPayload,
 	}); err != nil {
-		t.Fatalf("Process() error = %v", err)
+		t.Fatalf("Process(python) error = %v", err)
 	}
 	if !reflect.DeepEqual(events, []string{"audit-ack", "input-offset-ack", "mark"}) {
-		t.Fatalf("events = %v, want audit ACK before input offset ACK and local mark", events)
+		t.Fatalf("events = %v, want terminal audit ACK before source offset ACK and local mark", events)
 	}
 }
 
@@ -101,8 +115,22 @@ func TestComparatorRecordCoordinatorAuditFailureDoesNotCommitInputOffset(t *test
 	})
 	coordinator, run, _, _ := setupComparatorRecordCoordinatorWithAudit(t, 100, committer, audits, &events)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
+	input, err := contract.DecodeTriggerInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeTriggerInput() error = %v", err)
+	}
+	decisionPayload, decisionKey := comparatorTriggerDecisionFixture(t, input)
+	for _, record := range []consumer.Record{
+		{Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload)},
+		{Topic: "go-decision", Partition: 0, Offset: 20, Key: decisionKey, Value: decisionPayload},
+	} {
+		if _, err := coordinator.Process(context.Background(), record); err != nil {
+			t.Fatalf("Process(%s) error = %v", record.Topic, err)
+		}
+	}
+	events = nil
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "py-decision", Partition: 0, Offset: 30, Key: decisionKey, Value: decisionPayload,
 	}); !errors.Is(err, want) {
 		t.Fatalf("Process() error = %v, want audit failure", err)
 	}
@@ -123,7 +151,7 @@ func TestComparatorRecordCoordinatorCommitFailureStopsAssignment(t *testing.T) {
 	})
 	coordinator, run, _, _ := setupComparatorRecordCoordinator(t, 100, committer, &events)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
-	record := consumer.Record{Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload}
+	record := consumer.Record{Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload)}
 	if _, err := coordinator.Process(context.Background(), record); !errors.Is(err, want) {
 		t.Fatalf("Process() error = %v, want commit failure", err)
 	}
@@ -178,13 +206,13 @@ func TestComparatorRecordCoordinatorCommitsExplicitCapacityDrop(t *testing.T) {
 	}}
 	firstPayload, firstKey := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: firstKey, Value: firstPayload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: firstKey, Value: comparatorDetectInputPayload(t, firstPayload),
 	}); err != nil {
 		t.Fatalf("Process(first) error = %v", err)
 	}
 	secondPayload, secondKey := comparatorTriggerInputFixture(t, "anomalous")
 	updates, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 11, Key: secondKey, Value: secondPayload,
+		Topic: "trigger-input", Partition: 0, Offset: 11, Key: secondKey, Value: comparatorDetectInputPayload(t, secondPayload),
 	})
 	if err != nil {
 		t.Fatalf("Process(second) error = %v", err)
@@ -216,7 +244,7 @@ func TestComparatorRecordCoordinatorSuccessfulAckWinsCancellation(t *testing.T) 
 	coordinator, run, epoch, _ := setupComparatorRecordCoordinator(t, 100, committer, &events)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(ctx, consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process() after successful broker ack = %v, want nil", err)
 	}
@@ -256,7 +284,7 @@ func TestComparatorRecordCoordinatorRebalanceWaitsForSuccessfulInflightCommit(t 
 	)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(sessionContext, consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); err != nil {
 		t.Fatalf("Process() after successful rebalance-raced broker ack = %v, want nil", err)
 	}
@@ -282,7 +310,7 @@ func TestComparatorRecordCoordinatorPreCanceledContextStopsAssignment(t *testing
 	coordinator, run, _, _ := setupComparatorRecordCoordinator(t, 100, committer, &events)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
 	if _, err := coordinator.Process(ctx, consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Process() error = %v, want context canceled", err)
 	}
@@ -307,7 +335,7 @@ func TestComparatorRecordCoordinatorCanceledSessionStopsBackgroundCaller(t *test
 	cancel()
 	session.fakeSession.ctx = sessionContext
 	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
+		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload),
 	}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Process() error = %v, want canceled session", err)
 	}
@@ -351,7 +379,7 @@ func TestComparatorRecordCoordinatorFirstFailureStopsQueuedClaim(t *testing.T) {
 	})
 	coordinator, run, _, _ := setupComparatorRecordCoordinator(t, 100, committer, &events)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
-	record := consumer.Record{Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload}
+	record := consumer.Record{Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload)}
 	firstDone := make(chan error, 1)
 	go func() {
 		_, err := coordinator.Process(context.Background(), record)
@@ -397,7 +425,7 @@ func TestComparatorRecordCoordinatorMapsAllThreeFrozenStreamRoles(t *testing.T) 
 
 	for _, record := range []consumer.Record{
 		{Topic: "py-decision", Partition: 0, Offset: 30, Key: decisionKey, Value: decisionPayload},
-		{Topic: "trigger-input", Partition: 0, Offset: 10, Key: inputKey, Value: inputPayload},
+		{Topic: "trigger-input", Partition: 0, Offset: 10, Key: inputKey, Value: comparatorDetectInputPayload(t, inputPayload)},
 		{Topic: "go-decision", Partition: 0, Offset: 20, Key: decisionKey, Value: decisionPayload},
 	} {
 		if _, err := coordinator.Process(context.Background(), record); err != nil {
@@ -600,6 +628,33 @@ func comparatorTriggerInputFixture(t *testing.T, name string) ([]byte, []byte) {
 	}
 	t.Fatalf("fixture %q not found", name)
 	return nil, nil
+}
+
+func comparatorDetectInputPayload(t *testing.T, triggerPayload []byte) []byte {
+	t.Helper()
+	input, err := contract.DecodeTriggerInput(triggerPayload)
+	if err != nil {
+		t.Fatalf("DecodeTriggerInput() error = %v", err)
+	}
+	records := make([]json.RawMessage, 0, len(input.DetectionOutcomes))
+	for _, outcome := range input.DetectionOutcomes {
+		records = append(records, append(json.RawMessage(nil), outcome.Record.DataRaw...))
+	}
+	payload, err := json.Marshal(map[string]any{
+		"schema":                 map[string]any{"name": "detect-input", "major": 1, "minor": 0},
+		"required_features":      []string{},
+		"partition_hash_version": input.PartitionHashVersion,
+		"strategy_ir":            input.StrategyIR,
+		"batch_id":               input.DetectionOutcomes[0].BatchID,
+		"records":                records,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(DetectInput) error = %v", err)
+	}
+	if _, err := contract.DecodeDetectInput(payload); err != nil {
+		t.Fatalf("DecodeDetectInput() error = %v", err)
+	}
+	return payload
 }
 
 func comparatorTriggerDecisionFixture(t *testing.T, input *contract.TriggerInput) ([]byte, []byte) {

--- a/pkg/alarmd/kafka/comparator_service.go
+++ b/pkg/alarmd/kafka/comparator_service.go
@@ -23,20 +23,22 @@ import (
 // one single-member, three-stream comparison run.
 type ComparatorServiceConfig struct {
 	Brokers             []string
-	TriggerInputTopic   string
+	DetectInputTopic    string
 	GoDecisionTopic     string
 	PythonDecisionTopic string
 	GroupID             string
 	ClientID            string
 	BrokerVersion       string
+	InitialOffset       string
 	MaxEntries          int
 	CoverageTimeout     time.Duration
 	BarrierInterval     time.Duration
 	Diagnostics         ComparatorDiagnostics
+	ConsumerDiagnostics ConsumerDiagnostics
 }
 
 func (c ComparatorServiceConfig) Topics() []string {
-	return []string{c.TriggerInputTopic, c.GoDecisionTopic, c.PythonDecisionTopic}
+	return []string{c.DetectInputTopic, c.GoDecisionTopic, c.PythonDecisionTopic}
 }
 
 func (c ComparatorServiceConfig) Validate() error {
@@ -59,20 +61,22 @@ func (c ComparatorServiceConfig) Validate() error {
 	}
 	return (Config{
 		Brokers:       append([]string(nil), c.Brokers...),
-		Topic:         c.TriggerInputTopic,
+		Topic:         c.DetectInputTopic,
 		GroupID:       c.GroupID,
 		ClientID:      c.ClientID,
 		BrokerVersion: c.BrokerVersion,
+		InitialOffset: c.InitialOffset,
 	}).Validate()
 }
 
 func (c ComparatorServiceConfig) consumerCoordinates() Config {
 	return Config{
 		Brokers:       append([]string(nil), c.Brokers...),
-		Topic:         c.TriggerInputTopic,
+		Topic:         c.DetectInputTopic,
 		GroupID:       c.GroupID,
 		ClientID:      c.ClientID,
 		BrokerVersion: c.BrokerVersion,
+		InitialOffset: c.InitialOffset,
 	}
 }
 
@@ -112,7 +116,7 @@ func OpenComparatorService(
 	assignment, err := newComparatorAssignmentCoordinator(
 		client,
 		map[comparator.StreamRole]string{
-			comparator.StreamInput:  config.TriggerInputTopic,
+			comparator.StreamInput:  config.DetectInputTopic,
 			comparator.StreamGo:     config.GoDecisionTopic,
 			comparator.StreamPython: config.PythonDecisionTopic,
 		},
@@ -133,5 +137,9 @@ func OpenComparatorService(
 	if err != nil {
 		return nil, errors.Join(err, group.Close(), client.Close())
 	}
+	service.diagnostics = config.ConsumerDiagnostics
+	service.repairOffsets = newGroupOffsetRepairer(
+		client, config.GroupID, config.Topics(), saramaConfig.Consumer.Offsets.Initial,
+	).Repair
 	return service, nil
 }

--- a/pkg/alarmd/kafka/comparator_service_test.go
+++ b/pkg/alarmd/kafka/comparator_service_test.go
@@ -20,7 +20,7 @@ func TestComparatorServiceConfigFreezesThreeDistinctInputs(t *testing.T) {
 
 	config := ComparatorServiceConfig{
 		Brokers:             []string{"127.0.0.1:9092"},
-		TriggerInputTopic:   "trigger-input",
+		DetectInputTopic:    "detect-input",
 		GoDecisionTopic:     "go-decision",
 		PythonDecisionTopic: "python-decision",
 		GroupID:             "alarmd-comparator",
@@ -33,7 +33,7 @@ func TestComparatorServiceConfigFreezesThreeDistinctInputs(t *testing.T) {
 	if err := config.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	want := []string{"trigger-input", "go-decision", "python-decision"}
+	want := []string{"detect-input", "go-decision", "python-decision"}
 	if got := config.Topics(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("Topics() = %v, want %v", got, want)
 	}

--- a/pkg/alarmd/kafka/comparison_audit_sink_test.go
+++ b/pkg/alarmd/kafka/comparison_audit_sink_test.go
@@ -59,8 +59,8 @@ func TestComparisonAuditSinkPublishesOfficialWireBeforeInputCommit(t *testing.T)
 		t.Fatalf("newComparisonAuditSink() error = %v", err)
 	}
 	events := []string{}
-	committer := comparatorOffsetCommitterFunc(func(_ context.Context, _ sarama.ConsumerGroupSession, _ consumer.Record) error {
-		if produced == nil {
+	committer := comparatorOffsetCommitterFunc(func(_ context.Context, _ sarama.ConsumerGroupSession, record consumer.Record) error {
+		if record.Topic == "py-decision" && produced == nil {
 			t.Fatal("input offset committed before the audit producer ACK")
 		}
 		events = append(events, "input-offset-ack")
@@ -68,10 +68,19 @@ func TestComparisonAuditSinkPublishesOfficialWireBeforeInputCommit(t *testing.T)
 	})
 	coordinator, _, _, _ := setupComparatorRecordCoordinatorWithAudit(t, 100, committer, sink, &events)
 	payload, key := comparatorTriggerInputFixture(t, "normal")
-	if _, err := coordinator.Process(context.Background(), consumer.Record{
-		Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: payload,
-	}); err != nil {
-		t.Fatalf("Process() error = %v", err)
+	input, err := contract.DecodeTriggerInput(payload)
+	if err != nil {
+		t.Fatalf("DecodeTriggerInput() error = %v", err)
+	}
+	decisionPayload, decisionKey := comparatorTriggerDecisionFixture(t, input)
+	for _, record := range []consumer.Record{
+		{Topic: "trigger-input", Partition: 0, Offset: 10, Key: key, Value: comparatorDetectInputPayload(t, payload)},
+		{Topic: "go-decision", Partition: 0, Offset: 20, Key: decisionKey, Value: decisionPayload},
+		{Topic: "py-decision", Partition: 0, Offset: 30, Key: decisionKey, Value: decisionPayload},
+	} {
+		if _, err := coordinator.Process(context.Background(), record); err != nil {
+			t.Fatalf("Process(%s) error = %v", record.Topic, err)
+		}
 	}
 	if produced == nil || produced.Topic != "comparison-audit" {
 		t.Fatalf("produced message = %#v", produced)

--- a/pkg/alarmd/kafka/config.go
+++ b/pkg/alarmd/kafka/config.go
@@ -22,10 +22,12 @@ import (
 )
 
 const (
+	InitialOffsetOldest = "oldest"
+	InitialOffsetLatest = "latest"
 	// consumerMaxRecordBytes bounds one fetched record. Every Shadow wire is
 	// capped at 512 KiB by its own encoder, and the remainder covers Kafka
 	// record overhead such as the partition key and headers.
-	consumerMaxRecordBytes = contract.MaxTriggerInputBytesV1 + 64*1024
+	consumerMaxRecordBytes = contract.MaxDetectInputBytesV1 + 64*1024
 	// consumerChannelBufferRecords bounds prefetch. Claims are processed
 	// serially, so Sarama's default of 256 buffered records would let a single
 	// partition hold tens of MiB before the first record is even decoded.
@@ -48,6 +50,8 @@ type Config struct {
 	GroupID       string
 	ClientID      string
 	BrokerVersion string
+	InitialOffset string
+	Diagnostics   ConsumerDiagnostics
 }
 
 func (c Config) Validate() error {
@@ -74,6 +78,9 @@ func (c Config) Validate() error {
 	if _, err := sarama.ParseKafkaVersion(c.BrokerVersion); err != nil {
 		return fmt.Errorf("kafka: broker_version %q: %w", c.BrokerVersion, err)
 	}
+	if c.InitialOffset != "" && c.InitialOffset != InitialOffsetOldest && c.InitialOffset != InitialOffsetLatest {
+		return fmt.Errorf("kafka: initial_offset must be %q or %q", InitialOffsetOldest, InitialOffsetLatest)
+	}
 	version, _ := sarama.ParseKafkaVersion(c.BrokerVersion)
 	if !version.IsAtLeast(sarama.V0_10_2_0) || !sarama.MaxVersion.IsAtLeast(version) {
 		return fmt.Errorf("kafka: broker_version %q is outside consumer group range 0.10.2.0..%s", c.BrokerVersion, sarama.MaxVersion)
@@ -95,6 +102,9 @@ func NewSaramaConfig(coordinates Config) (*sarama.Config, error) {
 	config.Consumer.Return.Errors = true
 	config.Consumer.Offsets.AutoCommit.Enable = false
 	config.Consumer.Offsets.Initial = sarama.OffsetOldest
+	if coordinates.InitialOffset == InitialOffsetLatest {
+		config.Consumer.Offsets.Initial = sarama.OffsetNewest
+	}
 	config.ChannelBufferSize = consumerChannelBufferRecords
 	config.Consumer.Fetch.Default = consumerMaxRecordBytes
 	config.Consumer.Fetch.Max = consumerMaxRecordBytes

--- a/pkg/alarmd/kafka/config_test.go
+++ b/pkg/alarmd/kafka/config_test.go
@@ -44,6 +44,21 @@ func TestNewSaramaConfigForcesShadowConsumerInvariants(t *testing.T) {
 	}
 }
 
+func TestNewSaramaConfigSupportsLatestShadowEpoch(t *testing.T) {
+	t.Parallel()
+
+	config, err := NewSaramaConfig(Config{
+		Brokers: []string{"kafka-1.example:9092"}, Topic: "detect-input", GroupID: "alarmd-shadow-v2",
+		ClientID: "alarmd", BrokerVersion: "0.11.0.0", InitialOffset: InitialOffsetLatest,
+	})
+	if err != nil {
+		t.Fatalf("NewSaramaConfig() error = %v", err)
+	}
+	if config.Consumer.Offsets.Initial != sarama.OffsetNewest {
+		t.Fatalf("initial offset = %d, want newest", config.Consumer.Offsets.Initial)
+	}
+}
+
 func TestNewSaramaConfigBoundsConsumerPrefetch(t *testing.T) {
 	t.Parallel()
 
@@ -74,8 +89,8 @@ func TestNewSaramaConfigBoundsConsumerPrefetch(t *testing.T) {
 	if got, want := MaxConsumerBytesPerPartition(), 3*consumerMaxRecordBytes; got != want {
 		t.Fatalf("worst-case bytes per partition = %d, want %d", got, want)
 	}
-	if consumerMaxRecordBytes < contract.MaxTriggerInputBytesV1 {
-		t.Fatalf("fetch bound %d cannot carry a maximum TriggerInput record", consumerMaxRecordBytes)
+	if consumerMaxRecordBytes < contract.MaxDetectInputBytesV1 {
+		t.Fatalf("fetch bound %d cannot carry a maximum DetectInput record", consumerMaxRecordBytes)
 	}
 }
 

--- a/pkg/alarmd/kafka/offset_repair.go
+++ b/pkg/alarmd/kafka/offset_repair.go
@@ -1,0 +1,180 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2017-2025 Tencent. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+)
+
+type managedGroupOffsets interface {
+	ManagePartition(string, int32) (sarama.PartitionOffsetManager, error)
+	Close() error
+}
+
+type offsetRepairClient interface {
+	Partitions(string) ([]int32, error)
+	GetOffset(string, int32, int64) (int64, error)
+}
+
+type groupOffsetRepairer struct {
+	client        offsetRepairClient
+	topics        []string
+	initialOffset int64
+	openOffsets   func() (managedGroupOffsets, error)
+	commitOffsets func(context.Context, []OffsetReset) error
+}
+
+func newGroupOffsetRepairer(client sarama.Client, groupID string, topics []string, initialOffset int64) *groupOffsetRepairer {
+	return &groupOffsetRepairer{
+		client: client, topics: append([]string(nil), topics...), initialOffset: initialOffset,
+		openOffsets: func() (managedGroupOffsets, error) {
+			return sarama.NewOffsetManagerFromClient(groupID, client)
+		},
+		commitOffsets: (&groupOffsetResetCommitter{
+			coordinator: clientCoordinator{client: client}, groupID: groupID,
+		}).Commit,
+	}
+}
+
+func (r *groupOffsetRepairer) Repair(ctx context.Context) ([]OffsetReset, error) {
+	if r == nil || r.client == nil || r.openOffsets == nil || r.commitOffsets == nil {
+		return nil, errors.New("kafka offset repair: initialized repairer is required")
+	}
+	if ctx == nil {
+		return nil, errors.New("kafka offset repair: context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	manager, err := r.openOffsets()
+	if err != nil {
+		return nil, fmt.Errorf("kafka offset repair: open group offsets: %w", err)
+	}
+	events := make([]OffsetReset, 0)
+	var scanErr error
+
+scan:
+	for _, topic := range r.topics {
+		partitions, err := r.client.Partitions(topic)
+		if err != nil {
+			scanErr = fmt.Errorf("kafka offset repair: list partitions for %q: %w", topic, err)
+			break
+		}
+		for _, partition := range partitions {
+			if err := ctx.Err(); err != nil {
+				scanErr = err
+				break scan
+			}
+			partitionOffsets, err := manager.ManagePartition(topic, partition)
+			if err != nil {
+				scanErr = fmt.Errorf("kafka offset repair: manage %s/%d: %w", topic, partition, err)
+				break scan
+			}
+			current, _ := partitionOffsets.NextOffset()
+			oldest, err := r.client.GetOffset(topic, partition, sarama.OffsetOldest)
+			if err != nil {
+				scanErr = fmt.Errorf("kafka offset repair: read oldest %s/%d: %w", topic, partition, err)
+				break scan
+			}
+			newest, err := r.client.GetOffset(topic, partition, sarama.OffsetNewest)
+			if err != nil {
+				scanErr = fmt.Errorf("kafka offset repair: read newest %s/%d: %w", topic, partition, err)
+				break scan
+			}
+			if current >= oldest && current <= newest {
+				continue
+			}
+			target := oldest
+			if r.initialOffset == sarama.OffsetNewest {
+				target = newest
+			}
+			events = append(events, OffsetReset{Topic: topic, Partition: partition, Offset: target})
+		}
+	}
+	closeErr := manager.Close()
+	if scanErr != nil {
+		if closeErr != nil {
+			return nil, fmt.Errorf("%w; close group offsets: %v", scanErr, closeErr)
+		}
+		return nil, scanErr
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("kafka offset repair: close group offsets: %w", closeErr)
+	}
+	if len(events) != 0 {
+		if err := r.commitOffsets(ctx, events); err != nil {
+			return nil, err
+		}
+	}
+	return events, nil
+}
+
+type groupOffsetResetCommitter struct {
+	coordinator coordinator
+	groupID     string
+}
+
+func (c *groupOffsetResetCommitter) Commit(ctx context.Context, offsets []OffsetReset) error {
+	if c == nil || c.coordinator == nil || c.groupID == "" {
+		return errors.New("kafka offset repair: initialized committer is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	broker, err := c.coordinator.Coordinator(c.groupID)
+	if err != nil {
+		return fmt.Errorf("kafka offset repair: get group coordinator: %w", err)
+	}
+	if broker == nil {
+		return errors.New("kafka offset repair: group coordinator is nil")
+	}
+	request := &sarama.OffsetCommitRequest{
+		Version:                 1,
+		ConsumerGroup:           c.groupID,
+		ConsumerGroupGeneration: sarama.GroupGenerationUndefined,
+	}
+	for _, offset := range offsets {
+		if offset.Topic == "" || offset.Partition < 0 || offset.Offset < 0 {
+			return errors.New("kafka offset repair: invalid reset coordinate")
+		}
+		request.AddBlock(offset.Topic, offset.Partition, offset.Offset, sarama.ReceiveTime, "alarmd-offset-reset")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	response, err := broker.CommitOffset(request)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return contextErr
+		}
+		return fmt.Errorf("kafka offset repair: broker request: %w", err)
+	}
+	if response == nil {
+		return errors.New("kafka offset repair: empty broker response")
+	}
+	for _, offset := range offsets {
+		partitions, ok := response.Errors[offset.Topic]
+		if !ok {
+			return fmt.Errorf("kafka offset repair: response missing topic %q", offset.Topic)
+		}
+		commitError, ok := partitions[offset.Partition]
+		if !ok {
+			return fmt.Errorf("kafka offset repair: response missing partition %s/%d", offset.Topic, offset.Partition)
+		}
+		if commitError != sarama.ErrNoError {
+			return fmt.Errorf("kafka offset repair: broker rejected %s/%d: %w", offset.Topic, offset.Partition, commitError)
+		}
+	}
+	return nil
+}

--- a/pkg/alarmd/kafka/offset_repair_test.go
+++ b/pkg/alarmd/kafka/offset_repair_test.go
@@ -1,0 +1,145 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2017-2025 Tencent. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Shopify/sarama"
+)
+
+func TestGroupOffsetRepairerRepairsOnlyInvalidCommittedOffsets(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name          string
+		initialOffset int64
+		current       int64
+		wantTarget    int64
+		wantRepair    bool
+	}{
+		{name: "retention to oldest", initialOffset: sarama.OffsetOldest, current: 5, wantTarget: 10, wantRepair: true},
+		{name: "retention to latest", initialOffset: sarama.OffsetNewest, current: 5, wantTarget: 20, wantRepair: true},
+		{name: "log truncation", initialOffset: sarama.OffsetNewest, current: 25, wantTarget: 20, wantRepair: true},
+		{name: "valid", initialOffset: sarama.OffsetNewest, current: 15},
+		{name: "fresh group to latest", initialOffset: sarama.OffsetNewest, current: sarama.OffsetNewest, wantTarget: 20, wantRepair: true},
+		{name: "fresh group to oldest", initialOffset: sarama.OffsetOldest, current: sarama.OffsetOldest, wantTarget: 10, wantRepair: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			partition := &fakeManagedPartitionOffset{current: test.current}
+			manager := &fakeManagedGroupOffsets{partition: partition}
+			var committed []OffsetReset
+			repairer := &groupOffsetRepairer{
+				client: &fakeOffsetRepairClient{oldest: 10, newest: 20},
+				topics: []string{"detect-input"}, initialOffset: test.initialOffset,
+				openOffsets: func() (managedGroupOffsets, error) { return manager, nil },
+				commitOffsets: func(_ context.Context, offsets []OffsetReset) error {
+					committed = append([]OffsetReset(nil), offsets...)
+					return nil
+				},
+			}
+			events, err := repairer.Repair(context.Background())
+			if err != nil {
+				t.Fatalf("Repair() error = %v", err)
+			}
+			if test.wantRepair {
+				if len(events) != 1 || events[0].Topic != "detect-input" || events[0].Partition != 0 || events[0].Offset != test.wantTarget {
+					t.Fatalf("Repair() events = %#v, want offset %d", events, test.wantTarget)
+				}
+				if len(committed) != 1 || committed[0].Offset != test.wantTarget {
+					t.Fatalf("committed offsets = %#v, want %d", committed, test.wantTarget)
+				}
+			} else if len(events) != 0 || len(committed) != 0 {
+				t.Fatalf("Repair() events=%#v committed=%#v, want unchanged", events, committed)
+			}
+			if !manager.closed {
+				t.Fatal("Repair() did not close the offset manager")
+			}
+		})
+	}
+}
+
+func TestGroupOffsetResetCommitterRequiresBrokerAck(t *testing.T) {
+	t.Parallel()
+
+	response := &sarama.OffsetCommitResponse{Errors: map[string]map[int32]sarama.KError{
+		"detect-input": {0: sarama.ErrNoError},
+	}}
+	broker := &fakeOffsetBroker{response: response}
+	committer := &groupOffsetResetCommitter{coordinator: fakeCoordinator{broker: broker}, groupID: "alarmd-shadow"}
+	offsets := []OffsetReset{{Topic: "detect-input", Partition: 0, Offset: 20}}
+	if err := committer.Commit(context.Background(), offsets); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if broker.request.ConsumerGroupGeneration != sarama.GroupGenerationUndefined || broker.request.ConsumerID != "" {
+		t.Fatalf("Commit() group identity = %#v", broker.request)
+	}
+	committed, _, err := broker.request.Offset("detect-input", 0)
+	if err != nil || committed != 20 {
+		t.Fatalf("Commit() offset=%d error=%v, want 20", committed, err)
+	}
+
+	broker.response.Errors["detect-input"][0] = sarama.ErrNotCoordinatorForConsumer
+	if err := committer.Commit(context.Background(), offsets); err == nil {
+		t.Fatal("Commit() accepted a broker rejection")
+	}
+}
+
+type fakeOffsetRepairClient struct {
+	oldest int64
+	newest int64
+}
+
+func (c *fakeOffsetRepairClient) Partitions(string) ([]int32, error) { return []int32{0}, nil }
+
+func (c *fakeOffsetRepairClient) GetOffset(_ string, _ int32, selector int64) (int64, error) {
+	if selector == sarama.OffsetOldest {
+		return c.oldest, nil
+	}
+	return c.newest, nil
+}
+
+type fakeManagedGroupOffsets struct {
+	partition *fakeManagedPartitionOffset
+	closed    bool
+}
+
+func (m *fakeManagedGroupOffsets) ManagePartition(string, int32) (sarama.PartitionOffsetManager, error) {
+	return m.partition, nil
+}
+
+func (m *fakeManagedGroupOffsets) Close() error {
+	m.closed = true
+	return nil
+}
+
+type fakeManagedPartitionOffset struct {
+	current int64
+}
+
+func (p *fakeManagedPartitionOffset) NextOffset() (int64, string) { return p.current, "" }
+func (p *fakeManagedPartitionOffset) MarkOffset(offset int64, _ string) {
+	if offset > p.current {
+		p.current = offset
+	}
+}
+func (p *fakeManagedPartitionOffset) ResetOffset(offset int64, _ string) {
+	if offset <= p.current {
+		p.current = offset
+	}
+}
+func (p *fakeManagedPartitionOffset) Errors() <-chan *sarama.ConsumerError {
+	return make(chan *sarama.ConsumerError)
+}
+func (p *fakeManagedPartitionOffset) AsyncClose()  {}
+func (p *fakeManagedPartitionOffset) Close() error { return nil }

--- a/pkg/alarmd/kafka/service.go
+++ b/pkg/alarmd/kafka/service.go
@@ -48,6 +48,26 @@ type serviceHandler interface {
 
 type serviceHandlerFactory func(func(error)) (serviceHandler, error)
 
+// OffsetReset records one partition whose committed offset was repaired to a
+// retained broker offset before the next consumer-group session starts.
+type OffsetReset struct {
+	Topic     string
+	Partition int32
+	Offset    int64
+}
+
+// ConsumerDiagnostics exposes bounded recovery events without coupling the
+// reusable Kafka service to a logging or metrics implementation.
+type ConsumerDiagnostics struct {
+	OnOffsetReset func(OffsetReset)
+}
+
+func (d ConsumerDiagnostics) offsetReset(event OffsetReset) {
+	if d.OnOffsetReset != nil {
+		d.OnOffsetReset(event)
+	}
+}
+
 type Service struct {
 	topics       []string
 	group        consumerGroup
@@ -82,6 +102,10 @@ type Service struct {
 
 	cancelMu      sync.Mutex
 	cancelConsume context.CancelFunc
+	cycleCancel   context.CancelFunc
+	offsetReset   atomic.Bool
+	diagnostics   ConsumerDiagnostics
+	repairOffsets func(context.Context) ([]OffsetReset, error)
 
 	fatalOnce   sync.Once
 	fatalMu     sync.Mutex
@@ -120,6 +144,8 @@ func OpenService(cfg Config, newProcessor consumer.ProcessorFactory, drainTimeou
 	if err != nil {
 		return nil, errors.Join(err, group.Close(), client.Close())
 	}
+	service.diagnostics = cfg.Diagnostics
+	service.repairOffsets = newGroupOffsetRepairer(client, cfg.GroupID, []string{cfg.Topic}, saramaConfig.Consumer.Offsets.Initial).Repair
 	return service, nil
 }
 
@@ -330,9 +356,28 @@ func (s *Service) consumeLoop(ctx context.Context) error {
 		if s.firstFatal() != nil {
 			return nil
 		}
-		err := s.group.Consume(ctx, append([]string(nil), s.topics...), s.handler)
+		if s.repairOffsets != nil {
+			events, err := s.repairOffsets(ctx)
+			if err != nil {
+				return fmt.Errorf("kafka service: repair consumer offsets: %w", err)
+			}
+			for _, event := range events {
+				s.diagnostics.offsetReset(event)
+			}
+		}
+		cycleContext, cancelCycle := context.WithCancel(ctx)
+		s.setCycleCancel(cancelCycle)
+		if s.offsetReset.Load() {
+			cancelCycle()
+		}
+		err := s.group.Consume(cycleContext, append([]string(nil), s.topics...), s.handler)
+		cancelCycle()
+		s.setCycleCancel(nil)
 		if ctx.Err() != nil || s.closing.Load() || s.firstFatal() != nil {
 			return nil
+		}
+		if s.offsetReset.Swap(false) {
+			continue
 		}
 		if err != nil {
 			return fmt.Errorf("kafka service: consume group: %w", err)
@@ -360,19 +405,31 @@ func (s *Service) drainErrors(ready chan<- struct{}, done chan<- struct{}) {
 			return
 		}
 		if err != nil && !s.closing.Load() {
-			s.reportFatal(fmt.Errorf("kafka service: consumer group error: %w", err))
+			s.handleGroupError(err)
 		}
 	default:
 	}
 	close(ready)
 	for err := range errorsChannel {
 		if err != nil && !s.closing.Load() {
-			s.reportFatal(fmt.Errorf("kafka service: consumer group error: %w", err))
+			s.handleGroupError(err)
 		}
 	}
 	if !s.closing.Load() {
 		s.reportFatal(errErrorsChannelClosed)
 	}
+}
+
+func (s *Service) handleGroupError(err error) {
+	var consumerError *sarama.ConsumerError
+	if errors.As(err, &consumerError) &&
+		(errors.Is(consumerError.Err, sarama.ErrOffsetOutOfRange) ||
+			errors.Is(consumerError.Err, errComparatorSymbolicInitialOffset)) {
+		s.offsetReset.Store(true)
+		s.cancelCurrentCycle()
+		return
+	}
+	s.reportFatal(fmt.Errorf("kafka service: consumer group error: %w", err))
 }
 
 func (s *Service) reportFatal(err error) {
@@ -625,6 +682,21 @@ func (s *Service) setCancelConsume(cancel context.CancelFunc) {
 	s.cancelMu.Lock()
 	s.cancelConsume = cancel
 	s.cancelMu.Unlock()
+}
+
+func (s *Service) setCycleCancel(cancel context.CancelFunc) {
+	s.cancelMu.Lock()
+	s.cycleCancel = cancel
+	s.cancelMu.Unlock()
+}
+
+func (s *Service) cancelCurrentCycle() {
+	s.cancelMu.Lock()
+	cancel := s.cycleCancel
+	s.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }
 
 func (s *Service) cancelCurrentConsume() {

--- a/pkg/alarmd/kafka/service_test.go
+++ b/pkg/alarmd/kafka/service_test.go
@@ -12,6 +12,7 @@ package kafka
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -89,6 +90,76 @@ func TestServiceDrainsGroupErrorsBeforeConsume(t *testing.T) {
 	}
 	if snapshot := service.LifecycleSnapshot(); snapshot.FatalTotal != 1 || snapshot.DrainTotal[lifecycle.DrainSuccess] != 1 {
 		t.Fatalf("fatal shutdown snapshot = %+v, want one fatal and successful drain", snapshot)
+	}
+}
+
+func TestServiceRecoversOffsetOutOfRangeWithoutFatalExit(t *testing.T) {
+	t.Parallel()
+
+	var consumeCalls atomic.Int32
+	group := newFakeConsumerGroup(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+		consumeCalls.Add(1)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	recovered := make(chan OffsetReset, 1)
+	service := newTestService(t, group, &fakeServiceClient{}, noopProcessorFactory(), fakeSyncOffsetCommitter{}, time.Second)
+	var repairCalls atomic.Int32
+	service.repairOffsets = func(context.Context) ([]OffsetReset, error) {
+		if repairCalls.Add(1) == 1 {
+			return nil, nil
+		}
+		return []OffsetReset{{Topic: "detect-input", Partition: 2, Offset: 99}}, nil
+	}
+	service.diagnostics = ConsumerDiagnostics{OnOffsetReset: func(event OffsetReset) { recovered <- event }}
+	runContext, cancelRun := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- service.Run(runContext) }()
+	waitFor(t, func() bool { return consumeCalls.Load() == 1 }, "first Consume call")
+	groupErrorChannel(group) <- &sarama.ConsumerError{Topic: "detect-input", Partition: 2, Err: sarama.ErrOffsetOutOfRange}
+	waitFor(t, func() bool { return consumeCalls.Load() >= 2 }, "recovered Consume call")
+	select {
+	case event := <-recovered:
+		if event.Topic != "detect-input" || event.Partition != 2 || event.Offset != 99 {
+			t.Fatalf("offset reset = %#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("offset reset diagnostic was not recorded")
+	}
+	cancelRun()
+	if err := waitError(t, done); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if snapshot := service.LifecycleSnapshot(); snapshot.FatalTotal != 0 {
+		t.Fatalf("offset recovery snapshot = %+v, want no fatal", snapshot)
+	}
+}
+
+func TestServiceRetriesRepairWhenClaimFallsBackToSymbolicOffset(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(
+		t,
+		newFakeConsumerGroup(nil),
+		&fakeServiceClient{},
+		noopProcessorFactory(),
+		fakeSyncOffsetCommitter{},
+		time.Second,
+	)
+	cycleCancelled := make(chan struct{})
+	service.setCycleCancel(func() { close(cycleCancelled) })
+	service.handleGroupError(&sarama.ConsumerError{
+		Topic: "detect-input", Partition: 0,
+		Err: fmt.Errorf("claim setup: %w", errComparatorSymbolicInitialOffset),
+	})
+
+	select {
+	case <-cycleCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("symbolic offset fallback did not restart the consume cycle")
+	}
+	if !service.offsetReset.Load() || service.firstFatal() != nil {
+		t.Fatalf("offsetReset=%v fatal=%v, want recoverable retry", service.offsetReset.Load(), service.firstFatal())
 	}
 }
 

--- a/pkg/alarmd/observability/log.go
+++ b/pkg/alarmd/observability/log.go
@@ -28,15 +28,19 @@ const (
 	StageComparisonACK   = "comparison_audit_ack"
 	StageCapacityDrop    = "capacity_drop"
 	StageCoverageRelease = "coverage_release"
+	StageCoverageReset   = "coverage_reset"
+	StageOffsetReset     = "offset_reset"
 
-	ResultStarted   = "started"
-	ResultBrokerACK = "broker_ack"
-	ResultSuccess   = "success"
-	ResultFailed    = "failed"
-	ResultSkipped   = "skipped"
-	ResultTimeout   = "timeout"
-	ResultDropped   = "dropped"
-	ResultReleased  = "released"
+	ResultStarted     = "started"
+	ResultBrokerACK   = "broker_ack"
+	ResultSuccess     = "success"
+	ResultFailed      = "failed"
+	ResultSkipped     = "skipped"
+	ResultTimeout     = "timeout"
+	ResultDropped     = "dropped"
+	ResultReleased    = "released"
+	ResultRecovered   = "recovered"
+	ResultInvalidated = "invalidated"
 )
 
 // Logger emits the fixed event envelope used by alarmd. Metric labels remain


### PR DESCRIPTION
让全量 Shadow 对 Go Detect→Trigger 的最终结果负责：Comparator 以 DetectInput 为覆盖分母，只发布终态 Audit；fresh group 固化数值 offset，offset 越界和 claim 回退可恢复；重平衡显式记录 coverage reset；保留有界容量和资源诊断。Go 全量测试及 Comparator/Kafka race 测试通过。