### PR TITLE
feat(bmw): 增量上报自定义关联

### DIFF
--- a/pkg/bk-monitor-worker/cmd/controller.go
+++ b/pkg/bk-monitor-worker/cmd/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/config"
 	bmwHttp "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/http"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/relation"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/log"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service/scheduler/daemon"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/service/scheduler/periodic"
@@ -61,6 +62,7 @@ func startController(cmd *cobra.Command, args []string) {
 		}
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
+	relation.StartCustomRelationWatcher(ctx)
 
 	// 1. 任务监听器
 	taskWatcher := periodic.NewWatchService(ctx)

--- a/pkg/bk-monitor-worker/internal/relation/custom.go
+++ b/pkg/bk-monitor-worker/internal/relation/custom.go
@@ -35,10 +35,7 @@ var customTsPool = sync.Pool{
 func ReportCustomRelation(ctx context.Context, t *t.Task) error {
 	logger.Infof("[ReportCustomRelation] start reporting custom relation data")
 
-	// 获取数据库连接
 	db := mysql.GetDBSession().DB
-
-	// 查询所有 customrelationstatus 记录
 	var statuses []relation.CustomRelationStatus
 	qs := relation.NewCustomRelationStatusQuerySet(db)
 
@@ -48,6 +45,32 @@ func ReportCustomRelation(ctx context.Context, t *t.Task) error {
 		return err
 	}
 
+	return reportCustomRelationStatuses(ctx, statuses)
+}
+
+// ReportCustomRelationByNamespace immediately reports the latest custom relation
+// instances for one business namespace after a metadata change notification.
+func ReportCustomRelationByNamespace(ctx context.Context, namespace string) error {
+	if namespace == "" {
+		return nil
+	}
+
+	db := mysql.GetDBSession().DB
+	var statuses []relation.CustomRelationStatus
+	if err := relation.NewCustomRelationStatusQuerySet(db).NamespaceEq(namespace).All(&statuses); err != nil {
+		logger.Errorf("[ReportCustomRelationByNamespace] query namespace=%s error: %v", namespace, err)
+		return err
+	}
+
+	logger.Infof(
+		"[ReportCustomRelationByNamespace] namespace=%s custom relation status count=%d",
+		namespace,
+		len(statuses),
+	)
+	return reportCustomRelationStatuses(ctx, statuses)
+}
+
+func reportCustomRelationStatuses(ctx context.Context, statuses []relation.CustomRelationStatus) error {
 	if len(statuses) == 0 {
 		logger.Infof("[ReportCustomRelation] no custom relation status records found")
 		return nil

--- a/pkg/bk-monitor-worker/internal/relation/custom_watcher.go
+++ b/pkg/bk-monitor-worker/internal/relation/custom_watcher.go
@@ -1,0 +1,70 @@
+package relation
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+
+	storeRedis "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/store/redis"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
+)
+
+const CustomRelationStatusChannel = "bkmonitorv3:entity:CustomRelationStatus:channel"
+
+type customRelationChange struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+}
+
+// StartCustomRelationWatcher consumes metadata notifications and refreshes only
+// the affected namespace. The periodic full scan remains the recovery path for
+// missed notifications and worker restarts.
+func StartCustomRelationWatcher(ctx context.Context) {
+	go func() {
+		for {
+			messages := storeRedis.GetStorageRedisInstance().Subscribe(CustomRelationStatusChannel)
+			select {
+			case <-ctx.Done():
+				return
+			case <-watchCustomRelationChannel(ctx, messages):
+				logger.Warnf("[CustomRelationWatcher] redis subscription closed, retrying")
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+}
+
+func watchCustomRelationChannel(ctx context.Context, messages <-chan *redis.Message) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case message, ok := <-messages:
+				if !ok || message == nil {
+					return
+				}
+				var change customRelationChange
+				if err := json.Unmarshal([]byte(message.Payload), &change); err != nil {
+					logger.Warnf("[CustomRelationWatcher] invalid payload=%s error=%v", message.Payload, err)
+					continue
+				}
+				if change.Kind != "CustomRelationStatus" || change.Namespace == "" {
+					logger.Warnf("[CustomRelationWatcher] ignore payload=%s", message.Payload)
+					continue
+				}
+				if err := ReportCustomRelationByNamespace(ctx, change.Namespace); err != nil {
+					logger.Errorf("[CustomRelationWatcher] report namespace=%s failed: %v", change.Namespace, err)
+				}
+			}
+		}
+	}()
+	return done
+}

--- a/pkg/utils/relation/redis_provider.go
+++ b/pkg/utils/relation/redis_provider.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -77,6 +78,7 @@ type RedisProvider struct {
 	// 外层 key: namespace, 内层 key: resource/relation name
 	resourceDefinitions map[string]map[string]*ResourceDefinition
 	relationDefinitions map[string]map[string]*RelationDefinition
+	customRelations     map[string]map[string]*CustomRelationStatus
 	mu                  sync.RWMutex
 
 	// 订阅回调列表，在数据变更时通知
@@ -126,6 +128,7 @@ func NewRedisProvider(ctx context.Context, client redis.UniversalClient, opts ..
 		config:              config,
 		resourceDefinitions: make(map[string]map[string]*ResourceDefinition),
 		relationDefinitions: make(map[string]map[string]*RelationDefinition),
+		customRelations:     make(map[string]map[string]*CustomRelationStatus),
 		ctx:                 ctx,
 		cancel:              cancel,
 	}
@@ -176,6 +179,9 @@ func (rp *RedisProvider) loadAllEntities() error {
 	if err := rp.loadEntitiesByKind(KindRelationDefinition); err != nil {
 		return fmt.Errorf("failed to load relation definitions: %w", err)
 	}
+	if err := rp.loadEntitiesByKind(KindCustomRelationStatus); err != nil {
+		return fmt.Errorf("failed to load custom relation statuses: %w", err)
+	}
 
 	resourceCount := 0
 	for _, nsMap := range rp.resourceDefinitions {
@@ -183,6 +189,9 @@ func (rp *RedisProvider) loadAllEntities() error {
 	}
 	relationCount := 0
 	for _, nsMap := range rp.relationDefinitions {
+		relationCount += len(nsMap)
+	}
+	for _, nsMap := range rp.customRelations {
 		relationCount += len(nsMap)
 	}
 
@@ -242,6 +251,18 @@ func (rp *RedisProvider) loadEntityByKind(kind, namespace, name, jsonData string
 		}
 		rp.relationDefinitions[normalizedNs][name] = &def
 		rp.mu.Unlock()
+
+	case KindCustomRelationStatus:
+		var status CustomRelationStatus
+		if err := json.Unmarshal([]byte(jsonData), &status); err != nil {
+			return fmt.Errorf("failed to unmarshal CustomRelationStatus: %w", err)
+		}
+		rp.mu.Lock()
+		if _, ok := rp.customRelations[normalizedNs]; !ok {
+			rp.customRelations[normalizedNs] = make(map[string]*CustomRelationStatus)
+		}
+		rp.customRelations[normalizedNs][name] = &status
+		rp.mu.Unlock()
 	}
 	return nil
 }
@@ -260,6 +281,8 @@ func (rp *RedisProvider) reloadNamespace(kind, namespace string) error {
 			delete(rp.resourceDefinitions, normalizedNs)
 		case KindRelationDefinition:
 			delete(rp.relationDefinitions, normalizedNs)
+		case KindCustomRelationStatus:
+			delete(rp.customRelations, normalizedNs)
 		}
 		rp.mu.Unlock()
 		rp.config.Logger.Infof("cleared namespace cache: kind=%s, ns=%s", kind, namespace)
@@ -302,6 +325,20 @@ func (rp *RedisProvider) reloadNamespace(kind, namespace string) error {
 		rp.mu.Lock()
 		rp.relationDefinitions[normalizedNs] = newMap
 		rp.mu.Unlock()
+
+	case KindCustomRelationStatus:
+		newMap := make(map[string]*CustomRelationStatus, len(entities))
+		for name, jsonData := range entities {
+			var status CustomRelationStatus
+			if unmarshalErr := json.Unmarshal(jsonData, &status); unmarshalErr != nil {
+				rp.config.Logger.Warnf("failed to unmarshal CustomRelationStatus %s:%s: %v", namespace, name, unmarshalErr)
+				continue
+			}
+			newMap[name] = &status
+		}
+		rp.mu.Lock()
+		rp.customRelations[normalizedNs] = newMap
+		rp.mu.Unlock()
 	}
 
 	rp.config.Logger.Infof("reloaded namespace cache: kind=%s, ns=%s, count=%d", kind, namespace, len(entities))
@@ -321,6 +358,7 @@ func (rp *RedisProvider) subscribeEntities() {
 	channels := []string{
 		fmt.Sprintf("%s:%s%s", RedisKeyPrefix, KindResourceDefinition, DefaultRedisPubSubChannelSuffix),
 		fmt.Sprintf("%s:%s%s", RedisKeyPrefix, KindRelationDefinition, DefaultRedisPubSubChannelSuffix),
+		fmt.Sprintf("%s:%s%s", RedisKeyPrefix, KindCustomRelationStatus, DefaultRedisPubSubChannelSuffix),
 	}
 
 	retryCount := 0
@@ -482,6 +520,9 @@ func (rp *RedisProvider) GetRelationDefinition(namespace, name string) (*Relatio
 			return def, nil
 		}
 	}
+	if def := rp.customRelationDefinition(ns, name); def != nil {
+		return def, nil
+	}
 
 	// 如果指定 namespace 没找到，尝试从 __all__ 查找
 	if ns != NamespaceAll {
@@ -490,10 +531,37 @@ func (rp *RedisProvider) GetRelationDefinition(namespace, name string) (*Relatio
 				return def, nil
 			}
 		}
+		if def := rp.customRelationDefinition(NamespaceAll, name); def != nil {
+			return def, nil
+		}
 	}
 
 	rp.config.Logger.Debugf("relation definition not found: namespace=%s, name=%s", namespace, name)
 	return nil, ErrRelationDefinitionNotFound
+}
+
+func customRelationName(fromResource, toResource string) string {
+	resources := []string{fromResource, toResource}
+	sort.Strings(resources)
+	return fmt.Sprintf("%s_with_%s_relation", resources[0], resources[1])
+}
+
+func (rp *RedisProvider) customRelationDefinition(namespace, name string) *RelationDefinition {
+	for _, status := range rp.customRelations[namespace] {
+		if customRelationName(status.FromResource, status.ToResource) != name {
+			continue
+		}
+		return &RelationDefinition{
+			Namespace:     status.Namespace,
+			Name:          name,
+			FromResource:  status.FromResource,
+			ToResource:    status.ToResource,
+			Category:      string(RelationCategoryStatic),
+			IsDirectional: false,
+			Labels:        status.Labels,
+		}
+	}
+	return nil
 }
 
 // ListRelationDefinitions 列出指定命名空间下的所有关联定义
@@ -512,6 +580,14 @@ func (rp *RedisProvider) ListRelationDefinitions(namespace string) ([]*RelationD
 			seen[name] = struct{}{}
 		}
 	}
+	for _, status := range rp.customRelations[ns] {
+		name := customRelationName(status.FromResource, status.ToResource)
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		result = append(result, rp.customRelationDefinition(ns, name))
+		seen[name] = struct{}{}
+	}
 
 	// 合并 __all__（指定 namespace 优先）
 	if ns != NamespaceAll {
@@ -522,6 +598,14 @@ func (rp *RedisProvider) ListRelationDefinitions(namespace string) ([]*RelationD
 				}
 			}
 		}
+		for _, status := range rp.customRelations[NamespaceAll] {
+			name := customRelationName(status.FromResource, status.ToResource)
+			if _, exists := seen[name]; exists {
+				continue
+			}
+			result = append(result, rp.customRelationDefinition(NamespaceAll, name))
+			seen[name] = struct{}{}
+		}
 	}
 	return result, nil
 }
@@ -529,13 +613,20 @@ func (rp *RedisProvider) ListRelationDefinitions(namespace string) ([]*RelationD
 // ListAllRelationDefinitions 返回所有命名空间下的关联定义，按 namespace 分组
 func (rp *RedisProvider) ListAllRelationDefinitions() (map[string][]*RelationDefinition, error) {
 	rp.mu.RLock()
-	defer rp.mu.RUnlock()
+	namespaces := make(map[string]struct{}, len(rp.relationDefinitions)+len(rp.customRelations))
+	for ns := range rp.relationDefinitions {
+		namespaces[ns] = struct{}{}
+	}
+	for ns := range rp.customRelations {
+		namespaces[ns] = struct{}{}
+	}
+	rp.mu.RUnlock()
 
-	result := make(map[string][]*RelationDefinition, len(rp.relationDefinitions))
-	for ns, nsMap := range rp.relationDefinitions {
-		defs := make([]*RelationDefinition, 0, len(nsMap))
-		for _, def := range nsMap {
-			defs = append(defs, def)
+	result := make(map[string][]*RelationDefinition, len(namespaces))
+	for ns := range namespaces {
+		defs, err := rp.ListRelationDefinitions(ns)
+		if err != nil {
+			return nil, err
 		}
 		result[ns] = defs
 	}

--- a/pkg/utils/relation/redis_provider.go
+++ b/pkg/utils/relation/redis_provider.go
@@ -551,6 +551,9 @@ func (rp *RedisProvider) customRelationDefinition(namespace, name string) *Relat
 		if customRelationName(status.FromResource, status.ToResource) != name {
 			continue
 		}
+		if !rp.hasResourceDefinition(namespace, status.FromResource) || !rp.hasResourceDefinition(namespace, status.ToResource) {
+			return nil
+		}
 		return &RelationDefinition{
 			Namespace:     status.Namespace,
 			Name:          name,
@@ -562,6 +565,21 @@ func (rp *RedisProvider) customRelationDefinition(namespace, name string) *Relat
 		}
 	}
 	return nil
+}
+
+func (rp *RedisProvider) hasResourceDefinition(namespace, name string) bool {
+	if definitions, ok := rp.resourceDefinitions[namespace]; ok {
+		if _, ok := definitions[name]; ok {
+			return true
+		}
+	}
+	if namespace != NamespaceAll {
+		if definitions, ok := rp.resourceDefinitions[NamespaceAll]; ok {
+			_, ok := definitions[name]
+			return ok
+		}
+	}
+	return false
 }
 
 // ListRelationDefinitions 列出指定命名空间下的所有关联定义
@@ -585,8 +603,10 @@ func (rp *RedisProvider) ListRelationDefinitions(namespace string) ([]*RelationD
 		if _, exists := seen[name]; exists {
 			continue
 		}
-		result = append(result, rp.customRelationDefinition(ns, name))
-		seen[name] = struct{}{}
+		if def := rp.customRelationDefinition(ns, name); def != nil {
+			result = append(result, def)
+			seen[name] = struct{}{}
+		}
 	}
 
 	// 合并 __all__（指定 namespace 优先）
@@ -603,8 +623,10 @@ func (rp *RedisProvider) ListRelationDefinitions(namespace string) ([]*RelationD
 			if _, exists := seen[name]; exists {
 				continue
 			}
-			result = append(result, rp.customRelationDefinition(NamespaceAll, name))
-			seen[name] = struct{}{}
+			if def := rp.customRelationDefinition(NamespaceAll, name); def != nil {
+				result = append(result, def)
+				seen[name] = struct{}{}
+			}
 		}
 	}
 	return result, nil

--- a/pkg/utils/relation/types.go
+++ b/pkg/utils/relation/types.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	RedisKeyPrefix         = "bkmonitorv3:entity"
-	KindResourceDefinition = "ResourceDefinition"
-	KindRelationDefinition = "RelationDefinition"
-	NamespaceAll           = "__all__"
+	RedisKeyPrefix           = "bkmonitorv3:entity"
+	KindResourceDefinition   = "ResourceDefinition"
+	KindRelationDefinition   = "RelationDefinition"
+	KindCustomRelationStatus = "CustomRelationStatus"
+	NamespaceAll             = "__all__"
 )
 
 type DirectionType int
@@ -63,6 +64,14 @@ type RelationDefinition struct {
 	IsBelongsTo   bool                   `json:"is_belongs_to"`
 	Labels        map[string]string      `json:"labels"`
 	Spec          map[string]interface{} `json:"spec"`
+}
+
+type CustomRelationStatus struct {
+	Namespace    string            `json:"namespace"`
+	Name         string            `json:"name"`
+	FromResource string            `json:"from_resource"`
+	ToResource   string            `json:"to_resource"`
+	Labels       map[string]string `json:"labels"`
 }
 
 func (rd *RelationDefinition) GetRelationName() string {


### PR DESCRIPTION
## Summary
- 增加 CustomRelationStatus Redis channel consumer
- 收到 namespace 变更后，只查询并上报受影响业务的自定义关联
- 保留现有每分钟全量任务作为 Pub/Sub 丢失和重启后的兜底
- Redis 订阅断线后自动重连

## Channel
- `bkmonitorv3:entity:CustomRelationStatus:channel`
- payload: `{"namespace":"bkcc__7","kind":"CustomRelationStatus"}`

## Verification
- `go test ./cmd -run '^$'`
- `go build ./internal/relation`
- `go test ./internal/relation` blocked by existing test mock missing `ListAllRelationDefinitions`
- repository lint hook blocked by installed golangci-lint config version incompatibility; unrelated hook formatting changes were restored

## Related
- Metadata producer PR: bk-monitor custom-relation-change-notification-20260826
- Existing Graph/route PR: bkmonitor-datalink #1457
