### PR TITLE
ci(linkd): 支持原生双架构镜像及 Chart 发布

### DIFF
--- a/pkg/linkd/.dockerignore
+++ b/pkg/linkd/.dockerignore
@@ -20,3 +20,5 @@ configs/*.local.yaml
 **/*.keystore
 ecosystem.config.cjs
 **/*_test.go
+
+.release/

--- a/pkg/linkd/.gitignore
+++ b/pkg/linkd/.gitignore
@@ -1,4 +1,5 @@
 # Build outputs
+/.release/
 /bin/
 /dist/
 /console/dist/

--- a/pkg/linkd/Dockerfile
+++ b/pkg/linkd/Dockerfile
@@ -11,15 +11,19 @@
 # 或 docker build --build-arg VERSION=<version> -t linkd:<tag> .
 
 ARG GO_IMAGE=golang:1.26.7
-FROM ${GO_IMAGE} AS builder
+ARG RUNTIME_IMAGE=tencentos/tencentos4-minimal
+FROM --platform=$BUILDPLATFORM ${GO_IMAGE} AS builder
 
 ARG GOPROXY=direct
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 
 ENV CGO_ENABLED=0 \
+    GOTOOLCHAIN=local \
     GOPROXY=${GOPROXY}
 
 COPY go.mod go.sum ./
@@ -27,9 +31,9 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /out/linkd ./cmd/linkd
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /out/linkd ./cmd/linkd
 
-FROM tencentos/tencentos4-minimal
+FROM ${RUNTIME_IMAGE}
 
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown

--- a/pkg/linkd/Makefile
+++ b/pkg/linkd/Makefile
@@ -22,7 +22,7 @@ GO_FILES := $(shell find . -type f -name '*.go' \
 	-not -path './console/dist/*' \
 	-not -path './console/dist-server/*' | LC_ALL=C sort)
 
-.PHONY: fmt fmt-check test race vet lint console-check console-e2e helm-check check image console-image
+.PHONY: fmt fmt-check test race vet lint console-check console-e2e helm-check release-check check image console-image
 
 fmt:
 	$(GOFMT) -w $(GO_FILES)
@@ -65,6 +65,10 @@ helm-check:
 	helm lint --strict deploy/helm/linkd -f deploy/helm/linkd/examples/existing-secrets.yaml
 	node --test deploy/helm/linkd/tests/chart.test.mjs
 
+release-check:
+	python3 scripts/test_ci_release.py
+	NODE_PATH="$(CURDIR)/$(CONSOLE_DIR)/node_modules" node --test scripts/test-prepare-release-chart.cjs
+
 check:
 	$(MAKE) fmt-check
 	$(MAKE) test
@@ -73,6 +77,7 @@ check:
 	$(MAKE) lint
 	$(MAKE) console-check
 	$(MAKE) helm-check
+	$(MAKE) release-check
 
 image:
 	$(CONTAINER) build \

--- a/pkg/linkd/console/Dockerfile
+++ b/pkg/linkd/console/Dockerfile
@@ -2,12 +2,15 @@
 ARG NODE_IMAGE=node:24-bookworm-slim
 FROM ${NODE_IMAGE} AS builder
 ARG NODE_BUILD_OPTIONS=--max-old-space-size=3072
+ARG NPM_REGISTRY=https://registry.npmjs.org
+# Corepack 自身获取 pnpm 与 pnpm 获取项目依赖分别配置，避免只替换其中一个入口。
+ENV COREPACK_NPM_REGISTRY=${NPM_REGISTRY}
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --registry="${NPM_REGISTRY}"
 COPY . .
-RUN NODE_OPTIONS="${NODE_BUILD_OPTIONS}" pnpm build && pnpm prune --prod
+RUN NODE_OPTIONS="${NODE_BUILD_OPTIONS}" pnpm build && pnpm prune --prod --registry="${NPM_REGISTRY}"
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 RUN VERSION="${VERSION}" GIT_COMMIT="${GIT_COMMIT}" node -e 'require("node:fs").writeFileSync("build-info.json", JSON.stringify({version: process.env.VERSION, git_commit: process.env.GIT_COMMIT}))'

--- a/pkg/linkd/docs/guides/README.md
+++ b/pkg/linkd/docs/guides/README.md
@@ -6,6 +6,7 @@
 
 - [部署模式与进程拓扑](../design/deployment.md)（已确认方向与当前实现边界）；
 - [项目 README 的容器镜像](../../README.md#容器镜像)：在 `pkg/linkd` 独立构建 `tencentos/tencentos4-minimal` 运行时镜像；
+- [自建构建机发布](ci-release.md)：原生 amd64 / arm64 镜像构建、Chart 上传和任务清理；
 - [手动构建与发布镜像](image-release.md)：GitHub Actions 手动构建 Linkd / Console、GHCR 权限与版本标签；
 - [配置与启动](configuration.md)；
 - [Helm 部署与 worker 分组](helm.md)：三角色部署、独立配置 Secret、可选 Console 与认证入口；

--- a/pkg/linkd/docs/guides/ci-release.md
+++ b/pkg/linkd/docs/guides/ci-release.md
@@ -1,0 +1,70 @@
+# 在自建构建机发布镜像与 Chart
+
+使用 `scripts/ci-release.sh` 将镜像编译放在现有 Dockerfile 内执行。宿主机需要 Bash、Git、Docker Engine 及 Buildx 插件；打包 Chart 的机器还需要 Helm、curl 和 sha256sum。Go 1.26.7、Node 24、pnpm 11.24.0 由构建镜像提供，不要求宿主机安装。DevOps Agent 所需的 JDK 由构建机自身管理。
+
+amd64 和 arm64 各自在原生 Linux 构建机上执行，不需要 QEMU。每种架构生成 `linkd` 和 `linkd-console` 两个镜像。脚本校验 Docker 服务端架构、成品镜像架构，以及两个镜像的 `version` 命令输出。
+
+## 环境变量与步骤
+
+以下示例中域名为占位符。镜像源、目标仓库和凭据由流水线环境变量传入，不写进 Dockerfile。`RELEASE_ID` 在同一架构的所有步骤保持一致，并须包含流水线和构建编号以避免并发冲突。使用小写字母、数字、点、下划线或短横线，最长 80 个字符。
+
+```bash
+export RELEASE_ID=linkd-pipeline-123
+export TARGET_ARCH=amd64
+export PACKAGE_VERSION=0.1.0-ci.123
+export IMAGE_REPOSITORY=registry.example.com/project/images
+# 从 CI 凭据管理绑定 REGISTRY_USER、REGISTRY_PASSWORD。
+export GO_IMAGE=golang:1.26.7
+export RUNTIME_IMAGE=tencentos/tencentos4-minimal
+export NODE_IMAGE=node:24-bookworm-slim
+export GOPROXY=https://proxy.golang.org,direct
+export NPM_REGISTRY=https://registry.npmjs.org
+
+bash pkg/linkd/scripts/ci-release.sh build
+bash pkg/linkd/scripts/ci-release.sh push
+```
+
+ARM 构建步骤将 `TARGET_ARCH` 改为 `arm64`，并配置对应的 `IMAGE_REPOSITORY`。`PACKAGE_VERSION` 使用不带 `v` 前缀、不带 `+` 元数据的 SemVer，且作为两个镜像的 tag、Chart version 和 appVersion。请为每次发布使用新版本号，避免覆盖已有发布。
+
+两个架构的 clone 应固定同一个 Git 提交。若流水线按分支拉取，Chart 步骤必须比对两个 push 步骤输出的 `revision`；存在差异时停止发布，固定提交后重新构建。脚本输出使用蓝鲸 DevOps 的 `::set-output` 语法，其他 CI 可以从任务 `.release/<RELEASE_ID>-<TARGET_ARCH>/revision` 读取。
+
+## Chart 打包与上传
+
+Chart 步骤复用已成功构建和推送镜像的机器与工作目录。两种架构都选中时，只在 amd64 机器打包；仅选 arm64 时，在 ARM 机器打包。
+
+```bash
+# 延续前面构建步骤的环境变量。
+export HELM_UPLOAD_URL=https://repo.example.com/helm/api/project/repository/charts
+# 从 CI 凭据管理绑定 HELM_USER、HELM_PASSWORD（个人访问 token）。
+# 仅当同时构建另一架构时，设置这两个变量，并要求 PEER_REVISION 非空。
+export PEER_REVISION='<另一架构 push 步骤输出的完整 Git SHA>'
+export PEER_IMAGE_REPOSITORY=registry.example.com/project/images-arm
+bash pkg/linkd/scripts/ci-release.sh chart
+```
+
+脚本复制 Chart 后，用本次 Console 镜像内的 Node 和 `yaml` 更新副本。默认镜像仓库与节点架构跟随打包机器，并将各架构的 `values-amd64.yaml` / `values-arm64.yaml` 装入 Chart 包。双架构发布使用 ARM 集群时，下载并解压 Chart，安装时添加 `-f linkd/values-arm64.yaml`。覆盖文件同时调整 Linkd、Console 的镜像仓库和 `nodeSelector.kubernetes.io/arch`。
+
+Chart 执行严格 lint、示例配置渲染以及各架构覆盖配置渲染，再打包、输出 SHA256 并通过 `curl -F chart=@...` 上传。此步骤不访问 Kubernetes 集群，不部署服务，不执行数据库迁移。上传接口使用 HTTPS Basic Auth，token 从 stdin 传给 curl，不放入命令参数或磁盘配置文件。上传 POST 不自动重试；若上传超时，应先检查仓库中该版本是否已经存在。
+
+## 清理与网络
+
+在流水线 `finally` 中调用：
+
+```bash
+bash pkg/linkd/scripts/ci-release.sh cleanup
+```
+
+清理只删除本次成功生成并登记的镜像标签，以及本次任务目录（含临时 Docker 登录配置和 Chart 副本）。标签已指向其他镜像或存在运行中／已停止容器引用时保留。不会使用全局 prune、强制删除，也不清除共享 BuildKit 缓存。流水线可以在脚本退出后删除本次独立 clone 目录；不得删除共享 Git 缓存或其他构建的目录。Agent 被强制终止或主机宕机可能阻止 finally 执行，此时使用相同 `RELEASE_ID` 手工清理。
+
+首次构建仍需访问配置的基础镜像仓库、Go 模块源和 npm registry；本机有网不代表线上可达。完全断网时必须提前将基础镜像及包代理缓存同步到内网。Dockerfile 保留官方默认值，内部镜像源仅在流水线配置。
+
+## 验证
+
+```bash
+bash -n pkg/linkd/scripts/ci-release.sh
+python3 pkg/linkd/scripts/test_ci_release.py
+# 本机需已安装 Console 依赖及 Helm。
+NODE_PATH="$PWD/pkg/linkd/console/node_modules" node --test pkg/linkd/scripts/test-prepare-release-chart.cjs
+```
+
+上述脚本测试使用隔离的假 Docker，不拉镜像、不推送镜像。真实 amd64 / arm64 镜像构建、仓库认证和上传需要在目标构建池执行后才能确认。

--- a/pkg/linkd/scripts/ci-release.sh
+++ b/pkg/linkd/scripts/ci-release.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# 原生 Linux amd64/arm64 构建；由 CI 在 finally 中调用 cleanup。
+set -euo pipefail
+set +x
+
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+module=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+: "${RELEASE_ID:?设置流水线唯一 RELEASE_ID}"
+[[ $RELEASE_ID =~ ^[a-z0-9][a-z0-9._-]{0,79}$ ]] || fail '非法 RELEASE_ID'
+: "${TARGET_ARCH:?设置 amd64 或 arm64}"
+case $TARGET_ARCH in amd64|arm64) ;; *) fail 'TARGET_ARCH 必须为 amd64 或 arm64' ;; esac
+state="$module/.release/$RELEASE_ID-$TARGET_ARCH"
+command=${1:-}
+
+cleanup() {
+    [[ -d $state && ! -L $state && ! -L $module/.release ]] || return 0
+    touch "$state/images.tsv"
+    while IFS=$'\t' read -r ref expected; do
+        [[ -n $ref && $expected == sha256:* ]] || continue
+        current=$(docker image inspect --format '{{.Id}}' "$ref" 2>/dev/null) || continue
+        [[ $current == "$expected" ]] || { printf '保留已被替换的标签：%s\n' "$ref"; continue; }
+        # 包括停止的容器，避免删除仍由其他任务引用的镜像。
+        containers=$(docker ps -aq --filter "ancestor=$expected") || continue
+        [[ -z $containers ]] || { printf '保留容器引用的镜像：%s\n' "$ref"; continue; }
+        docker image rm "$ref" || printf 'WARN: 清理失败：%s\n' "$ref" >&2
+    done < "$state/images.tsv"
+    rm -rf -- "$state"
+}
+if [[ $command == cleanup ]]; then cleanup; exit 0; fi
+
+: "${PACKAGE_VERSION:?设置 SemVer 版本，例如 0.1.0-ci.123}"
+# 同时满足 Helm SemVer 和 Docker tag；不接受 v 前缀及 +build 元数据。
+[[ ${#PACKAGE_VERSION} -le 128 && $PACKAGE_VERSION =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]] || fail '非法 PACKAGE_VERSION'
+if [[ $PACKAGE_VERSION == *-* ]]; then
+    IFS=. read -r -a prerelease <<< "${PACKAGE_VERSION#*-}"
+    for part in "${prerelease[@]}"; do
+        [[ ! $part =~ ^0[0-9]+$ ]] || fail 'SemVer 数字预发布标识不能以 0 开头'
+    done
+fi
+: "${IMAGE_REPOSITORY:?设置不含组件名的镜像仓库前缀}"
+[[ $IMAGE_REPOSITORY == */* && $IMAGE_REPOSITORY =~ ^[a-z0-9][a-z0-9./:_-]*[a-z0-9]$ ]] || fail '非法 IMAGE_REPOSITORY'
+[[ ! -L $module/.release && ! -L $state ]] || fail '构建目录不能是符号链接'
+umask 077
+mkdir -p "$state"
+# 登录配置仅在本次任务目录中存在，不改宿主机已有的 Docker 登录状态。
+export DOCKER_CONFIG="$state/docker-config"
+mkdir -p "$DOCKER_CONFIG"
+revision=$(git -C "$module" rev-parse HEAD)
+[[ $revision =~ ^[0-9a-f]{40}$ ]] || fail '无法读取 Git SHA'
+if [[ -f $state/revision ]]; then
+    [[ $(cat "$state/revision") == "$revision" && $(cat "$state/version") == "$PACKAGE_VERSION" ]] || fail '工作区或版本在构建后发生变化'
+else
+    printf '%s\n' "$revision" > "$state/revision"
+    printf '%s\n' "$PACKAGE_VERSION" > "$state/version"
+fi
+
+login() {
+    : "${REGISTRY_USER:?设置镜像仓库用户名}"
+    : "${REGISTRY_PASSWORD:?通过 CI 凭据注入镜像仓库密码}"
+    printf '%s' "$REGISTRY_PASSWORD" | docker login "${IMAGE_REPOSITORY%%/*}" --username "$REGISTRY_USER" --password-stdin
+}
+record_image() {
+    local ref=$1 id
+    id=$(docker image inspect --format '{{.Id}}' "$ref")
+    printf '%s\t%s\n' "$ref" "$id" >> "$state/images.tsv"
+}
+local_image() { printf 'linkd-ci-%s-%s-%s:build' "$RELEASE_ID" "$TARGET_ARCH" "$1"; }
+release_image() { printf '%s/%s:%s' "$IMAGE_REPOSITORY" "$1" "$PACKAGE_VERSION"; }
+
+case $command in
+build)
+    rm -f -- "$state/built" "$state/pushed"
+    docker buildx version
+    daemon=$(docker info --format '{{.OSType}}/{{.Architecture}}')
+    case $daemon in linux/x86_64) daemon=linux/amd64 ;; linux/aarch64) daemon=linux/arm64 ;; esac
+    [[ $daemon == "linux/$TARGET_ARCH" ]] || fail "需要原生 linux/$TARGET_ARCH 构建机，实际为 $daemon"
+    login
+    for component in linkd linkd-console; do
+        context=$module
+        args=(--build-arg "GO_IMAGE=${GO_IMAGE:-golang:1.26.7}" --build-arg "RUNTIME_IMAGE=${RUNTIME_IMAGE:-tencentos/tencentos4-minimal}" --build-arg "GOPROXY=${GOPROXY:-direct}")
+        if [[ $component == linkd-console ]]; then
+            context=$module/console
+            args=(--build-arg "NODE_IMAGE=${NODE_IMAGE:-node:24-bookworm-slim}" --build-arg "NPM_REGISTRY=${NPM_REGISTRY:-https://registry.npmjs.org}")
+        fi
+        ref=$(local_image "$component")
+        docker buildx build --load --platform "linux/$TARGET_ARCH" --progress plain \
+            --build-arg "VERSION=$PACKAGE_VERSION" --build-arg "GIT_COMMIT=$revision" \
+            "${args[@]}" --tag "$ref" "$context"
+        # 只在成功生成镜像后登记；失败重建不能误删已有标签。
+        record_image "$ref"
+        [[ $(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$ref") == "linux/$TARGET_ARCH" ]] || fail "$component 架构错误"
+        actual=$(docker run --rm --network none "$ref" version)
+        expected=$(printf 'version: %s\ngit_commit: %s' "$PACKAGE_VERSION" "$revision")
+        [[ $actual == "$expected" ]] || fail "$component 版本元数据不匹配"
+    done
+    touch "$state/built"
+    printf '::set-output name=revision::%s\n' "$revision"
+    ;;
+push)
+    rm -f -- "$state/pushed"
+    [[ -f $state/built ]] || fail '两个镜像必须先全部构建并验证成功'
+    login
+    for component in linkd linkd-console; do
+        ref=$(release_image "$component")
+        docker tag "$(local_image "$component")" "$ref"
+        record_image "$ref"
+        docker push "$ref"
+    done
+    touch "$state/pushed"
+    printf '::set-output name=revision::%s\n' "$revision"
+    ;;
+chart)
+    [[ -f $state/pushed ]] || fail '镜像尚未全部推送成功'
+    # 调用方传入另一架构的输出，阻止同一版本混用两个 Git 提交。
+    if [[ -n ${PEER_REVISION:-} || -n ${PEER_IMAGE_REPOSITORY:-} ]]; then
+        [[ -n ${PEER_IMAGE_REPOSITORY:-} ]] || fail "缺少另一架构镜像仓库"
+        [[ ${PEER_REVISION:-} == "$revision" ]] || fail '两种架构的 Git SHA 不一致，停止 Chart 发布'
+    fi
+    : "${HELM_UPLOAD_URL:?设置 Chart 上传 API}"
+    : "${HELM_USER:?设置 Chart 上传用户名}"
+    : "${HELM_PASSWORD:?通过 CI 凭据注入 Chart 上传密码}"
+    [[ $HELM_UPLOAD_URL == https://* && $HELM_UPLOAD_URL != *'"'* ]] || fail 'Chart 上传必须使用 HTTPS'
+    # curl 配置通过 stdin 传入，避免密码出现在 argv、磁盘文件和日志中。
+    [[ $HELM_USER =~ ^[a-zA-Z0-9._-]+$ && $HELM_PASSWORD =~ ^[a-zA-Z0-9._-]+$ ]] || fail '用户名或 token 含不支持的字符'
+    chart="$state/chart/linkd"
+    mkdir -p "$state/chart" "$state/artifacts"
+    rm -rf -- "$chart"
+    cp -R "$module/deploy/helm/linkd" "$chart"
+    docker run --rm --network none --user "$(id -u):$(id -g)" \
+        --mount "type=bind,src=$chart,dst=/chart" \
+        -e PACKAGE_VERSION -e IMAGE_REPOSITORY -e TARGET_ARCH -e "PEER_IMAGE_REPOSITORY=${PEER_IMAGE_REPOSITORY:-}" \
+        --mount "type=bind,src=$module/scripts/prepare-release-chart.cjs,dst=/prepare.cjs,readonly" \
+        -e NODE_PATH=/app/node_modules \
+        --entrypoint node "$(local_image linkd-console)" /prepare.cjs
+    values=(-f "$chart/examples/external-services.yaml" -f "$chart/examples/clusters.yaml" -f "$chart/examples/console-ingress.yaml" -f "$chart/examples/servicemonitor.yaml")
+    helm lint --strict "$chart" "${values[@]}"
+    helm template linkd "$chart" "${values[@]}" > "$state/rendered.yaml"
+    for arch_values in "$chart"/values-*.yaml; do
+        helm template linkd "$chart" "${values[@]}" -f "$arch_values" > /dev/null
+    done
+    helm package "$chart" --version "$PACKAGE_VERSION" --app-version "$PACKAGE_VERSION" --destination "$state/artifacts"
+    archive="$state/artifacts/linkd-$PACKAGE_VERSION.tgz"
+    sha256sum "$archive"
+    # POST 不自动重试，避免超时后重复上传已成功的版本。
+    printf 'user = "%s:%s"\n' "$HELM_USER" "$HELM_PASSWORD" | \
+        curl --config - --fail --silent --show-error --connect-timeout 30 --max-time 300 \
+        --form "chart=@$archive" "$HELM_UPLOAD_URL"
+    printf '\nChart uploaded: linkd-%s.tgz (Git %s)\n' "$PACKAGE_VERSION" "$revision"
+    ;;
+*) fail '用法：ci-release.sh build|push|chart|cleanup' ;;
+esac

--- a/pkg/linkd/scripts/prepare-release-chart.cjs
+++ b/pkg/linkd/scripts/prepare-release-chart.cjs
@@ -1,0 +1,21 @@
+// 只修改发布目录中的 Chart 副本；使用 Console 镜像中已有的 yaml 依赖。
+const fs = require("node:fs"), YAML = require("yaml");
+const env = process.env;
+const directory = process.argv[2] || "/chart";
+function images(repo, arch) {
+  const slash = repo.indexOf("/");
+  const image = name => ({registry: repo.slice(0, slash), repository: repo.slice(slash + 1) + "/" + name, tag: env.PACKAGE_VERSION, digest: ""});
+  return {nodeSelector: {"kubernetes.io/arch": arch}, global: {imageRegistry: ""}, image: image("linkd"), console: {image: image("linkd-console")}};
+}
+const values = YAML.parseDocument(fs.readFileSync(`${directory}/values.yaml`, "utf8"));
+const overrides = images(env.IMAGE_REPOSITORY, env.TARGET_ARCH);
+values.setIn(["global", "imageRegistry"], "");
+for (const [key, value] of Object.entries(overrides.image)) values.setIn(["image", key], value);
+values.setIn(["nodeSelector", "kubernetes.io/arch"], env.TARGET_ARCH);
+for (const [key, value] of Object.entries(overrides.console.image)) values.setIn(["console", "image", key], value);
+fs.writeFileSync(`${directory}/values.yaml`, values.toString());
+fs.writeFileSync(`${directory}/values-${env.TARGET_ARCH}.yaml`, YAML.stringify(overrides));
+if (env.PEER_IMAGE_REPOSITORY) {
+  const peer = env.TARGET_ARCH === "amd64" ? "arm64" : "amd64";
+  fs.writeFileSync(`${directory}/values-${peer}.yaml`, YAML.stringify(images(env.PEER_IMAGE_REPOSITORY, peer)));
+}

--- a/pkg/linkd/scripts/test-prepare-release-chart.cjs
+++ b/pkg/linkd/scripts/test-prepare-release-chart.cjs
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { test } = require('node:test');
+const YAML = require('yaml');
+const source = path.resolve(__dirname, '../deploy/helm/linkd');
+for (const arch of ['amd64', 'arm64']) {
+  test(`Chart 默认 ${arch}，另一架构覆盖仓库及节点选择`, t => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'linkd-chart-'));
+    t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+    const chart = path.join(directory, 'linkd');
+    fs.cpSync(source, chart, { recursive: true });
+    const original = fs.readFileSync(path.join(source, 'values.yaml'), 'utf8');
+    const primary = 'registry.example/project/images-' + arch;
+    const peer = arch === 'amd64' ? 'arm64' : 'amd64';
+    execFileSync(process.execPath, [path.join(__dirname, 'prepare-release-chart.cjs'), chart], {
+      env: { ...process.env, TARGET_ARCH: arch, PACKAGE_VERSION: '1.2.3-ci.4', IMAGE_REPOSITORY: primary,
+        PEER_IMAGE_REPOSITORY: 'registry.example/project/images-' + peer },
+    });
+    const values = YAML.parse(fs.readFileSync(path.join(chart, 'values.yaml'), 'utf8'));
+    assert.equal(values.image.registry, 'registry.example');
+    assert.equal(values.image.repository, `project/images-${arch}/linkd`);
+    assert.equal(values.console.image.repository, `project/images-${arch}/linkd-console`);
+    assert.equal(values.image.tag, '1.2.3-ci.4');
+    assert.equal(values.nodeSelector['kubernetes.io/arch'], arch);
+    assert.deepEqual(values.clusters, YAML.parse(original).clusters);
+    assert.equal(fs.readFileSync(path.join(source, 'values.yaml'), 'utf8'), original);
+    const override = YAML.parse(fs.readFileSync(path.join(chart, `values-${peer}.yaml`), 'utf8'));
+    assert.equal(override.image.repository, `project/images-${peer}/linkd`);
+    assert.equal(override.console.image.tag, '1.2.3-ci.4');
+    assert.equal(override.nodeSelector['kubernetes.io/arch'], peer);
+    const args = ['external-services', 'clusters', 'console-ingress', 'servicemonitor']
+      .flatMap(name => ['-f', path.join(chart, 'examples', name + '.yaml')]);
+    try { execFileSync('helm', ['lint', '--strict', chart, ...args], { encoding: 'utf8' }); } catch (error) { throw new Error(error.stdout + error.stderr); }
+    const rendered = execFileSync('helm', ['template', 'linkd', chart, ...args, '-f', path.join(chart, `values-${peer}.yaml`)], { encoding: 'utf8' });
+    assert.ok(rendered.includes(`registry.example/project/images-${peer}/linkd:1.2.3-ci.4`));
+    assert.ok(rendered.includes(`registry.example/project/images-${peer}/linkd-console:1.2.3-ci.4`));
+    assert.ok(rendered.includes(`kubernetes.io/arch: ${peer}`));
+    execFileSync('helm', ['package', chart, '--version', '1.2.3-ci.4', '--app-version', '1.2.3-ci.4', '-d', directory]);
+    const metadata = YAML.parse(execFileSync('helm', ['show', 'chart', path.join(directory, 'linkd-1.2.3-ci.4.tgz')], { encoding: 'utf8' }));
+    assert.equal(metadata.version, '1.2.3-ci.4');
+    assert.equal(metadata.appVersion, '1.2.3-ci.4');
+  });
+}

--- a/pkg/linkd/scripts/test_ci_release.py
+++ b/pkg/linkd/scripts/test_ci_release.py
@@ -1,0 +1,124 @@
+"""CI 编排回归测试：用隔离的假 Docker 验证副作用，不访问本机 Docker。"""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name('ci-release.sh')
+FAKE_DOCKER = r'''#!/usr/bin/env python3
+import json, os, pathlib, sys
+root = pathlib.Path(os.environ['FAKE_ROOT'])
+p = root / 'images.json'
+images = json.loads(p.read_text()) if p.exists() else {}
+a = sys.argv[1:]
+with (root / 'calls').open('a') as f: f.write(json.dumps(a) + '\n')
+if a[:2] == ['buildx', 'version']: print('buildx fake')
+elif a[:1] == ['info']: print(os.environ.get('FAKE_ARCH', 'linux/amd64'))
+elif a[:1] == ['login']: sys.stdin.read()
+elif a[:2] == ['buildx', 'build']:
+    ref = a[a.index('--tag')+1]
+    if os.environ.get('FAIL_BUILD') and 'console' in ref: sys.exit(1)
+    images[ref] = 'sha256:' + ('b'*64 if 'console' in ref else 'a'*64)
+elif a[:2] == ['image', 'inspect']:
+    if a[-1] not in images: sys.exit(1)
+    print('linux/amd64' if a[3] == '{{.Os}}/{{.Architecture}}' else images[a[-1]])
+elif a[:1] == ['run']:
+    print('version: ' + os.environ['PACKAGE_VERSION'])
+    print('git_commit: ' + ('0'*40 if os.environ.get('BAD_VERSION') else '1'*40))
+elif a[:1] == ['tag']: images[a[2]] = images[a[1]]
+elif a[:1] == ['push']:
+    if os.environ.get('FAIL_PUSH'): sys.exit(1)
+elif a[:1] == ['ps']:
+    if os.environ.get('IN_USE'): print('container-id')
+elif a[:2] == ['image', 'rm']: images.pop(a[-1], None)
+else: raise RuntimeError(a)
+p.write_text(json.dumps(images))
+'''
+
+class ReleaseTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        scripts = self.root / 'module/scripts'
+        scripts.mkdir(parents=True)
+        self.script = scripts / SCRIPT.name
+        shutil.copyfile(SCRIPT, self.script)
+        binary = self.root / 'bin'
+        binary.mkdir()
+        for name, content in [('docker', FAKE_DOCKER), ('git', '#!/bin/sh\nprintf "%s\\n" 1111111111111111111111111111111111111111\n')]:
+            file = binary / name
+            file.write_text(content)
+            file.chmod(0o755)
+        self.env = dict(os.environ, PATH=str(binary) + ':' + os.environ['PATH'],
+                        FAKE_ROOT=str(self.root), RELEASE_ID='test-123', TARGET_ARCH='amd64',
+                        PACKAGE_VERSION='0.1.0-ci.123', IMAGE_REPOSITORY='registry.example/project/images',
+                        REGISTRY_USER='test', REGISTRY_PASSWORD='test-token')
+        self.state = self.root / 'module/.release/test-123-amd64'
+
+    def run_script(self, command, success=True, **env):
+        result = subprocess.run(['bash', str(self.script), command], env=dict(self.env, **env),
+                                capture_output=True, text=True)
+        self.assertEqual(result.returncode == 0, success, result.stdout + result.stderr)
+        return result
+
+    def images(self):
+        p = self.root / 'images.json'
+        return json.loads(p.read_text()) if p.exists() else {}
+
+    def test_success_and_cleanup_preserves_unrelated_images(self):
+        (self.root / 'images.json').write_text(json.dumps({'unrelated:keep': 'sha256:'+'c'*64}))
+        self.run_script('build')
+        self.run_script('push')
+        self.assertEqual(len(self.images()), 5)
+        self.run_script('cleanup')
+        self.assertEqual(list(self.images()), ['unrelated:keep'])
+        self.assertFalse(self.state.exists())
+
+    def test_partial_build_cannot_push_and_is_cleaned(self):
+        self.run_script('build', success=False, FAIL_BUILD='1')
+        self.run_script('push', success=False)
+        self.run_script('cleanup')
+        self.assertEqual(self.images(), {})
+
+    def test_invalid_version_and_wrong_architecture_fail_before_build(self):
+        for version in ('../bad', '1.2.3;echo bad', '1.2.3-01', '1.2.3+meta', 'v1.2.3'):
+            self.run_script('build', success=False, PACKAGE_VERSION=version)
+        self.run_script('build', success=False, FAKE_ARCH='linux/arm64')
+        self.assertEqual(self.images(), {})
+        self.run_script('cleanup')
+        self.assertFalse(self.state.exists())
+
+    def test_version_smoke_failure_blocks_push(self):
+        self.run_script('build', success=False, BAD_VERSION='1')
+        self.run_script('push', success=False)
+        self.run_script('cleanup')
+        self.assertEqual(self.images(), {})
+
+    def test_failed_push_blocks_chart(self):
+        self.run_script('build')
+        self.run_script('push', success=False, FAIL_PUSH='1')
+        self.run_script('chart', success=False)
+
+    def test_peer_commit_mismatch_blocks_chart(self):
+        self.run_script('build')
+        self.run_script('push')
+        self.run_script('chart', success=False, PEER_REVISION='2'*40, PEER_IMAGE_REPOSITORY='registry.example/project/images-arm')
+
+    def test_cleanup_preserves_in_use_and_replaced_tags(self):
+        self.run_script('build')
+        self.run_script('cleanup', IN_USE='1')
+        self.assertEqual(len(self.images()), 2)
+        self.run_script('build')
+        images = self.images()
+        replaced = next(iter(images))
+        images[replaced] = 'sha256:'+'d'*64
+        (self.root / 'images.json').write_text(json.dumps(images))
+        self.run_script('cleanup')
+        self.assertEqual(list(self.images()), [replaced])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
为原生 Linux amd64 / arm64 自建构建机提供 Linkd 与 Console 的镜像构建、推送、Chart 打包上传及任务清理入口。宿主机只需提供 Docker/Buildx 和 Helm 等命令，Go、Node、pnpm 随现有多阶段 Dockerfile 使用；镜像源、目标仓库和凭据均通过 CI 环境变量传入。

- Dockerfile 增加运行时基础镜像及 npm registry 参数，保持公开默认值；构建时写入相同版本与 Git SHA，并验证两个成品镜像的架构和 `version` 输出。
- Chart 只在一个构建节点打包，支持双架构使用独立镜像仓库，随包生成架构覆盖文件和节点选择器，并检查两个构建结果的 Git SHA。
- 清理使用本次构建登记的镜像 ID 和标签，保留其他任务、容器引用及共享构建缓存。Docker 登录配置隔离到本次工作目录；Chart token 经 stdin 传入 curl。
- 新增使用文档和隔离测试，并将发布脚本测试纳入 `make check`。

验证：`make check` 已通过（Go 1.26.7、golangci-lint 2.13.2、Node 24、Helm 4.2.2），包含 Go 单测/vet/race/lint、134 个 Console 测试及构建、15 个现有 Chart 测试、7 个隔离编排测试和 2 个 Chart 打包测试。Console 测试曾出现一次超时，重跑完整门禁通过。

未运行真实 Docker 镜像构建、推送或 Chart 上传；这些操作需要在目标构建池和制品仓库完成验证。
