### PR TITLE
fix: 修复直连 SurrealDB 图查询响应对象解析失败 --bug=163523526

### DIFF
--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
@@ -373,5 +373,62 @@ func (c *BKBaseSurrealDBClient) executeDirect(ctx context.Context, storageID, na
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("decode surrealdb response: %w", err)
 	}
-	return NewSurrealResponseParser(start, end).Parse(payload)
+	rows, err := normalizeDirectSurrealDBResponse(payload)
+	if err != nil {
+		return nil, err
+	}
+	rawResponse := []map[string]any{
+		{
+			ResponseFieldResult: rows,
+		},
+	}
+	return NewSurrealResponseParser(start, end).Parse(rawResponse)
+}
+
+// normalizeDirectSurrealDBResponse adapts the statement-oriented response from
+// SurrealDB's /sql endpoint to the graph row shape consumed by the parser.
+// USE NS/DB statements return a session object instead of a graph row and are
+// intentionally omitted from the normalized result.
+func normalizeDirectSurrealDBResponse(payload []map[string]any) ([]any, error) {
+	rows := make([]any, 0)
+	for statementIndex, statement := range payload {
+		result, exists := statement[ResponseFieldResult]
+		if !exists {
+			return nil, fmt.Errorf("parse surrealdb response: response[%d].%s: missing field", statementIndex, ResponseFieldResult)
+		}
+
+		if resultObject, ok := result.(map[string]any); ok {
+			if _, hasRoot := resultObject[ResponseFieldRoot]; !hasRoot {
+				if isSurrealDBSessionResult(resultObject) {
+					continue
+				}
+				return nil, fmt.Errorf("parse surrealdb response: response[%d].%s: missing field %s", statementIndex, ResponseFieldResult, ResponseFieldRoot)
+			}
+			rows = append(rows, map[string]any{ResponseFieldResult: resultObject})
+			continue
+		}
+
+		resultRows, ok := responseArray(result)
+		if !ok {
+			return nil, fmt.Errorf("parse surrealdb response: response[%d].%s: expected array, got %T", statementIndex, ResponseFieldResult, result)
+		}
+		for rowIndex, rowValue := range resultRows {
+			row, ok := rowValue.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("parse surrealdb response: response[%d].%s[%d]: expected object, got %T", statementIndex, ResponseFieldResult, rowIndex, rowValue)
+			}
+			normalizedRows, err := normalizeBKBaseGraphRows([]map[string]any{row})
+			if err != nil {
+				return nil, fmt.Errorf("parse surrealdb response: response[%d].%s[%d]: %w", statementIndex, ResponseFieldResult, rowIndex, err)
+			}
+			rows = append(rows, normalizedRows...)
+		}
+	}
+	return rows, nil
+}
+
+func isSurrealDBSessionResult(result map[string]any) bool {
+	_, hasNamespace := result["namespace"]
+	_, hasDatabase := result["database"]
+	return hasNamespace && hasDatabase
 }

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
@@ -396,6 +396,10 @@ func normalizeDirectSurrealDBResponse(payload []map[string]any) ([]any, error) {
 		if !exists {
 			return nil, fmt.Errorf("parse surrealdb response: response[%d].%s: missing field", statementIndex, ResponseFieldResult)
 		}
+		// LET and other control statements can return null without producing graph rows.
+		if result == nil {
+			continue
+		}
 
 		if resultObject, ok := result.(map[string]any); ok {
 			if _, hasRoot := resultObject[ResponseFieldRoot]; !hasRoot {

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
@@ -72,14 +72,14 @@ func TestSurrealDBRouteResolvesStorageAndExecutesDirectQuery(t *testing.T) {
 	assert.Empty(t, graphs)
 }
 
-func TestSurrealDBDirectQueryNormalizesObjectGraphResult(t *testing.T) {
+func TestSurrealDBDirectQuerySkipsSessionAndEmptyStatements(t *testing.T) {
 	const storageID = "700008"
 
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
 		assert.Equal(t, "/sql", request.URL.Path)
 		response.Header().Set("Content-Type", "application/json")
-		_, err := response.Write([]byte(`[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":{"root":{"entity_type":"node","entity_id":"node:node-1","entity_data":{"node":"node-1"}}}}]`))
+		_, err := response.Write([]byte(`[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":null},{"result":{"root":{"entity_type":"node","entity_id":"node:node-1","entity_data":{"node":"node-1"}}}}]`))
 		require.NoError(t, err)
 	}))
 	defer server.Close()

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
@@ -10,6 +10,7 @@
 package v1beta3
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -106,4 +107,70 @@ func TestSurrealDBDirectQuerySkipsSessionAndEmptyStatements(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, graphs, 1)
 	assert.Equal(t, "node:node-1", graphs[0].RootID)
+}
+
+func TestNormalizeDirectSurrealDBResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		wantRows int
+		wantErr  string
+	}{
+		{
+			name:     "session and null statements with graph object",
+			response: `[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":null},{"result":{"root":{"entity_type":"node","entity_id":"node:node-1"}}}]`,
+			wantRows: 1,
+		},
+		{
+			name:     "graph array with direct rows",
+			response: `[{"result":[{"root":{"entity_type":"node","entity_id":"node:node-1"}}]}]`,
+			wantRows: 1,
+		},
+		{
+			name:     "graph array with wrapped rows",
+			response: `[{"result":[{"result":{"root":{"entity_type":"node","entity_id":"node:node-1"}}}]}]`,
+			wantRows: 1,
+		},
+		{
+			name:     "only control statements produce no rows",
+			response: `[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":null},{"result":[]}]`,
+			wantRows: 0,
+		},
+		{
+			name:     "missing result field",
+			response: `[{"status":"OK"}]`,
+			wantErr:  "response[0].result: missing field",
+		},
+		{
+			name:     "non session object without root",
+			response: `[{"result":{"status":"OK"}}]`,
+			wantErr:  "response[0].result: missing field root",
+		},
+		{
+			name:     "scalar result",
+			response: `[{"result":"Exceeded query recursion depth limit"}]`,
+			wantErr:  "response[0].result: expected array, got string",
+		},
+		{
+			name:     "array row must be object",
+			response: `[{"result":["broken-row"]}]`,
+			wantErr:  "response[0].result[0]: expected object, got string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var payload []map[string]any
+			require.NoError(t, json.Unmarshal([]byte(tt.response), &payload))
+
+			rows, err := normalizeDirectSurrealDBResponse(payload)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, rows, tt.wantRows)
+		})
+	}
 }

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
@@ -71,3 +71,39 @@ func TestSurrealDBRouteResolvesStorageAndExecutesDirectQuery(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, graphs)
 }
+
+func TestSurrealDBDirectQueryNormalizesObjectGraphResult(t *testing.T) {
+	const storageID = "700008"
+
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "/sql", request.URL.Path)
+		response.Header().Set("Content-Type", "application/json")
+		_, err := response.Write([]byte(`[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":{"root":{"entity_type":"node","entity_id":"node:node-1","entity_data":{"node":"node-1"}}}}]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	tsdb.SetStorage(storageID, &tsdb.Storage{
+		Type:    metadata.SurrealDBStorageType,
+		Address: server.URL,
+	})
+
+	binding := BindingInfo{
+		StorageID: storageID,
+		Namespace: "mapleleaf_2",
+		Database:  "2_graph_rt",
+	}
+	graphs, err := (&BKBaseSurrealDBClient{}).ExecuteWithBinding(
+		contextWithTenantForBindingResolverTest("tenant-a"),
+		"bkcc__2",
+		binding,
+		"RETURN {root: {entity_type: 'node', entity_id: 'node:node-1'}};",
+		1000,
+		2000,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, graphs, 1)
+	assert.Equal(t, "node:node-1", graphs[0].RootID)
+}

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3.go
@@ -71,6 +71,17 @@ type GraphQueryExecutorWithBinding interface {
 
 type graphQueryRunner func(ctx context.Context, sql string, start, end int64) ([]*LivenessGraph, error)
 
+type directSurrealDBRouteContextKey struct{}
+
+func withDirectSurrealDBRoute(ctx context.Context) context.Context {
+	return context.WithValue(ctx, directSurrealDBRouteContextKey{}, true)
+}
+
+func isDirectSurrealDBRoute(ctx context.Context) bool {
+	value, _ := ctx.Value(directSurrealDBRouteContextKey{}).(bool)
+	return value
+}
+
 var sourceInferencePriority = buildSourceInferencePriority()
 
 func buildSourceInferencePriority() map[ResourceType]int {
@@ -565,7 +576,7 @@ func (m *Model) queryLivenessGraph(
 	if m.executor != nil {
 		start := time.Now()
 		bindingResolveStarted := time.Now()
-		runner, err := m.newGraphQueryRunner(ctx, req)
+		runner, directSurrealDB, err := m.newGraphQueryRunnerWithRoute(ctx, req)
 		span.Set("binding-resolve-duration", time.Since(bindingResolveStarted))
 		if err != nil {
 			span.Set("failure-stage", "binding-resolution")
@@ -576,7 +587,11 @@ func (m *Model) queryLivenessGraph(
 			return nil, nil, nil, err
 		}
 		if len(paths) > 0 {
-			graphs, paths, err = m.executeGraphQueryPathByPath(ctx, req, provider, paths, queryStart, queryEnd, mode, rangeStart, rangeEnd, stepMs, runner)
+			queryCtx := ctx
+			if directSurrealDB {
+				queryCtx = withDirectSurrealDBRoute(ctx)
+			}
+			graphs, paths, err = m.executeGraphQueryPathByPath(queryCtx, req, provider, paths, queryStart, queryEnd, mode, rangeStart, rangeEnd, stepMs, runner)
 		}
 		elapsed := time.Since(start).Seconds()
 		status := "ok"
@@ -793,6 +808,13 @@ func (m *Model) executeOneGraphQueryPath(
 	configureBuilderForGraphQueryMode(builder, mode)
 	route := builder.routeName()
 	usesFlatMultiHop := usesFlatMultiHopActiveEdgeServingPath(req, provider, path, mode)
+	if !usesFlatMultiHop && isDirectSurrealDBRoute(ctx) {
+		// The native SurrealDB /sql endpoint enforces a query AST recursion limit.
+		// For direct bindings, active-edge paths can be evaluated hop by hop using
+		// literal primary-key filters, which preserves the graph shape without
+		// embedding all hops in one deeply nested statement.
+		usesFlatMultiHop = usesDirectSurrealDBFlatMultiHopPath(req, provider, path, mode)
+	}
 	if usesFlatMultiHop {
 		route = "active_edge_serving_flat_multi_hop"
 	}
@@ -900,6 +922,38 @@ func usesFlatMultiHopActiveEdgeServingPath(
 			return false
 		}
 		if _, ok := flatRelations[relationType]; !ok {
+			return false
+		}
+		currentType := ResourceType(path.Steps[hop-1].ResourceType)
+		nextType := ResourceType(path.Steps[hop].ResourceType)
+		if len(provider.GetResourcePrimaryKeys(req.SchemaNamespace(), currentType)) == 0 ||
+			len(provider.GetResourcePrimaryKeys(req.SchemaNamespace(), nextType)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func usesDirectSurrealDBFlatMultiHopPath(
+	req *QueryRequest,
+	provider SchemaProvider,
+	path resourcePath,
+	mode graphQueryMode,
+) bool {
+	if req == nil || provider == nil || len(path.Steps) <= 2 || len(req.SourceExpandInfo) > 0 {
+		return false
+	}
+	if mode != graphQueryModeInstant && mode != graphQueryModeRange {
+		return false
+	}
+
+	servingRelations := make(map[RelationType]struct{}, len(ActiveEdgeServingRelations))
+	for _, relationType := range ActiveEdgeServingRelations {
+		servingRelations[RelationType(relationType)] = struct{}{}
+	}
+	for hop := 1; hop < len(path.Steps); hop++ {
+		relationType := RelationType(path.Steps[hop].RelationType)
+		if _, ok := servingRelations[relationType]; !ok {
 			return false
 		}
 		currentType := ResourceType(path.Steps[hop-1].ResourceType)
@@ -1256,14 +1310,19 @@ func resourcePathSortKey(path resourcePath) string {
 // 逐路径查询会依次执行多条 SQL；绑定元数据只和 space_uid 相关，提前解析一次
 // 可以避免每条路径重复访问绑定解析器，同时保证所有路径使用同一份路由上下文。
 func (m *Model) newGraphQueryRunner(ctx context.Context, req *QueryRequest) (graphQueryRunner, error) {
+	runner, _, err := m.newGraphQueryRunnerWithRoute(ctx, req)
+	return runner, err
+}
+
+func (m *Model) newGraphQueryRunnerWithRoute(ctx context.Context, req *QueryRequest) (graphQueryRunner, bool, error) {
 	if m.resolver != nil {
 		if ex, ok := m.executor.(GraphQueryExecutorWithBinding); ok {
 			if req.SpaceUID == "" {
-				return nil, fmt.Errorf("space_uid is required for binding graph query")
+				return nil, false, fmt.Errorf("space_uid is required for binding graph query")
 			}
 			binding, err := m.resolver.Resolve(ctx, req.SpaceUID)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			return func(ctx context.Context, sql string, start, end int64) ([]*LivenessGraph, error) {
 				graphs, err := ex.ExecuteWithBinding(ctx, req.SpaceUID, *binding, sql, start, end)
@@ -1274,7 +1333,7 @@ func (m *Model) newGraphQueryRunner(ctx context.Context, req *QueryRequest) (gra
 					return nil, err
 				}
 				return graphs, nil
-			}, nil
+			}, binding.StorageID != "", nil
 		}
 	}
 	return func(ctx context.Context, sql string, start, end int64) ([]*LivenessGraph, error) {
@@ -1286,7 +1345,7 @@ func (m *Model) newGraphQueryRunner(ctx context.Context, req *QueryRequest) (gra
 			return nil, err
 		}
 		return graphs, nil
-	}, nil
+	}, false, nil
 }
 
 // executeGraphQuery 根据 resolver / executor 能力选择最合适的调用路径。

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3.go
@@ -561,9 +561,17 @@ func (m *Model) queryLivenessGraph(
 	} else {
 		paths, err = pf.FindAllPaths(req.SourceType, req.TargetType, req.PathResource)
 		if err != nil {
-			span.Set("path-discovery-duration", time.Since(pathDiscoveryStarted))
-			span.Set("failure-stage", "path-discovery")
-			return nil, nil, nil, err
+			// 旧 Relation API 对显式 source==target 且没有自关联边的请求
+			// 返回空结果成功；仅在兼容模式保留这个行为。原生 v1beta3
+			// 仍然报告无路径，帮助调用方发现错误的自关联请求。
+			if req.LegacyCompatibility && isLegacyExplicitSelfTargetWithoutPath(req) {
+				paths = nil
+				err = nil
+			} else {
+				span.Set("path-discovery-duration", time.Since(pathDiscoveryStarted))
+				span.Set("failure-stage", "path-discovery")
+				return nil, nil, nil, err
+			}
 		}
 	}
 	span.Set("path-discovery-duration", time.Since(pathDiscoveryStarted))
@@ -1527,6 +1535,14 @@ func shouldIncludeRootTarget(req *QueryRequest) bool {
 
 func isExplicitDirectSelfTarget(req *QueryRequest) bool {
 	return req != nil && req.TargetTypeExplicit && req.SourceType == req.TargetType && len(req.PathResource) == 0
+}
+
+func isLegacyExplicitSelfTargetWithoutPath(req *QueryRequest) bool {
+	return req != nil &&
+		req.TargetTypeExplicit &&
+		req.SourceType == req.TargetType &&
+		len(req.PathResource) == 1 &&
+		req.PathResource[0] == ""
 }
 
 func targetExtractionPathResource(req *QueryRequest) []ResourceType {

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
@@ -2917,6 +2917,44 @@ func TestQueryLivenessGraphRejectsExplicitSameTypeWithoutSelfRelation(t *testing
 	assert.ErrorContains(t, err, "empty paths")
 }
 
+func TestQueryLivenessGraphLegacyCompatibilityReturnsEmptyForMissingExplicitSelfRelation(t *testing.T) {
+	ctx := context.Background()
+	provider := relation.NewStaticSchemaProvider(relation.StaticProviderConfig{
+		ResourcePrimaryKeys: map[string][]string{
+			"system": {"bk_target_ip"},
+			"pod":    {"pod"},
+		},
+		RelationSchemas: []relation.RelationSchema{
+			{
+				RelationName:  "system_to_pod",
+				Category:      relation.RelationCategoryStatic,
+				FromType:      "system",
+				ToType:        "pod",
+				IsDirectional: true,
+			},
+		},
+	})
+	model, err := NewModel(ctx, &mockGraphQueryExecutor{})
+	require.NoError(t, err)
+	model.SetSchemaProvider(NewSchemaProviderFromRelation(provider))
+
+	graphs, paths, matchers, err := model.QueryLivenessGraph(ctx, &QueryRequest{
+		Timestamp:           300000,
+		SourceType:          ResourceTypeSystem,
+		SourceInfo:          map[string]string{"bk_target_ip": "127.0.0.1"},
+		TargetType:          ResourceTypeSystem,
+		TargetTypeExplicit:  true,
+		LegacyCompatibility: true,
+		LookBackDelta:       600000,
+		LookBackDeltaSet:    true,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, graphs)
+	assert.Empty(t, paths)
+	assert.Empty(t, matchers)
+}
+
 func TestQueryLivenessGraphExecutesInstantQueryPathByPath(t *testing.T) {
 	ctx := context.Background()
 	provider := relation.NewStaticSchemaProvider(relation.StaticProviderConfig{

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
@@ -3316,6 +3316,76 @@ func TestQueryLivenessGraphFlattensBusinessSevenTwoHopEventPath(t *testing.T) {
 	}
 }
 
+func TestDirectSurrealDBRouteFlattensActiveMultiHopPath(t *testing.T) {
+	const timestamp = int64(1786731939847)
+
+	previousServingRelations := ActiveEdgeServingRelations
+	previousFlatMultiHopRelations := FlatMultiHopActiveEdgeServingRelations
+	ActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
+	FlatMultiHopActiveEdgeServingRelations = nil
+	t.Cleanup(func() {
+		ActiveEdgeServingRelations = previousServingRelations
+		FlatMultiHopActiveEdgeServingRelations = previousFlatMultiHopRelations
+	})
+
+	provider := businessSevenTwoHopSchemaProvider()
+	firstHop := businessSevenSingleHopGraph(
+		ResourceTypeHost,
+		"host:`185667`",
+		map[string]string{"bk_host_id": "185667"},
+		RelationHostWithModule,
+		"host_with_module:`185667_73`",
+		ResourceTypeModule,
+		"module:`73`",
+		map[string]string{"bk_module_id": "73"},
+		[]*VisiblePeriod{{Start: timestamp, End: timestamp}},
+	)
+	secondHop := businessSevenSingleHopGraph(
+		ResourceTypeModule,
+		"module:`73`",
+		map[string]string{"bk_module_id": "73"},
+		RelationModuleWithSet,
+		"module_with_set:`73_15`",
+		ResourceTypeSet,
+		"set:`15`",
+		map[string]string{"bk_set_id": "15"},
+		[]*VisiblePeriod{{Start: timestamp, End: timestamp}},
+	)
+
+	var sqls []string
+	runner := func(_ context.Context, sql string, _, _ int64) ([]*LivenessGraph, error) {
+		sqls = append(sqls, sql)
+		switch {
+		case strings.Contains(sql, "FROM host_with_module_active_edge_view"):
+			return []*LivenessGraph{cloneLivenessGraphForTest(firstHop, 0, 0)}, nil
+		case strings.Contains(sql, "FROM module_with_set_active_edge_view"):
+			return []*LivenessGraph{cloneLivenessGraphForTest(secondHop, 0, 0)}, nil
+		default:
+			return nil, errors.New("unexpected SurrealQL")
+		}
+	}
+
+	result := (&Model{}).executeOneGraphQueryPath(
+		withDirectSurrealDBRoute(context.Background()),
+		businessSevenTwoHopRequest(timestamp, "185667"),
+		provider,
+		businessSevenTwoHopPath(),
+		0,
+		0,
+		timestamp,
+		graphQueryModeInstant,
+		runner,
+	)
+
+	require.NoError(t, result.err)
+	require.Len(t, result.graphs, 1)
+	assert.Equal(t, "host:`185667`", result.graphs[0].RootID)
+	assert.Len(t, sqls, 2)
+	for _, sql := range sqls {
+		assert.NotContains(t, sql, "$parent")
+	}
+}
+
 func TestLivenessGraphMergesDuplicateEdgePeriods(t *testing.T) {
 	graph := NewLivenessGraph(0, 0)
 	graph.RootID = "host:`185667`"


### PR DESCRIPTION
## Summary

- Normalize direct SurrealDB /sql graph responses when a graph result is returned as an object or statement array.
- Ignore USE NS/DB session result objects and valid result:null entries from LET statements before graph parsing.
- For native direct SurrealDB bindings, flatten deep active-edge paths into one-hop SQL requests to avoid the server query AST recursion limit; existing BKBase query_sync and non-serving paths retain the nested query path.
- Preserve existing BKBase row normalization and add regression coverage for direct response shapes and direct multi-hop routing.

## Tests

- go test -count=1 ./cmdb/v1beta3
- go test -race -count=1 ./cmdb/v1beta3
- make MODULE=unify-query test BUILDTAGS=
- go test -count=1 ./...

The default jsonsonic-tagged test command is blocked locally by the installed sonic dependency and Go toolchain combination (`GoMapIterator` is undefined); the same suite passes with the standard build tags.

## Direct validation

- Direct read-only execution from the 3.9.4390 Test Pod used SQL generated by the UQ v1beta3 builder.
- The real /sql response had 8 statements: one USE object, six LET null results, and a final graph array.
- Full fixtures on 3.9.4392 showed no old parser errors (`expected array`, `expected map`, `expected object`, or `result:null`); seven deep active-edge cases instead reached the SurrealDB recursion-depth limit.
- This commit adds the direct-route hop-by-hop fallback for those active-edge paths; a new image rollout is required for pod-level revalidation.