### PR TITLE
feat: 修复自定义指标中文维度展示为 base62 编码 --story=137662640

### DIFF
--- a/pkg/bk-monitor-worker/go.mod
+++ b/pkg/bk-monitor-worker/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c
 	github.com/jinzhu/gorm v1.9.16
 	github.com/josephburnett/jd v1.7.1
+	github.com/jxskiss/base62 v1.1.0
 	github.com/minio/highwayhash v1.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/panjf2000/ants/v2 v2.10.0

--- a/pkg/bk-monitor-worker/go.sum
+++ b/pkg/bk-monitor-worker/go.sum
@@ -399,6 +399,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/jxskiss/base62 v1.1.0 h1:A5zbF8v8WXx2xixnAKD2w+abC+sIzYJX+nxmhA6HWFw=
+github.com/jxskiss/base62 v1.1.0/go.mod h1:HhWAlUXvxKThfOlZbcuFzsqwtF5TcqS9ru3y5GfjWAc=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=

--- a/pkg/bk-monitor-worker/internal/metadata/service/timeseriesscope.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/timeseriesscope.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/internal/metadata/models/customreport"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/store/mysql"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/stringx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
 
@@ -208,6 +209,18 @@ func collectMetricsAndDimensions(svc *TimeSeriesGroupSvc, metricInfoList []map[s
 	return scopeNameToMetrics, scopeNameToDimensions, nil
 }
 
+// buildNewDimensionConfig : 新发现维度的初始配置
+//
+// SDK 会把含中文等非法字符的维度名编码成 base62 标识符上报，查询必须继续使用编码后的名字，
+// 这里把解码出的原始名回填成别名，让各展示入口都能拿到可读的维度名。
+func buildNewDimensionConfig(dimension string) map[string]any {
+	originalName := stringx.DecodeIdentifier(dimension)
+	if originalName == dimension {
+		return map[string]any{}
+	}
+	return map[string]any{"alias": originalName}
+}
+
 // doBulkRefreshTSScopes : 批量刷新 TimeSeriesScope
 func doBulkRefreshTSScopes(groupID uint, scopeNameToDimensions map[string]*scopeDimensionInfo) error {
 	db := mysql.GetDBSession().DB
@@ -238,7 +251,7 @@ func doBulkRefreshTSScopes(groupID uint, scopeNameToDimensions map[string]*scope
 			newDims := false
 			for _, dim := range dimensions {
 				if _, has := dimensionConfig[dim]; !has {
-					dimensionConfig[dim] = map[string]any{}
+					dimensionConfig[dim] = buildNewDimensionConfig(dim)
 					newDims = true
 				}
 			}
@@ -250,7 +263,7 @@ func doBulkRefreshTSScopes(groupID uint, scopeNameToDimensions map[string]*scope
 		} else {
 			dimensionConfig := make(map[string]any)
 			for _, dim := range dimensions {
-				dimensionConfig[dim] = map[string]any{}
+				dimensionConfig[dim] = buildNewDimensionConfig(dim)
 			}
 			configJSON, _ := json.Marshal(dimensionConfig)
 			autoRulesJSON, _ := json.Marshal([]string{})

--- a/pkg/bk-monitor-worker/utils/stringx/base62.go
+++ b/pkg/bk-monitor-worker/utils/stringx/base62.go
@@ -1,0 +1,56 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package stringx
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/jxskiss/base62"
+)
+
+// Base62Prefix 上报 SDK 对非法字段名编码后使用的前缀
+const Base62Prefix = "base62"
+
+// DecodeIdentifier 还原上报 SDK 编码前的原始字段名，非编码字段名原样返回。
+//
+// SDK 会把不满足 [a-zA-Z0-9_] 的指标名、维度名用 base62 编码成带 base62 前缀的标识符，存储与查询都
+// 使用编码后的名字，原始名需要在展示前解码还原。SDK 仅以前缀区分编码字段，用户把字段命名成 base62xxx
+// 时同样会命中前缀，这类字段解出来是乱码，因此要求解码结果可打印，否则视为未编码。
+func DecodeIdentifier(name string) string {
+	if !strings.HasPrefix(name, Base62Prefix) {
+		return name
+	}
+
+	decoded, err := base62.Decode([]byte(name[len(Base62Prefix):]))
+	if err != nil {
+		return name
+	}
+
+	original := string(decoded)
+	if original == "" || original == name || !isPrintable(original) {
+		return name
+	}
+	return original
+}
+
+// isPrintable 解码结果必须是合法 UTF-8 且全部可打印，否则说明这不是 SDK 编码出来的名字
+func isPrintable(s string) bool {
+	if !utf8.ValidString(s) {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsPrint(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/bk-monitor-worker/utils/stringx/base62_test.go
+++ b/pkg/bk-monitor-worker/utils/stringx/base62_test.go
@@ -1,0 +1,51 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package stringx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		// 取自 SDK eco/go/sdk/base/model/name_format_test.go，保证与上报侧编码一致
+		{"base62Hap5tiL5", "中文"},
+		{"base62pUCK", "(%)"},
+		{"base62pUCKgcojnjKlnf3eSOI1B3Y", "cpu 使用率 (%)"},
+		{"base629uZ5tiL5tQ3clRH", "test-中国"},
+		{"base629uZ5tiL5tEG", "a-中国"},
+		{
+			"base62H645oS55ftXyxczzDc0zJUzzrs3yddzzBpFQyN00P1RzjczzP0SzbFXyBpFQus1ybEyyr8V0XsWzB",
+			"测试名字 - 中文监控项 - 目录的磁盘使用率",
+		},
+		// 满足 [a-zA-Z0-9_] 的名字 SDK 不会编码，不能被改写
+		{"namespace", "namespace"},
+		{"service_name", "service_name"},
+		{"skuId", "skuId"},
+		{"3rd_party", "3rd_party"},
+		{"", ""},
+		// SDK 只按前缀区分编码字段，用户命名成 base62xxx 时解出来是乱码，需保持原样
+		{"base62", "base62"},
+		{"base62_test", "base62_test"},
+		{"base62abc", "base62abc"},
+		{"base62Id", "base62Id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DecodeIdentifier(tt.name))
+		})
+	}
+}


### PR DESCRIPTION
close #1010158081137662640

## 变更

- 上报 SDK 会把不满足 `[a-zA-Z0-9_]` 的维度名（中文、`.`、`-`）编码成 base62 前缀的标识符，页面展示的是编码后的名字。
- 维度发现时把解码出的原始名回填成别名，查询仍使用编码后的字段名。与 bk-monitor 侧 Python 实现对齐。
- 解码复用上报 SDK 同款 `github.com/jxskiss/base62`；解码结果非可打印时保持原样，避免误伤用户自己以 `base62` 开头命名的维度。