### PR TITLE
feat: 修复自定义指标中文指标名展示为 base62 编码 --story=137847962

### DIFF
--- a/pkg/bk-monitor-worker/internal/metadata/service/timeseriesmetric.go
+++ b/pkg/bk-monitor-worker/internal/metadata/service/timeseriesmetric.go
@@ -23,8 +23,21 @@ import (
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/jsonx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/mapx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/slicex"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/bk-monitor-worker/utils/stringx"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/logger"
 )
+
+// buildNewMetricConfig : 新发现指标的初始配置
+//
+// SDK 会把含中文等非法字符的指标名编码成 base62 标识符上报，查询必须继续使用编码后的名字，
+// 这里把解码出的原始名回填成别名，让各展示入口都能拿到可读的指标名。
+func buildNewMetricConfig(fieldName string) map[string]any {
+	originalName := stringx.DecodeMetricIdentifier(fieldName)
+	if originalName == fieldName {
+		return map[string]any{}
+	}
+	return map[string]any{"alias": originalName}
+}
 
 // TimeSeriesMetricSvc time series metric service
 type TimeSeriesMetricSvc struct {
@@ -180,12 +193,14 @@ func (s *TimeSeriesMetricSvc) BulkCreateMetricsByKeys(bkTenantId string, metricM
 		}
 		tagListStr, _ := jsonx.MarshalString(tagList)
 		realTableId := fmt.Sprintf("%s.%s", strings.Split(tableId, ".")[0], fieldName)
+		fieldConfigStr, _ := jsonx.MarshalString(buildNewMetricConfig(fieldName))
 		tsm := customreport.TimeSeriesMetric{
 			GroupID:        groupId,
 			TableID:        realTableId,
 			FieldName:      fieldName,
 			FieldScope:     fieldScope,
 			TagList:        tagListStr,
+			FieldConfig:    fieldConfigStr,
 			LastModifyTime: time.Now(),
 			IsActive:       isActive,
 		}
@@ -300,8 +315,8 @@ func (s *TimeSeriesMetricSvc) BulkUpdateMetricsByKeys(bkTenantId string, metricM
 				tsm.ScopeID = uint(v)
 			}
 			// 与 Python 逻辑保持一致：指标从 disabled 状态恢复时，
-			// 除了重新分配 scope_id，还需要清空包含 disabled=true 的字段配置。
-			tsm.FieldConfig = "{}"
+			// 除了重新分配 scope_id，还需要重置包含 disabled=true 的字段配置。
+			tsm.FieldConfig, _ = jsonx.MarshalString(buildNewMetricConfig(tsm.FieldName))
 			needUpdateFieldConfig = true
 			isNeedUpdate = true
 		}

--- a/pkg/bk-monitor-worker/utils/stringx/base62.go
+++ b/pkg/bk-monitor-worker/utils/stringx/base62.go
@@ -42,6 +42,23 @@ func DecodeIdentifier(name string) string {
 	return original
 }
 
+// DecodeMetricIdentifier 还原指标名中被编码的部分，非编码指标名原样返回。
+//
+// 维度名整体就是一个编码标识符，指标名则可能由多段拼成：直方图会追加 _sum/_count/_bucket 后缀，
+// SDK 自定义指标名形如 custom_$type_$group_$name_$usage，编码块夹在中间。
+// base62 载荷只含字母和数字，不会出现下划线，因此按下划线切分能安全地隔离出编码段。
+func DecodeMetricIdentifier(fieldName string) string {
+	if !strings.Contains(fieldName, Base62Prefix) {
+		return fieldName
+	}
+
+	segments := strings.Split(fieldName, "_")
+	for i, segment := range segments {
+		segments[i] = DecodeIdentifier(segment)
+	}
+	return strings.Join(segments, "_")
+}
+
 // isPrintable 解码结果必须是合法 UTF-8 且全部可打印，否则说明这不是 SDK 编码出来的名字
 func isPrintable(s string) bool {
 	if !utf8.ValidString(s) {


### PR DESCRIPTION
close #1010158081137847962

## 变更

- 指标名的 base62 编码块夹在名字中间（`base62xxx_sum`、`custom_$type_$group_$name_$usage`），按前缀匹配的 `DecodeIdentifier` 解不出来。
- 新增 `DecodeMetricIdentifier` 按下划线逐段解码：base62 载荷只含字母和数字，切分不会劈开编码段。
- 指标发现时把解码出的原始名回填成别名，查询仍使用编码后的字段名。与 bk-monitor 侧 Python 实现对齐。
- 指标从 disabled 恢复时重新生成 `field_config` 而非清空，否则禁用一次就会丢掉别名。