### PR TITLE
fix(linkd): 修复 Console 镜像依赖裁剪参数

### DIFF
--- a/pkg/linkd/console/Dockerfile
+++ b/pkg/linkd/console/Dockerfile
@@ -10,7 +10,8 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile --registry="${NPM_REGISTRY}"
 COPY . .
-RUN NODE_OPTIONS="${NODE_BUILD_OPTIONS}" pnpm build && npm_config_registry="${NPM_REGISTRY}" pnpm prune --prod
+# prune 不接受 --registry；通过 pnpm 的配置参数传入，保持依赖裁剪使用相同的源。
+RUN NODE_OPTIONS="${NODE_BUILD_OPTIONS}" pnpm build && pnpm prune --prod --config.registry="${NPM_REGISTRY}"
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 RUN VERSION="${VERSION}" GIT_COMMIT="${GIT_COMMIT}" node -e 'require("node:fs").writeFileSync("build-info.json", JSON.stringify({version: process.env.VERSION, git_commit: process.env.GIT_COMMIT}))'

--- a/pkg/linkd/docs/guides/ci-release.md
+++ b/pkg/linkd/docs/guides/ci-release.md
@@ -28,6 +28,8 @@ ARM 构建步骤将 `TARGET_ARCH` 改为 `arm64`，并配置对应的 `IMAGE_REP
 
 两个架构的 clone 应固定同一个 Git 提交。若流水线按分支拉取，Chart 步骤必须比对两个 push 步骤输出的 `revision`；存在差异时停止发布，固定提交后重新构建。脚本输出使用蓝鲸 DevOps 的 `::set-output` 语法，其他 CI 可以从任务 `.release/<RELEASE_ID>-<TARGET_ARCH>/revision` 读取。
 
+`fast_git_clone` 等插件可能只导出源码，目标目录不保留 `.git`。此时在调用发布脚本前，将 `GIT_DIR` 指向拉取插件的缓存仓库 `.git`，并核对其 HEAD 与本次 clone 输出的 `commitId` 完全一致；每个 build、push、chart 步骤都需核对，避免共享缓存改变后写入错误的镜像版本信息。部分 DevOps 版本不会在自定义环境变量中展开 `${{ci.workspace}}` 和凭据引用；工作目录应在 Bash 内根据运行时 `$WORKSPACE` 计算，凭据引用由脚本插件解析，并关闭 `set -x`。
+
 ## Chart 打包与上传
 
 Chart 步骤复用已成功构建和推送镜像的机器与工作目录。两种架构都选中时，只在 amd64 机器打包；仅选 arm64 时，在 ARM 机器打包。
@@ -48,11 +50,13 @@ Chart 执行严格 lint、示例配置渲染以及各架构覆盖配置渲染，
 
 ## 清理与网络
 
-在流水线 `finally` 中调用：
+在保证失败或取消后也执行的清理步骤中调用：
 
 ```bash
 bash pkg/linkd/scripts/ci-release.sh cleanup
 ```
+
+蓝鲸 DevOps 可将清理放在每个架构的构建 Job 末尾，配置 `if: ALWAYS`，并在该 Job 内完成需要其镜像的 Chart 步骤。不要为未选择的架构创建需要复用构建节点的全局 Finally Job：该架构没有分配节点时，平台会在执行 Bash 条件判断前报错。双架构发布可以先完成 ARM 的构建、推送和清理，再由 X86 完成构建与 Chart 发布；只有 ARM 时，在 ARM Job 内打包 Chart 后再清理。
 
 清理只删除本次成功生成并登记的镜像标签，以及本次任务目录（含临时 Docker 登录配置和 Chart 副本）。标签已指向其他镜像或存在运行中／已停止容器引用时保留。不会使用全局 prune、强制删除，也不清除共享 BuildKit 缓存。流水线可以在脚本退出后删除本次独立 clone 目录；不得删除共享 Git 缓存或其他构建的目录。Agent 被强制终止或主机宕机可能阻止 finally 执行，此时使用相同 `RELEASE_ID` 手工清理。
 


### PR DESCRIPTION
Console 镜像在 pnpm 11.24.0 的依赖裁剪阶段因 `Unknown option: 'registry'` 失败。改用 `--config.registry` 传递同一包源，使前后端编译后的生产依赖裁剪能够完成。

补充自建 DevOps 的发布约束：源码导出目录通过已核对提交号的 Git 缓存获取版本信息；工作目录和凭据在 Bash 插件内解析；各架构在自身 Job 末尾执行 `if: ALWAYS` 清理，避免未选择的架构在全局 Finally 中复用不存在的节点。

验证：

- 本地实际构建 Linkd 和 Console 的 `linux/amd64` 镜像，两个成品均通过断网 `version` 检查；Console 的 pnpm install、build、prune 全部完成。
- 使用 Console 成品镜像生成 Chart 配置，完成 Helm 严格 lint、渲染和打包，并校验 Chart/appVersion。
- 使用发布脚本实际清理本次两个临时镜像及状态目录。
- `VITEST_MAX_WORKERS=2 make check` 全量通过，使用 Go 1.26.7、golangci-lint 2.13.2；默认高并发运行时已有前端测试出现超时，限制并发后通过。

本次本地镜像验证运行在 OrbStack 的 ARM 主机上，amd64 运行步骤通过仿真执行。内部原生 X86 流水线需要在合入同步后完成最终发布验证。
