### PR TITLE
fix(alarmd): 修正全天策略并增加配置预检 --story=137617592

### DIFF
--- a/pkg/alarmd/cmd/alarmd/main.go
+++ b/pkg/alarmd/cmd/alarmd/main.go
@@ -51,12 +51,17 @@ func runWithDependencies(
 	flags := flag.NewFlagSet("alarmd", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	configPath := flags.String("config", "", "path to alarmd YAML configuration")
+	checkConfig := flags.Bool("check-config", false, "validate configuration and exit")
 	showVersion := flags.Bool("version", false, "print build information and exit")
 	if err := flags.Parse(args); err != nil {
 		return 2
 	}
 	if flags.NArg() != 0 {
 		fmt.Fprintf(stderr, "unexpected arguments: %v\n", flags.Args())
+		return 2
+	}
+	if *showVersion && *checkConfig {
+		fmt.Fprintln(stderr, "--version and --check-config cannot be used together")
 		return 2
 	}
 	if *showVersion {
@@ -68,6 +73,9 @@ func runWithDependencies(
 	if err != nil {
 		fmt.Fprintf(stderr, "load configuration: %v\n", err)
 		return 1
+	}
+	if *checkConfig {
+		return 0
 	}
 
 	recorder := metric.NewRecorder(metric.BuildInfo{

--- a/pkg/alarmd/cmd/alarmd/main_test.go
+++ b/pkg/alarmd/cmd/alarmd/main_test.go
@@ -39,6 +39,62 @@ func TestRunPrintsVersionWithoutLoadingConfiguration(t *testing.T) {
 	}
 }
 
+func TestRunChecksConfigurationWithoutStartingApplication(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "alarmd.yaml")
+	if err := os.WriteFile(path, []byte(validApplicationYAML()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	want := errors.New("application must not start")
+	dependencies := applicationDependencies{
+		openBundle: func(context.Context, config.Config, *metric.Recorder, *observability.Logger) (*applicationBundle, error) {
+			return nil, want
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWithDependencies(
+		context.Background(), []string{"--check-config", "--config", path}, &stdout, &stderr, dependencies,
+	)
+	if code != 0 {
+		t.Fatalf("runWithDependencies() code = %d, stderr = %q", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), want.Error()) {
+		t.Fatalf("runWithDependencies() started application: %q", stderr.String())
+	}
+}
+
+func TestRunCheckConfigurationRejectsUnknownField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "alarmd.yaml")
+	contents := validApplicationYAML() + "unknown_field: true\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run(context.Background(), []string{"--check-config", "--config", path}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "field unknown_field not found") {
+		t.Fatalf("run() stderr = %q, want strict field error", stderr.String())
+	}
+}
+
+func TestRunRejectsConflictingTerminalFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run(context.Background(), []string{"--version", "--check-config"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cannot be used together") {
+		t.Fatalf("run() stderr = %q, want flag conflict", stderr.String())
+	}
+}
+
 func TestRunRejectsOwnerConfiguration(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "alarmd.yaml")
 	if err := os.WriteFile(path, []byte("mode: owner\n"), 0o600); err != nil {

--- a/pkg/alarmd/strategy/effective_time.go
+++ b/pkg/alarmd/strategy/effective_time.go
@@ -243,6 +243,10 @@ func compileEffectiveTimeRequirement(uptime *uptimeConfigV1, timezoneRef string)
 		if err != nil {
 			return EffectiveTimeRequirement{}, err
 		}
+		if len(active) == 0 && len(inactive) == 0 && len(ranges) == 1 &&
+			ranges[0].startMinute == 0 && ranges[0].endMinute == 24*60-1 {
+			ranges = nil
+		}
 		if len(ranges) > 0 || len(active) > 0 || len(inactive) > 0 {
 			if timezoneRef != "BUSINESS_LOCAL" {
 				return EffectiveTimeRequirement{}, errors.New("effective time: timezone_ref must be BUSINESS_LOCAL")

--- a/pkg/alarmd/strategy/effective_time_test.go
+++ b/pkg/alarmd/strategy/effective_time_test.go
@@ -60,6 +60,36 @@ func TestCompilerCompilesEffectiveTimeRequirements(t *testing.T) {
 	}
 }
 
+func TestCompilerCanonicalizesNoCalendarFullDayUptimeToAlways(t *testing.T) {
+	compiler := newTestCompiler(t)
+	want := mustCompilePlan(t, compiler, validPlan()).Levels()[0].EffectiveTimeRequirement()
+	tests := []struct {
+		name       string
+		timeRanges []any
+	}{
+		{name: "empty ranges", timeRanges: []any{}},
+		{name: "full day range", timeRanges: []any{map[string]any{"start": "00:00", "end": "23:59"}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plan := validPlan()
+			plan.StrategyIR.Levels[0].TriggerPlan.Config = triggerConfigWithUptime("BUSINESS_LOCAL", map[string]any{
+				"time_ranges":      test.timeRanges,
+				"active_calendars": []any{},
+				"calendars":        []any{},
+			})
+			requirement := mustCompilePlan(t, compiler, plan).Levels()[0].EffectiveTimeRequirement()
+			if requirement.Kind() != EffectiveTimeAlways {
+				t.Fatalf("effective-time kind = %q, want %q", requirement.Kind(), EffectiveTimeAlways)
+			}
+			if requirement.Digest() != want.Digest() {
+				t.Fatalf("ALWAYS digest = %q, want %q", requirement.Digest(), want.Digest())
+			}
+		})
+	}
+}
+
 func TestCompilerIncludesTimeRangeContentInEffectiveTimeDigest(t *testing.T) {
 	compiler := newTestCompiler(t)
 	first := validPlan()


### PR DESCRIPTION
## 背景

alarmd 一期 v2 首次发布前发现两个明确问题：平台常见的全天 uptime 会被编译为 STATIC_SCHEDULE，在 EffectiveTime Fact 尚未接入时冻结为 UNKNOWN；历史上旧 YAML 字段也曾直接导致新镜像启动失败。

## 改动

- 无日历的空时段或 00:00-23:59 统一编译为 ALWAYS。
- 新增无副作用 `alarmd --check-config --config <path>`，严格加载并校验 YAML 后退出。
- `--check-config` 不连接 Kafka、Redis 或 HTTP；自定义时段与日历语义保持不变。

## 验证

- `cd pkg/alarmd && go test -count=1 ./...`
- `cd pkg/alarmd && go vet ./...`
- `git diff --check upstream/master..HEAD`

## 边界

本 PR 不实现 EffectiveTime Fact Refresher。非默认时段/日历策略继续明确进入 UNKNOWN 覆盖缺口，不误判，也不作为本轮全量等价结论。