### PR TITLE
fix: 修复 64KB 页进程内存采集偏低问题

### DIFF
--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf.go
@@ -132,11 +132,6 @@ func (p *procPerfMgr) getMem(pid int32) (*define.MemStat, error) {
 	}, nil
 }
 
-func (p *procPerfMgr) mem(pid int32) (gosigar.ProcMem, error) {
-	g := gosigar.ProcMem{}
-	return g, g.Get(int(pid))
-}
-
 func (p *procPerfMgr) getCPU(pid int32) (*define.CPUStat, error) {
 	p.mut.Lock()
 	defer p.mut.Unlock()

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_linux.go
@@ -14,6 +14,8 @@ package process
 import (
 	"os"
 
+	"github.com/elastic/gosigar"
+
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
 )
 
@@ -29,6 +31,10 @@ func (p *procPerfMgr) procFSReader() *procFSReader {
 		p.reader = newProcFSReader(hostProcRoot())
 	}
 	return p.reader.(*procFSReader)
+}
+
+func (p *procPerfMgr) mem(pid int32) (gosigar.ProcMem, error) {
+	return p.procFSReader().readMem(pid, uint64(os.Getpagesize()))
 }
 
 func hostProcRoot() string {

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_notlinux.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_notlinux.go
@@ -11,8 +11,17 @@
 
 package process
 
-import "github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+import (
+	"github.com/elastic/gosigar"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bkmonitorbeat/define"
+)
 
 func (p *procPerfMgr) getOneMetaData(pid int32) (define.ProcStat, error) {
 	return p.getOneMetaDataByGopsutil(pid)
+}
+
+func (p *procPerfMgr) mem(pid int32) (gosigar.ProcMem, error) {
+	g := gosigar.ProcMem{}
+	return g, g.Get(int(pid))
 }

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/perf_test.go
@@ -39,6 +39,25 @@ func TestGetProcState(t *testing.T) {
 	}
 }
 
+func TestParseProcStatmMemUsesRuntimePageSize(t *testing.T) {
+	statm := []byte("1199 576 42 1 2 3 4\n")
+
+	got, err := parseProcStatmMem(statm, 64*1024)
+	if err != nil {
+		t.Fatalf("parseProcStatmMem error: %v", err)
+	}
+
+	if got.Size != 1199*64*1024 {
+		t.Fatalf("size = %d, want %d", got.Size, 1199*64*1024)
+	}
+	if got.Resident != 576*64*1024 {
+		t.Fatalf("resident = %d, want %d", got.Resident, 576*64*1024)
+	}
+	if got.Share != 42*64*1024 {
+		t.Fatalf("share = %d, want %d", got.Share, 42*64*1024)
+	}
+}
+
 func TestProcFSReaderReadsStableMetaWithSingleBootTimeLookup(t *testing.T) {
 	root := t.TempDir()
 	writeLinuxProc(t, root, 101, "worker 1", "S", 1, 12345, "worker\x00--config\x00x", 1000)

--- a/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_mem.go
+++ b/pkg/bkmonitorbeat/tasks/processbeat/process/procfs_mem.go
@@ -1,0 +1,53 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package process
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/gosigar"
+)
+
+func (r *procFSReader) readMem(pid int32, pageSize uint64) (gosigar.ProcMem, error) {
+	contents, err := r.readFile(filepath.Join(r.procDir(pid), "statm"))
+	if err != nil {
+		return gosigar.ProcMem{}, err
+	}
+	return parseProcStatmMem(contents, pageSize)
+}
+
+func parseProcStatmMem(contents []byte, pageSize uint64) (gosigar.ProcMem, error) {
+	var ret gosigar.ProcMem
+	fields := strings.Fields(string(contents))
+	if len(fields) < 3 {
+		return ret, fmt.Errorf("invalid proc statm: %q", string(contents))
+	}
+
+	size, err := strconv.ParseUint(fields[0], 10, 64)
+	if err != nil {
+		return ret, err
+	}
+	rss, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return ret, err
+	}
+	share, err := strconv.ParseUint(fields[2], 10, 64)
+	if err != nil {
+		return ret, err
+	}
+
+	ret.Size = size * pageSize
+	ret.Resident = rss * pageSize
+	ret.Share = share * pageSize
+	return ret, nil
+}


### PR DESCRIPTION
## 背景

在 ARM 架构 64KB 页大小内核环境下，进程监控指标 `system.proc.mem_res` 与 `/proc/<pid>/status` 中 `VmRSS` 存在较大差异。排查发现原采集逻辑依赖 `gosigar` 读取 `/proc/<pid>/statm` 后固定按 4KB 页大小换算，导致进程物理内存被低估约 16 倍。

## 变更内容

- Linux 下进程内存采集改为读取 `HOST_PROC`/`/proc/<pid>/statm`
- 使用 `os.Getpagesize()` 获取运行时真实页大小，正确换算 `size/rss/share`
- 非 Linux 平台保留原 `gosigar` 采集逻辑
- 补充 64KB page size 场景的单元测试