### PR TITLE
fix(unify-query): query SurrealDB relation tables directly

### DIFF
--- a/pkg/unify-query/cmdb/struct.go
+++ b/pkg/unify-query/cmdb/struct.go
@@ -50,6 +50,8 @@ type RelationMultiResourceRequest struct {
 		TargetType     Resource `json:"target_type,omitempty"`
 		TargetInfoShow bool     `json:"target_info_show,omitempty"`
 
+		// MaxHops controls v1beta3 traversal depth; nil uses the server default.
+		MaxHops       *int       `json:"max_hops,omitempty"`
 		PathResource  []Resource `json:"path_resource,omitempty"`
 		LookBackDelta string     `json:"look_back_delta,omitempty"`
 	} `json:"query_list"`
@@ -93,6 +95,8 @@ type RelationMultiResourceRangeRequest struct {
 		TargetType     Resource `json:"target_type,omitempty"`
 		TargetInfoShow bool     `json:"target_info_show,omitempty"`
 
+		// MaxHops controls v1beta3 traversal depth; nil uses the server default.
+		MaxHops       *int       `json:"max_hops,omitempty"`
 		PathResource  []Resource `json:"path_resource,omitempty"`
 		LookBackDelta string     `json:"look_back_delta,omitempty"`
 	} `json:"query_list"`

--- a/pkg/unify-query/cmdb/v1beta3/binding_resolver.go
+++ b/pkg/unify-query/cmdb/v1beta3/binding_resolver.go
@@ -272,11 +272,14 @@ func (r *BindingResolver) fetchFromRedis(ctx context.Context, tenantID, spaceUID
 func (r *BindingResolver) fetchFromResultTableRoute(ctx context.Context, tenantID, spaceUID, bizID string, lookup bindingRedisLookup) (*BindingInfo, error) {
 	fields := routeRedisFields(tenantID, spaceUID)
 	spaceValue, err := lookup(ctx, DefaultSpaceToResultTableRedisKey, fields[0])
-	if errors.Is(err, goRedis.Nil) || spaceValue == "" {
+	if errors.Is(err, goRedis.Nil) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get space_to_result_table route from redis failed: %w", err)
+	}
+	if spaceValue == "" {
+		return nil, nil
 	}
 	var tableRoutes map[string]any
 	if err := json.Unmarshal([]byte(spaceValue), &tableRoutes); err != nil {
@@ -290,11 +293,14 @@ func (r *BindingResolver) fetchFromResultTableRoute(ctx context.Context, tenantI
 
 	for _, tableID := range tableIDs {
 		value, err := lookup(ctx, DefaultResultTableDetailRedisKey, routeRedisFields(tenantID, tableID)[0])
-		if errors.Is(err, goRedis.Nil) || value == "" {
+		if errors.Is(err, goRedis.Nil) {
 			continue
 		}
 		if err != nil {
 			return nil, fmt.Errorf("get result_table_detail route from redis failed: table_id=%s: %w", tableID, err)
+		}
+		if value == "" {
+			continue
 		}
 		var detail map[string]any
 		if err := json.Unmarshal([]byte(value), &detail); err != nil {

--- a/pkg/unify-query/cmdb/v1beta3/binding_resolver_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/binding_resolver_test.go
@@ -200,3 +200,40 @@ func routeRedisLookupForTest(values map[string]string, requests *[]string) bindi
 func routeRedisLookupKey(key, field string) string {
 	return fmt.Sprintf("%s#%s", key, field)
 }
+
+func TestBindingResolverPreservesRedisFailure(t *testing.T) {
+	for _, failedKey := range []string{DefaultSpaceToResultTableRedisKey, DefaultResultTableDetailRedisKey} {
+		t.Run(failedKey, func(t *testing.T) {
+			failure := fmt.Errorf("redis unavailable")
+			resolver := &BindingResolver{redisLookup: func(_ context.Context, key, field string) (string, error) {
+				if key == failedKey {
+					return "", failure
+				}
+				return `{"graph":{}}`, nil
+			}}
+			_, err := resolver.Resolve(contextWithTenantForBindingResolverTest("default"), "bkcc__7")
+			require.ErrorIs(t, err, failure)
+		})
+	}
+}
+
+func TestBindingResolverRecoversAfterRouteProvisioning(t *testing.T) {
+	for _, biz := range []string{"2", "7", "10"} {
+		t.Run(biz, func(t *testing.T) {
+			ctx := contextWithTenantForBindingResolverTest("default")
+			space := "bkcc__" + biz
+			values := map[string]string{}
+			resolver := &BindingResolver{redisLookup: routeRedisLookupForTest(values, nil)}
+			_, err := resolver.Resolve(ctx, space)
+			require.ErrorContains(t, err, "no usable SurrealDB result table route")
+			values[routeRedisLookupKey(DefaultSpaceToResultTableRedisKey, space+"|default")] = `{"graph":{}}`
+			values[routeRedisLookupKey(DefaultResultTableDetailRedisKey, "graph|default")] = fmt.Sprintf(`{"storage_type":"victoria_metrics","storage_id":6,"surrealdb":{"storage_type":"surrealdb","storage_id":7,"namespace":"mapleleaf_2","database":"2_bkm_%s_bkcc_built_in_time_series_graph"}}`, biz)
+			info, err := resolver.Resolve(ctx, space)
+			require.NoError(t, err)
+			require.Equal(t, "2_bkm_"+biz+"_bkcc_built_in_time_series_graph", info.Database)
+			require.Equal(t, "7", info.StorageID)
+			_, err = resolver.Resolve(contextWithTenantForBindingResolverTest("system"), space)
+			require.ErrorContains(t, err, "no usable SurrealDB result table route")
+		})
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/graph_e2e_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/graph_e2e_test.go
@@ -12,7 +12,6 @@ package v1beta3
 import (
 	"encoding/json"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,11 +41,7 @@ func getNodeStaticTestCase() E2ETestCase {
 			LookBackDelta:        600000,
 			Limit:                10,
 		},
-		ExpectedSQL: `LET $timestamp = 600000;
-LET $look_back_delta = 600000;
-LET $start = 0;
-LET $end = 600;
-LET $start_ms = 0;
+		ExpectedSQL: `LET $start_ms = 0;
 LET $end_ms = 600000;
 
 SELECT {
@@ -55,59 +50,24 @@ SELECT {
         entity_id: <string>id,
         entity_data: { bcs_cluster_id: bcs_cluster_id, node: node },
         created_at: created_at,
-        updated_at: updated_at,
-        liveness: (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
+        updated_at: updated_at
     },
 
     hop1: {
-        node_with_system: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'node_with_system',
-            relation_category: 'static',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM node_with_system_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'system',
-                entity_id: <string>out,
-                entity_data: { bk_target_ip: out.bk_target_ip },
-                liveness: (SELECT * FROM system_liveness_record WHERE reference_id = $parent.out AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM node_with_system WHERE in = $parent.id
-          AND (SELECT * FROM node_with_system_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE),
-        node_with_pod: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'node_with_pod',
-            relation_category: 'static',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'pod',
-                entity_id: <string>out,
-                entity_data: { bcs_cluster_id: out.bcs_cluster_id, namespace: out.namespace, pod: out.pod },
-                liveness: (SELECT * FROM pod_liveness_record WHERE reference_id = $parent.out AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM node_with_pod WHERE in = $parent.id
-          AND (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE),
-        datasource_with_node: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'datasource_with_node',
-            relation_category: 'static',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM datasource_with_node_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'datasource',
-                entity_id: <string>in,
-                entity_data: { bk_data_id: in.bk_data_id },
-                liveness: (SELECT * FROM datasource_liveness_record WHERE reference_id = $parent.in AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM datasource_with_node WHERE out = $parent.id
-          AND (SELECT * FROM datasource_with_node_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE)
+node_with_system: (SELECT VALUE { hop: 1, relation_type: 'node_with_system', relation_category: 'static', relation_id: <string>type::record('node_with_system', relation_id), relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'system', entity_id: <string>target_id, entity_data: { bk_target_ip: target_id.bk_target_ip } } } FROM node_with_system WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001),
+node_with_pod: (SELECT VALUE { hop: 1, relation_type: 'node_with_pod', relation_category: 'static', relation_id: <string>type::record('node_with_pod', relation_id), relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'pod', entity_id: <string>target_id, entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod } } } FROM node_with_pod WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001),
+datasource_with_node: (SELECT VALUE { hop: 1, relation_type: 'datasource_with_node', relation_category: 'static', relation_id: <string>type::record('datasource_with_node', relation_id), relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'datasource', entity_id: <string>source_id, entity_data: { bk_data_id: source_id.bk_data_id } } } FROM datasource_with_node WHERE target_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001)
     }
 } AS result
 FROM node
 WHERE bcs_cluster_id = 'BCS-K8S-00001'
   AND node = 'node-1'
-  AND (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
 LIMIT 10;`,
 		MockResponse: []map[string]any{
 			{
@@ -255,11 +215,7 @@ func getSystemDynamicOutboundTestCase() E2ETestCase {
 			LookBackDelta:            600000,
 			Limit:                    10,
 		},
-		ExpectedSQL: `LET $timestamp = 600000;
-LET $look_back_delta = 600000;
-LET $start = 0;
-LET $end = 600;
-LET $start_ms = 0;
+		ExpectedSQL: `LET $start_ms = 0;
 LET $end_ms = 600000;
 
 SELECT {
@@ -268,46 +224,20 @@ SELECT {
         entity_id: <string>id,
         entity_data: { bk_target_ip: bk_target_ip },
         created_at: created_at,
-        updated_at: updated_at,
-        liveness: (SELECT * FROM system_liveness_record WHERE reference_id = $parent.id AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
+        updated_at: updated_at
     },
 
     hop1: {
-        system_to_pod_outbound: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'system_to_pod',
-            relation_category: 'dynamic',
-            direction: 'outbound',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM system_to_pod_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'pod',
-                entity_id: <string>out,
-                entity_data: { bcs_cluster_id: out.bcs_cluster_id, namespace: out.namespace, pod: out.pod },
-                liveness: (SELECT * FROM pod_liveness_record WHERE reference_id = $parent.out AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM system_to_pod WHERE in = $parent.id
-          AND (SELECT * FROM system_to_pod_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE),
-        system_to_system_outbound: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'system_to_system',
-            relation_category: 'dynamic',
-            direction: 'outbound',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM system_to_system_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'system',
-                entity_id: <string>out,
-                entity_data: { bk_target_ip: out.bk_target_ip },
-                liveness: (SELECT * FROM system_liveness_record WHERE reference_id = $parent.out AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM system_to_system WHERE in = $parent.id
-          AND (SELECT * FROM system_to_system_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE)
+system_to_pod_outbound: (SELECT VALUE { hop: 1, relation_type: 'system_to_pod', relation_category: 'dynamic', relation_id: <string>type::record('system_to_pod', relation_id), direction: 'outbound', relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'pod', entity_id: <string>target_id, entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod } } } FROM system_to_pod WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001),
+system_to_system_outbound: (SELECT VALUE { hop: 1, relation_type: 'system_to_system', relation_category: 'dynamic', relation_id: <string>type::record('system_to_system', relation_id), direction: 'outbound', relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'system', entity_id: <string>target_id, entity_data: { bk_target_ip: target_id.bk_target_ip } } } FROM system_to_system WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001)
     }
 } AS result
 FROM system
 WHERE bk_target_ip = '192.168.1.1'
-  AND (SELECT * FROM system_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
 LIMIT 10;`,
 		MockResponse: []map[string]any{
 			{
@@ -414,11 +344,7 @@ func getEmptyResponseTestCase() E2ETestCase {
 			LookBackDelta:        600000,
 			Limit:                10,
 		},
-		ExpectedSQL: `LET $timestamp = 600000;
-LET $look_back_delta = 600000;
-LET $start = 0;
-LET $end = 600;
-LET $start_ms = 0;
+		ExpectedSQL: `LET $start_ms = 0;
 LET $end_ms = 600000;
 
 SELECT {
@@ -427,59 +353,24 @@ SELECT {
         entity_id: <string>id,
         entity_data: { bcs_cluster_id: bcs_cluster_id, node: node },
         created_at: created_at,
-        updated_at: updated_at,
-        liveness: (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
+        updated_at: updated_at
     },
 
     hop1: {
-        node_with_system: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'node_with_system',
-            relation_category: 'static',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM node_with_system_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'system',
-                entity_id: <string>out,
-                entity_data: { bk_target_ip: out.bk_target_ip },
-                liveness: (SELECT * FROM system_liveness_record WHERE reference_id = $parent.out AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM node_with_system WHERE in = $parent.id
-          AND (SELECT * FROM node_with_system_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE),
-        node_with_pod: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'node_with_pod',
-            relation_category: 'static',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'pod',
-                entity_id: <string>out,
-                entity_data: { bcs_cluster_id: out.bcs_cluster_id, namespace: out.namespace, pod: out.pod },
-                liveness: (SELECT * FROM pod_liveness_record WHERE reference_id = $parent.out AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM node_with_pod WHERE in = $parent.id
-          AND (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE),
-        datasource_with_node: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'datasource_with_node',
-            relation_category: 'static',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM datasource_with_node_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'datasource',
-                entity_id: <string>in,
-                entity_data: { bk_data_id: in.bk_data_id },
-                liveness: (SELECT * FROM datasource_liveness_record WHERE reference_id = $parent.in AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM datasource_with_node WHERE out = $parent.id
-          AND (SELECT * FROM datasource_with_node_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE)
+node_with_system: (SELECT VALUE { hop: 1, relation_type: 'node_with_system', relation_category: 'static', relation_id: <string>type::record('node_with_system', relation_id), relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'system', entity_id: <string>target_id, entity_data: { bk_target_ip: target_id.bk_target_ip } } } FROM node_with_system WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001),
+node_with_pod: (SELECT VALUE { hop: 1, relation_type: 'node_with_pod', relation_category: 'static', relation_id: <string>type::record('node_with_pod', relation_id), relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'pod', entity_id: <string>target_id, entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod } } } FROM node_with_pod WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001),
+datasource_with_node: (SELECT VALUE { hop: 1, relation_type: 'datasource_with_node', relation_category: 'static', relation_id: <string>type::record('datasource_with_node', relation_id), relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }], target: { entity_type: 'datasource', entity_id: <string>source_id, entity_data: { bk_data_id: source_id.bk_data_id } } } FROM datasource_with_node WHERE target_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001)
     }
 } AS result
 FROM node
 WHERE bcs_cluster_id = 'BCS-K8S-00001'
   AND node = 'non-existent'
-  AND (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
 LIMIT 10;`,
 		MockResponse: []map[string]any{
 			{
@@ -837,7 +728,7 @@ func TestGraphE2E(t *testing.T) {
 
 			// Step 2: 验证 SQL（如果 ExpectedSQL 非空）
 			if tc.ExpectedSQL != "" {
-				assert.Equal(t, tc.ExpectedSQL, stripTargetLivenessFilterSQL(actualSQL), "Generated SQL mismatch")
+				assert.Equal(t, tc.ExpectedSQL, actualSQL, "Generated SQL mismatch")
 			} else {
 				t.Logf("Generated SQL (length=%d):\n%s", len(actualSQL), actualSQL)
 			}
@@ -857,42 +748,6 @@ func TestGraphE2E(t *testing.T) {
 			}
 		})
 	}
-}
-
-func stripTargetLivenessFilterSQL(sql string) string {
-	lines := strings.Split(sql, "\n")
-	// 旧用例只比较目标存活过滤逻辑；先移除新增的边数量保护，使 SQL 仍可按原口径归一化比较。
-	withoutEdgeLimits := lines[:0]
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "LIMIT 1001)") {
-			if len(withoutEdgeLimits) > 0 {
-				withoutEdgeLimits[len(withoutEdgeLimits)-1] += strings.TrimPrefix(trimmed, "LIMIT 1001")
-			}
-			continue
-		}
-		withoutEdgeLimits = append(withoutEdgeLimits, line)
-	}
-
-	filtered := withoutEdgeLimits[:0]
-	for _, line := range withoutEdgeLimits {
-		if strings.Contains(line, "AND (SELECT * FROM") &&
-			strings.Contains(line, " WHERE reference_id = $parent.") &&
-			(strings.Contains(line, "$parent.out ") || strings.Contains(line, "$parent.in ")) {
-			if len(filtered) > 0 {
-				trimmed := strings.TrimSpace(line)
-				switch {
-				case strings.HasSuffix(trimmed, "),"):
-					filtered[len(filtered)-1] += "),"
-				case strings.HasSuffix(trimmed, ")"):
-					filtered[len(filtered)-1] += ")"
-				}
-			}
-			continue
-		}
-		filtered = append(filtered, line)
-	}
-	return strings.Join(filtered, "\n")
 }
 
 // assertLivenessGraphEqual 比较两个 LivenessGraph，忽略 Adjacency 中的顺序差异

--- a/pkg/unify-query/cmdb/v1beta3/hook.go
+++ b/pkg/unify-query/cmdb/v1beta3/hook.go
@@ -25,11 +25,7 @@ func setDefaultConfig() {
 	viper.SetDefault(MaxEdgesPerHopConfigPath, 1000)
 	viper.SetDefault(MaxTargetsConfigPath, 5000)
 	viper.SetDefault(MaxResponseBytesConfigPath, 10*1024*1024)
-	viper.SetDefault(RootRecordIDEnabledConfigPath, false)
 	viper.SetDefault(DefaultLookBackDeltaConfigPath, 86400000) // 24小时（毫秒）
-	viper.SetDefault(ActiveEdgeServingRelationsConfigPath, []string{})
-	viper.SetDefault(FlatOneHopActiveEdgeServingRelationsConfigPath, []string{})
-	viper.SetDefault(FlatMultiHopActiveEdgeServingRelationsConfigPath, []string{})
 	viper.SetDefault(VMPreferredRelationsConfigPath, []string{})
 
 	viper.SetDefault(BKBaseSurrealDBResultTableIDConfigPath, DefaultBKBaseSurrealDBResultTableID)
@@ -48,11 +44,7 @@ func LoadConfig() {
 	MaxEdgesPerHop = viper.GetInt(MaxEdgesPerHopConfigPath)
 	MaxTargets = viper.GetInt(MaxTargetsConfigPath)
 	MaxResponseBytes = viper.GetInt(MaxResponseBytesConfigPath)
-	RootRecordIDEnabled = viper.GetBool(RootRecordIDEnabledConfigPath)
 	DefaultLookBackDelta = viper.GetInt64(DefaultLookBackDeltaConfigPath)
-	ActiveEdgeServingRelations = viper.GetStringSlice(ActiveEdgeServingRelationsConfigPath)
-	FlatOneHopActiveEdgeServingRelations = viper.GetStringSlice(FlatOneHopActiveEdgeServingRelationsConfigPath)
-	FlatMultiHopActiveEdgeServingRelations = viper.GetStringSlice(FlatMultiHopActiveEdgeServingRelationsConfigPath)
 	VMPreferredRelations = viper.GetStringSlice(VMPreferredRelationsConfigPath)
 
 	BKBaseSurrealDBResultTableID = viper.GetString(BKBaseSurrealDBResultTableIDConfigPath)

--- a/pkg/unify-query/cmdb/v1beta3/hop_budget_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/hop_budget_test.go
@@ -1,0 +1,137 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/relation"
+)
+
+func TestSameTypeQueryHonorsHopBudget(t *testing.T) {
+	provider := NewSchemaProviderFromRelation(relation.NewStaticSchemaProvider(relation.StaticProviderConfig{
+		ResourcePrimaryKeys: map[string][]string{"pod": {"pod"}, "system": {"bk_target_ip"}},
+		RelationSchemas: []relation.RelationSchema{
+			{RelationName: "pod_to_pod", Category: relation.RelationCategoryDynamic, FromType: "pod", ToType: "pod", IsDirectional: true},
+			{RelationName: "pod_to_system", Category: relation.RelationCategoryDynamic, FromType: "pod", ToType: "system", IsDirectional: true},
+			{RelationName: "system_to_pod", Category: relation.RelationCategoryDynamic, FromType: "system", ToType: "pod", IsDirectional: true},
+		},
+	}))
+	for _, hops := range []int{1, 2, 3} {
+		t.Run(string(rune('0'+hops)), func(t *testing.T) {
+			executor := &mockGraphQueryExecutor{}
+			model, err := NewModel(context.Background(), executor)
+			require.NoError(t, err)
+			model.SetSchemaProvider(provider)
+			req := &QueryRequest{Timestamp: 300000, SourceType: ResourceTypePod, SourceInfo: map[string]string{"pod": "p1"}, TargetType: ResourceTypePod, TargetTypeExplicit: true, MaxHops: hops, AllowedRelationTypes: []RelationCategory{RelationCategoryDynamic}, DynamicRelationDirection: DirectionOutbound}
+			_, paths, _, err := model.QueryLivenessGraph(context.Background(), req)
+			require.NoError(t, err)
+			require.Equal(t, hops, req.MaxHops)
+			require.NotEmpty(t, paths)
+			longest := 0
+			for _, path := range paths {
+				length := len(path.Steps) - 1
+				require.LessOrEqual(t, length, hops)
+				if length > longest {
+					longest = length
+				}
+			}
+			require.Equal(t, hops, longest, "repeated pod types must not terminate discovery at the first pod")
+		})
+	}
+}
+
+func TestRelationAdaptersValidateHTTPHopBudget(t *testing.T) {
+	for _, payload := range []string{
+		`{"query_list":[{"max_hops":0}]}`,
+		`{"query_list":[{"max_hops":-1}]}`,
+		`{"query_list":[{"max_hops":999}]}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			var instant cmdb.RelationMultiResourceRequest
+			var ranged cmdb.RelationMultiResourceRangeRequest
+			require.NoError(t, json.Unmarshal([]byte(payload), &instant))
+			require.NoError(t, json.Unmarshal([]byte(payload), &ranged))
+			executor := &mockGraphQueryExecutor{}
+			model, err := NewModel(context.Background(), executor)
+			require.NoError(t, err)
+			_, _, _, _, _, err = model.QueryResourceMatcherWithMaxHops(context.Background(), "", "", "300", "pod", "pod", cmdb.Matcher{"pod": "p1"}, nil, false, nil, instant.QueryList[0].MaxHops)
+			require.ErrorContains(t, err, "max_allowed_hops")
+			_, _, _, _, _, err = model.QueryResourceMatcherRangeWithMaxHops(context.Background(), "", "", "60s", "120", "300", "pod", "pod", cmdb.Matcher{"pod": "p1"}, nil, false, nil, ranged.QueryList[0].MaxHops)
+			require.ErrorContains(t, err, "max_allowed_hops")
+			require.Empty(t, executor.sqls)
+		})
+	}
+}
+
+func TestQueryLivenessGraphRejectsExcessiveHopBudget(t *testing.T) {
+	executor := &mockGraphQueryExecutor{}
+	model, err := NewModel(context.Background(), executor)
+	require.NoError(t, err)
+	req := &QueryRequest{Timestamp: 300000, SourceType: ResourceTypePod, SourceInfo: map[string]string{"pod": "p1"}, TargetType: ResourceTypePod, TargetTypeExplicit: true, MaxHops: MaxAllowedHops + 1}
+	_, _, _, err = model.QueryLivenessGraph(context.Background(), req)
+	require.ErrorContains(t, err, "max_allowed_hops")
+	require.Equal(t, MaxAllowedHops+1, req.MaxHops)
+	require.Empty(t, executor.sqls)
+}
+
+func TestRelationAdaptersHonorSameTypeHopBudget(t *testing.T) {
+	provider := NewSchemaProviderFromRelation(relation.NewStaticSchemaProvider(relation.StaticProviderConfig{
+		ResourcePrimaryKeys: map[string][]string{"pod": {"pod"}, "system": {"bk_target_ip"}},
+		RelationSchemas:     []relation.RelationSchema{{RelationName: "pod_with_system", Category: relation.RelationCategoryStatic, FromType: "pod", ToType: "system"}},
+	}))
+	for _, hops := range []int{1, 3} {
+		t.Run(string(rune('0'+hops)), func(t *testing.T) {
+			executor := &mockGraphQueryExecutor{}
+			model, err := NewModel(context.Background(), executor)
+			require.NoError(t, err)
+			model.SetSchemaProvider(provider)
+			_, _, _, _, _, instantErr := model.QueryResourceMatcherWithMaxHops(context.Background(), "", "", "300", "pod", "pod", cmdb.Matcher{"pod": "p1"}, nil, false, nil, &hops)
+			_, _, _, _, _, rangeErr := model.QueryResourceMatcherRangeWithMaxHops(context.Background(), "", "", "60s", "120", "300", "pod", "pod", cmdb.Matcher{"pod": "p1"}, nil, false, nil, &hops)
+			if hops == 1 {
+				require.ErrorContains(t, instantErr, "empty paths")
+				require.ErrorContains(t, rangeErr, "empty paths")
+				require.Empty(t, executor.sqls)
+			} else {
+				require.NoError(t, instantErr)
+				require.NoError(t, rangeErr)
+				require.NotEmpty(t, executor.sqls)
+			}
+		})
+	}
+}
+
+func TestSameTypeExtractionPreservesPathAndHopBound(t *testing.T) {
+	graph := NewLivenessGraph(0, 100)
+	graph.RootID = "p1"
+	hops := 2
+	graph.maxTargetHops = &hops
+	periods := []*VisiblePeriod{{Start: 0, End: 100}}
+	for _, id := range []string{"p1", "p2", "p3", "p4"} {
+		graph.AddNode(&NodeLiveness{ResourceID: id, ResourceType: ResourceTypePod, Labels: map[string]string{"pod": id}, RawPeriods: periods})
+	}
+	for _, edge := range [][2]string{{"p1", "p2"}, {"p2", "p3"}, {"p3", "p4"}} {
+		graph.AddEdge(&EdgeLiveness{RelationID: edge[0] + edge[1], FromID: edge[0], ToID: edge[1], RawPeriods: periods})
+	}
+	merged := mergeLivenessGraphsByRoot([]*LivenessGraph{graph})
+	require.Len(t, merged, 1)
+	for _, paths := range [][]*TargetPath{
+		merged[0].TargetPaths(ResourceTypePod, []ResourceType{ResourceTypePod, ResourceTypePod, ResourceTypePod}, false),
+		merged[0].TargetPathsFromFilteredInstantQuery(ResourceTypePod, []ResourceType{ResourceTypePod, ResourceTypePod, ResourceTypePod}, false),
+	} {
+		require.Len(t, paths, 1)
+		require.Equal(t, "p3", paths[0].Target.ResourceID)
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/liveness_graph.go
+++ b/pkg/unify-query/cmdb/v1beta3/liveness_graph.go
@@ -16,6 +16,9 @@ import (
 )
 
 type LivenessGraph struct {
+	// maxTargetHops bounds extraction after rows from different SQL hops are merged.
+	maxTargetHops *int
+
 	QueryStart      int64                    `json:"query_start"`
 	QueryEnd        int64                    `json:"query_end"`
 	RootID          string                   `json:"root_id,omitempty"`
@@ -167,6 +170,10 @@ func mergeLivenessGraphsByRoot(graphs []*LivenessGraph) []*LivenessGraph {
 }
 
 func mergeLivenessGraphInto(dst, src *LivenessGraph) {
+	if src != nil && dst != nil && src.maxTargetHops != nil && (dst.maxTargetHops == nil || *src.maxTargetHops < *dst.maxTargetHops) {
+		dst.maxTargetHops = src.maxTargetHops
+	}
+
 	if dst == nil || src == nil {
 		return
 	}
@@ -298,6 +305,9 @@ func (g *LivenessGraph) collectTargetPaths(
 		})
 	}
 
+	if g.maxTargetHops != nil && len(edgePeriods) >= *g.maxTargetHops {
+		return
+	}
 	for _, edge := range g.outEdgesFromMap(nodeID) {
 		allowSelfLoop := !includeRootTarget && edge.ToID == nodeID && len(edgePeriods) == 0 && node.ResourceType == targetType
 		if visited[edge.ToID] && !allowSelfLoop {

--- a/pkg/unify-query/cmdb/v1beta3/path.go
+++ b/pkg/unify-query/cmdb/v1beta3/path.go
@@ -91,16 +91,6 @@ func NewPathFinder(opts ...PathFinderOption) *PathFinder {
 
 // FindAllPaths 查找从 source 到 target 的所有路径
 func (pf *PathFinder) FindAllPaths(source, target ResourceType, pathResource []ResourceType) ([]resourcePath, error) {
-	if source == target && len(pathResource) == 0 {
-		// 显式 source==target 优先解释为“查真实自关联边”；
-		// 只有 schema 中完全没有自关联时，才回退成单节点信息展示路径。
-		paths := pf.findSelfRelationPaths(source)
-		if len(paths) > 0 {
-			return paths, nil
-		}
-		return []resourcePath{{Steps: []resourcePathStep{{ResourceType: string(source)}}}}, nil
-	}
-
 	pathConstraint, directOnly := normalizePathResource(source, target, pathResource)
 	var results []resourcePath
 	visited := make(map[ResourceType]bool)
@@ -119,25 +109,6 @@ func (pf *PathFinder) FindAllPaths(source, target ResourceType, pathResource []R
 	return results, nil
 }
 
-func (pf *PathFinder) findSelfRelationPaths(resourceType ResourceType) []resourcePath {
-	var results []resourcePath
-	for _, rel := range pf.getRelationsForType(resourceType) {
-		if rel.TargetType != resourceType {
-			continue
-		}
-		results = append(results, resourcePath{Steps: []resourcePathStep{
-			{ResourceType: string(resourceType)},
-			{
-				ResourceType: string(resourceType),
-				RelationType: string(rel.Schema.RelationType),
-				Category:     string(rel.Schema.Category),
-				Direction:    string(rel.Direction),
-			},
-		}})
-	}
-	return results
-}
-
 func normalizePathResource(source, target ResourceType, pathResource []ResourceType) ([]ResourceType, bool) {
 	if len(pathResource) == 0 {
 		return nil, false
@@ -146,6 +117,11 @@ func normalizePathResource(source, target ResourceType, pathResource []ResourceT
 	pathConstraint := make([]ResourceType, 0, len(pathResource))
 	hasDirectOnlyConstraint := false
 	hasFullEndpointConstraint := len(pathResource) >= 2 && pathResource[0] == source && pathResource[len(pathResource)-1] == target
+	// Preserve complete multi-hop paths, including repeated endpoint types.
+	// Dropping every occurrence of pod would turn pod -> pod -> pod into direct-only.
+	if hasFullEndpointConstraint && len(pathResource) > 2 {
+		return pathResource, false
+	}
 	for _, resourceType := range pathResource {
 		if resourceType == "" {
 			// 旧 VM 客户端用空字符串表达“只允许 source->target 直连”。
@@ -193,6 +169,8 @@ func (pf *PathFinder) dfs(
 			copy(pathCopy, currentPath)
 			*results = append(*results, resourcePath{Steps: pathCopy})
 		}
+	}
+	if len(currentPath) == pf.maxHops+1 {
 		return
 	}
 
@@ -201,9 +179,7 @@ func (pf *PathFinder) dfs(
 	for _, rel := range relations {
 		nextType := rel.TargetType
 		wasVisited := visited[nextType]
-		// nextType == target 时允许“访问已访问过的终点”来保留
-		// source -> ... -> target 这种显式闭环；递归开头会在命中 target 后直接 return，
-		// 因此不会继续从 target 扩散成无限环路。
+		// 允许再次到达目标类型，例如 pod -> pod -> pod；maxHops 限制展开深度。
 		if wasVisited && nextType != target {
 			continue
 		}

--- a/pkg/unify-query/cmdb/v1beta3/path_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/path_test.go
@@ -231,7 +231,22 @@ func TestPathFinder_FindAllPaths(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tc.Expected, paths)
+			// First-arrival paths remain unchanged. Additional paths may continue through
+			// a target of the same type, but must remain within the requested budget.
+			var firstArrival []resourcePath
+			for _, path := range paths {
+				assert.LessOrEqual(t, len(path.Steps)-1, tc.MaxHops)
+				repeatedTarget := false
+				for _, step := range path.Steps[1 : len(path.Steps)-1] {
+					if step.ResourceType == string(tc.Target) {
+						repeatedTarget = true
+					}
+				}
+				if !repeatedTarget {
+					firstArrival = append(firstArrival, path)
+				}
+			}
+			assert.Equal(t, tc.Expected, firstArrival)
 		})
 	}
 }

--- a/pkg/unify-query/cmdb/v1beta3/request.go
+++ b/pkg/unify-query/cmdb/v1beta3/request.go
@@ -9,7 +9,11 @@
 
 package v1beta3
 
-import "github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/relation"
+import (
+	"fmt"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/utils/relation"
+)
 
 // QueryRequest 关联查询请求
 type QueryRequest struct {
@@ -22,7 +26,7 @@ type QueryRequest struct {
 	TargetTypeExplicit       bool               `json:"-"`                                    // target_type 是否由调用方显式传入
 	TargetInfoShow           bool               `json:"target_info_show,omitempty"`           // 是否展示目标资源扩展信息
 	PathResource             []ResourceType     `json:"path_resource,omitempty"`              // 路径约束资源类型
-	MaxHops                  int                `json:"max_hops,omitempty"`                   // 最大跳数（默认2，范围1-5）
+	MaxHops                  int                `json:"max_hops,omitempty"`                   // 请求最大跳数；未传使用 max_hops 配置，不能超过服务端 max_allowed_hops
 	AllowedRelationTypes     []RelationCategory `json:"allowed_relation_types,omitempty"`     // 允许的关系类别
 	DynamicRelationDirection TraversalDirection `json:"dynamic_relation_direction,omitempty"` // 动态关系方向（默认both）
 	LookBackDelta            int64              `json:"look_back_delta,omitempty"`            // 回溯时间窗口（毫秒，默认86400000）
@@ -34,11 +38,8 @@ type QueryRequest struct {
 
 // Normalize 规范化请求参数，填充默认值
 func (r *QueryRequest) Normalize() {
-	if r.MaxHops <= 0 {
+	if r.MaxHops == 0 {
 		r.MaxHops = DefaultMaxHops
-	}
-	if r.MaxHops > MaxAllowedHops {
-		r.MaxHops = MaxAllowedHops
 	}
 	if r.Limit <= 0 && !r.DisableRootLimit {
 		r.Limit = DefaultLimit
@@ -96,4 +97,12 @@ func (r *QueryRequest) IsRelationCategoryAllowed(category RelationCategory) bool
 		}
 	}
 	return false
+}
+
+// validateMaxHops rejects an invalid budget instead of silently changing query depth.
+func validateMaxHops(hops int) error {
+	if hops < 1 || hops > MaxAllowedHops {
+		return fmt.Errorf("max_hops must be between 1 and max_allowed_hops (%d), got %d", MaxAllowedHops, hops)
+	}
+	return nil
 }

--- a/pkg/unify-query/cmdb/v1beta3/settings.go
+++ b/pkg/unify-query/cmdb/v1beta3/settings.go
@@ -10,19 +10,15 @@
 package v1beta3
 
 const (
-	MaxHopsConfigPath                                = "cmdb.v1beta3.max_hops"
-	MaxAllowedHopsConfigPath                         = "cmdb.v1beta3.max_allowed_hops"
-	DefaultLimitConfigPath                           = "cmdb.v1beta3.default_limit"
-	MaxRangePointsConfigPath                         = "cmdb.v1beta3.max_range_points"
-	MaxEdgesPerHopConfigPath                         = "cmdb.v1beta3.max_edges_per_hop"
-	MaxTargetsConfigPath                             = "cmdb.v1beta3.max_targets"
-	MaxResponseBytesConfigPath                       = "cmdb.v1beta3.max_response_bytes"
-	RootRecordIDEnabledConfigPath                    = "cmdb.v1beta3.root_record_id.enabled"
-	DefaultLookBackDeltaConfigPath                   = "cmdb.v1beta3.look_back_delta"
-	ActiveEdgeServingRelationsConfigPath             = "cmdb.v1beta3.active_edge_serving.relations"
-	FlatOneHopActiveEdgeServingRelationsConfigPath   = "cmdb.v1beta3.active_edge_serving.flat_one_hop_relations"
-	FlatMultiHopActiveEdgeServingRelationsConfigPath = "cmdb.v1beta3.active_edge_serving.flat_multi_hop_relations"
-	VMPreferredRelationsConfigPath                   = "cmdb.v1beta3.vm_preferred.relations"
+	MaxHopsConfigPath              = "cmdb.v1beta3.max_hops"
+	MaxAllowedHopsConfigPath       = "cmdb.v1beta3.max_allowed_hops"
+	DefaultLimitConfigPath         = "cmdb.v1beta3.default_limit"
+	MaxRangePointsConfigPath       = "cmdb.v1beta3.max_range_points"
+	MaxEdgesPerHopConfigPath       = "cmdb.v1beta3.max_edges_per_hop"
+	MaxTargetsConfigPath           = "cmdb.v1beta3.max_targets"
+	MaxResponseBytesConfigPath     = "cmdb.v1beta3.max_response_bytes"
+	DefaultLookBackDeltaConfigPath = "cmdb.v1beta3.look_back_delta"
+	VMPreferredRelationsConfigPath = "cmdb.v1beta3.vm_preferred.relations"
 )
 
 var (
@@ -35,18 +31,9 @@ var (
 	// MaxTargets 限制单个时间点可返回的目标数量。
 	MaxTargets = 5000
 	// MaxResponseBytes 限制 BKBase 查询响应体大小，防止超大响应占用过多内存。
-	MaxResponseBytes = 10 * 1024 * 1024
-	// RootRecordIDEnabled 控制是否使用完整主键生成 Record ID 定点查询根资源。
-	RootRecordIDEnabled        = false
-	DefaultLookBackDelta       = int64(86400000) // 24小时（毫秒）
-	ActiveEdgeServingRelations = []string{}
-	// FlatOneHopActiveEdgeServingRelations 仅允许已完成主键投影和复合索引验证的 Event relation
-	// 使用单跳扁平查询。raw relation 和多跳查询不受该配置影响。
-	FlatOneHopActiveEdgeServingRelations = []string{}
-	// FlatMultiHopActiveEdgeServingRelations 仅允许所有 hop 均完成主键投影和复合索引验证的
-	// Event relation。多跳由 UQ 分层并发执行，避免在 SurrealQL 中以 $parent 相关查询展开下一跳。
-	FlatMultiHopActiveEdgeServingRelations = []string{}
-	VMPreferredRelations                   = []string{}
+	MaxResponseBytes     = 10 * 1024 * 1024
+	DefaultLookBackDelta = int64(86400000) // 24小时（毫秒）
+	VMPreferredRelations = []string{}
 )
 
 // effectiveMaxEdgesPerHop 返回单个节点每跳允许展开的最大边数，并为非法配置提供安全默认值。

--- a/pkg/unify-query/cmdb/v1beta3/single_table_live_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/single_table_live_test.go
@@ -1,0 +1,332 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/cmdb"
+	traceservice "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/service/trace"
+	uqtrace "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// This opt-in, read-only acceptance test runs inside the query Pod. Credentials
+// arrive on stdin and are never logged or stored by the test.
+type singleTableLiveConfig struct {
+	Host, User, Password, Namespace, Database string
+	Trace                                     map[string]any
+	Tables                                    []struct{ Table, Source, Target string }
+}
+
+type singleTableLiveExecutor struct{ config singleTableLiveConfig }
+
+func (e *singleTableLiveExecutor) query(ctx context.Context, sql string) ([]map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.config.Host+"/sql", strings.NewReader(sql))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("surreal-ns", e.config.Namespace)
+	req.Header.Set("surreal-db", e.config.Database)
+	req.SetBasicAuth(e.config.User, e.config.Password)
+	res, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("database transport failed")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("database HTTP status %d", res.StatusCode)
+	}
+	var statements []map[string]any
+	if err := json.NewDecoder(io.LimitReader(res.Body, 16<<20)).Decode(&statements); err != nil {
+		return nil, err
+	}
+	for i, s := range statements {
+		if s["status"] != "OK" {
+			return nil, fmt.Errorf("statement %d: %v", i, s["result"])
+		}
+	}
+	return statements, nil
+}
+
+func (e *singleTableLiveExecutor) Execute(ctx context.Context, sql string, start, end int64) (graphs []*LivenessGraph, err error) {
+	ctx, span := uqtrace.NewSpan(ctx, "surrealdb-single-table-direct")
+	defer span.End(&err)
+	span.Set("dsl", sql)
+	span.Set("namespace", e.config.Namespace)
+	span.Set("database", e.config.Database)
+	statements, err := e.query(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := normalizeDirectSurrealDBResponse(statements)
+	if err != nil {
+		return nil, err
+	}
+	return NewSurrealResponseParser(start, end).Parse([]map[string]any{{"result": rows}})
+}
+
+func liveRows(t *testing.T, e *singleTableLiveExecutor, sql string) []any {
+	t.Helper()
+	s, err := e.query(context.Background(), sql)
+	require.NoError(t, err)
+	require.NotEmpty(t, s)
+	rows, ok := responseArray(s[len(s)-1]["result"])
+	require.True(t, ok)
+	return rows
+}
+
+func liveMatcher(t *testing.T, provider SchemaProvider, resource ResourceType, row map[string]any) map[string]string {
+	t.Helper()
+	result := map[string]string{}
+	keys := provider.GetResourcePrimaryKeys("", resource)
+	require.NotEmpty(t, keys)
+	for _, key := range keys {
+		value, ok := row[key].(string)
+		require.True(t, ok, "missing entity key %s for %s", key, resource)
+		result[key] = value
+	}
+	return result
+}
+
+func liveTargetIDs(graphs []*LivenessGraph, relation RelationType) []string {
+	ids := map[string]bool{}
+	for _, g := range graphs {
+		for _, edge := range g.Edges {
+			if edge.RelationType == relation {
+				ids[edge.ToID] = true
+			}
+		}
+	}
+	result := []string{}
+	for id := range ids {
+		result = append(result, id)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func liveReferenceIDs(rows []any, start, end int64) []string {
+	ids := map[string]bool{}
+	for _, v := range rows {
+		r := v.(map[string]any)
+		a := int64(r["start"].(float64))
+		b := int64(r["end"].(float64))
+		if a <= b && a <= end && b >= start {
+			ids[r["target"].(string)] = true
+		}
+	}
+	result := []string{}
+	for id := range ids {
+		result = append(result, id)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func TestSingleTableLiveAcceptance(t *testing.T) {
+	if os.Getenv("UQ_SINGLE_TABLE_LIVE") != "1" {
+		t.Skip("requires explicit read-only database configuration on stdin")
+	}
+	var config singleTableLiveConfig
+	require.NoError(t, json.NewDecoder(os.Stdin).Decode(&config))
+	require.NotEmpty(t, config.Tables)
+	executor := &singleTableLiveExecutor{config: config}
+	if len(config.Trace) > 0 {
+		viper.Set("trace", config.Trace)
+		viper.Set("trace.enable", true)
+		viper.Set("trace.service_name", "unify-query-single-table-test")
+		traceservice.InitConfig()
+		service := &traceservice.Service{}
+		service.Start(context.Background())
+		defer func() { service.Close(); service.Wait() }()
+	}
+	provider := NewStaticSchemaProvider()
+	populated := 0
+	for _, table := range config.Tables {
+		t.Run(table.Table, func(t *testing.T) {
+			var sampleRows []any
+			for _, offset := range []int{0, 128, 512, 2048} {
+				rows := liveRows(t, executor, fmt.Sprintf("SELECT source_id, target_id, source_id.* AS source_entity, target_id.* AS target_entity, active_period_start_ms, active_period_end_ms FROM %s LIMIT 1 START %d;", surrealTableName(table.Table), offset))
+				if len(rows) == 0 {
+					break
+				}
+				row := rows[0].(map[string]any)
+				valid := true
+				for _, endpoint := range []struct{ field, resource string }{{"source_entity", table.Source}, {"target_entity", table.Target}} {
+					entity, _ := row[endpoint.field].(map[string]any)
+					for _, key := range provider.GetResourcePrimaryKeys("", ResourceType(endpoint.resource)) {
+						value, ok := entity[key].(string)
+						if !ok || value == "" {
+							valid = false
+						}
+					}
+				}
+				if valid {
+					sampleRows = rows
+					break
+				}
+			}
+			if len(sampleRows) == 0 {
+				t.Skip("no positive sample with complete endpoint keys within bounded sampling")
+			}
+			populated++
+			sample := sampleRows[0].(map[string]any)
+			end := int64(sample["active_period_end_ms"].(float64))
+			start := int64(sample["active_period_start_ms"].(float64))
+			if end > start+300000 {
+				end = start + 300000
+			}
+			for _, reverse := range []bool{false, true} {
+				sourceType, targetType := ResourceType(table.Source), ResourceType(table.Target)
+				sourceField, targetField, entityField := "source_id", "target_id", "source_entity"
+				direction := DirectionOutbound
+				if reverse {
+					sourceType, targetType = targetType, sourceType
+					sourceField, targetField, entityField = "target_id", "source_id", "target_entity"
+					direction = DirectionInbound
+				}
+				sourceID := sample[sourceField].(string)
+				entity := sample[entityField].(map[string]any)
+				sourceInfo := liveMatcher(t, provider, sourceType, entity)
+				relationType := RelationType(table.Table)
+				request := &QueryRequest{Timestamp: end, LookBackDelta: end - start, SourceType: sourceType, SourceInfo: sourceInfo, TargetType: targetType, TargetTypeExplicit: true, MaxHops: 1}
+				path := resourcePath{Steps: []resourcePathStep{{ResourceType: string(sourceType)}, {ResourceType: string(targetType), RelationType: table.Table, Category: string(RelationCategoryStatic), Direction: string(direction)}}}
+				// Use the live table contract, independent of optional global relation categories.
+				resources := map[ResourceType]tableResourceDefinition{}
+				for _, r := range []ResourceType{sourceType, targetType} {
+					resources[r] = tableResourceDefinition{primaryKeys: provider.GetResourcePrimaryKeys("", r)}
+				}
+				schema := newTableSchemaProvider(resources, []RelationSchema{{RelationType: relationType, Category: RelationCategoryStatic, FromType: ResourceType(table.Source), ToType: ResourceType(table.Target)}})
+				reference := liveRows(t, executor, fmt.Sprintf("SELECT <string>%s AS target, active_period_start_ms AS start, active_period_end_ms AS end FROM %s WHERE %s = <record>'%s';", targetField, surrealTableName(table.Table), sourceField, escapeSurrealString(sourceID)))
+				for _, mode := range []graphQueryMode{graphQueryModeInstant, graphQueryModeRange} {
+					t.Run(fmt.Sprintf("%s/%s", direction, mode), func(t *testing.T) {
+						builder := NewSurrealQueryBuilderForPath(request, schema, path)
+						configureBuilderForGraphQueryMode(builder, mode)
+						sql := builder.Build()
+						require.NotContains(t, sql, "_liveness_record")
+						require.NotContains(t, sql, "_active_edge_view")
+						require.NotContains(t, sql, "source_data")
+						require.NotContains(t, sql, "target_data")
+						graphs, err := executor.Execute(context.Background(), sql, start, end)
+						require.NoError(t, err)
+						require.Equal(t, liveReferenceIDs(reference, start, end), liveTargetIDs(graphs, relationType))
+						require.NotEmpty(t, graphs, "positive sample must produce results")
+						model, err := NewModel(context.Background(), executor)
+						require.NoError(t, err)
+						model.SetSchemaProvider(schema)
+						ctx, span := uqtrace.NewSpan(context.Background(), "single-table-acceptance")
+						span.Set("test-case", table.Table+"/"+string(direction)+"/"+string(mode))
+						span.Set("test-request", request)
+						modelGraphs, modelPaths, modelMatchers, err := model.queryLivenessGraph(ctx, cloneQueryRequest(request), mode, start, end, 60000)
+						span.Set("target-count", len(liveTargetIDs(modelGraphs, relationType)))
+						span.End(&err)
+						response := map[string]any{"paths": modelPaths, "matchers": modelMatchers}
+						defer func() {
+							record, _ := json.Marshal(map[string]any{"case": table.Table, "direction": direction, "mode": mode, "trace_id": span.TraceID(), "request": request, "response": response, "target_count": len(liveTargetIDs(modelGraphs, relationType))})
+							t.Logf("TRACE_RECORD %s", record)
+						}()
+						require.NoError(t, err)
+						require.Equal(t, liveReferenceIDs(reference, start, end), liveTargetIDs(modelGraphs, relationType), "Model result must match independent table read")
+						for _, g := range graphs {
+							for _, edge := range g.Edges {
+								labels := g.GetNode(edge.ToID).Labels
+								for _, key := range schema.GetResourcePrimaryKeys("", targetType) {
+									_, ok := labels[key]
+									require.True(t, ok, "missing target label %s", key)
+								}
+							}
+						}
+						if mode == graphQueryModeRange {
+							for _, g := range graphs {
+								for _, edge := range g.Edges {
+									require.NotEmpty(t, edge.RawPeriods)
+								}
+							}
+							points := buildTargetMatchersTimeSeriesWithOptions(modelGraphs, targetType, []ResourceType{sourceType, targetType}, start, end, 60000, schema, "", false, false)
+							response["range_result"] = points
+							byTime := map[int64]cmdb.Matchers{}
+							for _, point := range points {
+								byTime[point.Timestamp] = point.Matchers
+							}
+							for bucket := start; bucket <= end; bucket += 60000 {
+								// The public range contract is count_over_time over (bucket-step, bucket].
+								expected := map[string]bool{}
+								for _, value := range reference {
+									row := value.(map[string]any)
+									a, b := int64(row["start"].(float64)), int64(row["end"].(float64))
+									if a <= b && a <= end && b >= start && a <= bucket && b > bucket-60000 {
+										expected[row["target"].(string)] = true
+									}
+								}
+								require.Len(t, byTime[bucket], len(expected), "bucket %d", bucket)
+							}
+						}
+					})
+				}
+			}
+		})
+	}
+	t.Logf("relations=%d positive_samples=%d empty_tables=%d", len(config.Tables), populated, len(config.Tables)-populated)
+	t.Run("host_module_set", func(t *testing.T) { liveHostModuleSet(t, executor, provider) })
+}
+
+func liveHostModuleSet(t *testing.T, executor *singleTableLiveExecutor, provider SchemaProvider) {
+	rows := liveRows(t, executor, "SELECT source_id, source_id.* AS entity, last_seen_at FROM host_with_module LIMIT 1;")
+	require.NotEmpty(t, rows)
+	sample := rows[0].(map[string]any)
+	end := int64(sample["last_seen_at"].(float64))
+	start := end - 1
+	sourceID := sample["source_id"].(string)
+	referenceSQL := fmt.Sprintf(`LET $modules = (SELECT VALUE target_id FROM host_with_module WHERE source_id = <record>'%s' AND active_period_start_ms <= %d AND active_period_end_ms >= %d AND active_period_start_ms <= active_period_end_ms);
+SELECT <string>target_id AS target, active_period_start_ms AS start, active_period_end_ms AS end FROM module_with_set WHERE source_id IN $modules AND active_period_start_ms <= %d AND active_period_end_ms >= %d AND active_period_start_ms <= active_period_end_ms;`, escapeSurrealString(sourceID), end, start, end, start)
+	reference := liveRows(t, executor, referenceSQL)
+	require.NotEmpty(t, reference, "two-hop positive reference required")
+	resources := map[ResourceType]tableResourceDefinition{}
+	for _, r := range []ResourceType{ResourceTypeHost, ResourceTypeModule, ResourceTypeSet} {
+		resources[r] = tableResourceDefinition{primaryKeys: provider.GetResourcePrimaryKeys("", r)}
+	}
+	schema := newTableSchemaProvider(resources, []RelationSchema{
+		{RelationType: RelationHostWithModule, Category: RelationCategoryStatic, FromType: ResourceTypeHost, ToType: ResourceTypeModule},
+		{RelationType: RelationModuleWithSet, Category: RelationCategoryStatic, FromType: ResourceTypeModule, ToType: ResourceTypeSet},
+	})
+	request := &QueryRequest{Timestamp: end, LookBackDelta: 1, LookBackDeltaSet: true, SourceType: ResourceTypeHost, SourceInfo: liveMatcher(t, provider, ResourceTypeHost, sample["entity"].(map[string]any)), TargetType: ResourceTypeSet, TargetTypeExplicit: true, MaxHops: 2, PathResource: []ResourceType{ResourceTypeModule}}
+	model, err := NewModel(context.Background(), executor)
+	require.NoError(t, err)
+	model.SetSchemaProvider(schema)
+	for _, mode := range []graphQueryMode{graphQueryModeInstant, graphQueryModeRange} {
+		t.Run(string(mode), func(t *testing.T) {
+			ctx, span := uqtrace.NewSpan(context.Background(), "single-table-acceptance-multi-hop")
+			span.Set("test-case", "host/module/set/"+string(mode))
+			span.Set("test-request", request)
+			graphs, paths, matchers, err := model.queryLivenessGraph(ctx, cloneQueryRequest(request), mode, start, end, 1)
+			span.Set("target-count", len(matchers))
+			span.End(&err)
+			record, _ := json.Marshal(map[string]any{"case": "host/module/set", "mode": mode, "trace_id": span.TraceID(), "request": request, "response": map[string]any{"paths": paths, "matchers": matchers}, "target_count": len(matchers)})
+			t.Logf("TRACE_RECORD %s", record)
+			require.NoError(t, err)
+			require.NotEmpty(t, matchers)
+			require.Len(t, paths, 1)
+			require.Len(t, paths[0].Steps, 3)
+			require.Equal(t, liveReferenceIDs(reference, start, end), liveTargetIDs(graphs, RelationModuleWithSet))
+		})
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/single_table_query_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/single_table_query_test.go
@@ -1,0 +1,33 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleTableLogicalEdgeIdentity(t *testing.T) {
+	provider := newTableSchemaProvider(map[ResourceType]tableResourceDefinition{
+		ResourceTypeHost: {primaryKeys: []string{"bk_host_id"}}, ResourceTypeModule: {primaryKeys: []string{"bk_module_id"}},
+	}, []RelationSchema{
+		{RelationType: "first_link", Category: RelationCategoryStatic, FromType: ResourceTypeHost, ToType: ResourceTypeModule},
+		{RelationType: "second_link", Category: RelationCategoryStatic, FromType: ResourceTypeHost, ToType: ResourceTypeModule},
+	})
+	sql := NewSurrealQueryBuilderWithSchemaProvider(&QueryRequest{SourceType: ResourceTypeHost, SourceInfo: map[string]string{"bk_host_id": "1"}, TargetType: ResourceTypeModule, MaxHops: 1}, provider).Build()
+	// History segments share the logical relation ID within a table, while IDs
+	// from different relation tables must not overwrite one another in the graph.
+	require.Contains(t, sql, "type::record('first_link', relation_id)")
+	require.Contains(t, sql, "type::record('second_link', relation_id)")
+	require.NotContains(t, sql, "relation_id: <string>id")
+	require.NotContains(t, sql, "_liveness_record")
+	require.NotContains(t, sql, "_active_edge_view")
+}

--- a/pkg/unify-query/cmdb/v1beta3/sql_proxy_integration_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/sql_proxy_integration_test.go
@@ -75,11 +75,7 @@ func TestSurrealQLSQLProxyIntegration(t *testing.T) {
 				Limit:              1,
 			},
 			stepMs: 2000,
-			wantSQL: `LET $timestamp = 1782558879000;
-LET $look_back_delta = 2000;
-LET $start = 1782558877;
-LET $end = 1782558879;
-LET $start_ms = 1782558877000;
+			wantSQL: `LET $start_ms = 1782558877000;
 LET $end_ms = 1782558879000;
 
 SELECT {
@@ -150,11 +146,7 @@ LIMIT 1;`,
 				Limit:              1,
 			},
 			stepMs: 2000,
-			wantSQL: `LET $timestamp = 1782558879000;
-LET $look_back_delta = 2000;
-LET $start = 1782558877;
-LET $end = 1782558879;
-LET $start_ms = 1782558877000;
+			wantSQL: `LET $start_ms = 1782558877000;
 LET $end_ms = 1782558879000;
 
 SELECT {

--- a/pkg/unify-query/cmdb/v1beta3/surreal_query_builder.go
+++ b/pkg/unify-query/cmdb/v1beta3/surreal_query_builder.go
@@ -19,24 +19,10 @@ import (
 
 // SQL 模板常量
 const (
-	sqlIndent1 = "    "                     // 1级缩进
-	sqlIndent2 = "        "                 // 2级缩进
-	sqlIndent3 = "            "             // 3级缩进
-	sqlIndent4 = "                "         // 4级缩进
-	sqlIndent5 = "                    "     // 5级缩进
-	sqlIndent6 = "                        " // 6级缩进
+	sqlIndent1 = "    "
 
-	fieldIn         = "in"
-	fieldOut        = "out"
-	fieldRelationID = "relation_id"
-
-	// SQL 子查询模板
-	tplLivenessSelect    = "(SELECT * FROM %s WHERE %s = $parent.id AND period_end >= $start AND period_start <= $end AND period_start <= period_end)"
-	tplLivenessSelectRef = "(SELECT * FROM %s WHERE %s = $parent.%s AND period_end >= $start AND period_start <= $end AND period_start <= period_end)"
-	tplRelLivenessSelect = "(SELECT * FROM %s WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end)"
-	tplLivenessFilter    = "(SELECT * FROM %s WHERE %s = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE"
-	tplLivenessFilterRef = "(SELECT * FROM %s WHERE %s = $parent.%s AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE"
-	tplRelLivenessFilter = "(SELECT * FROM %s WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE"
+	fieldIn  = "in"
+	fieldOut = "out"
 )
 
 // buildEntityDataFields 构建 entity_data 字段列表
@@ -55,17 +41,13 @@ func buildEntityDataFields(keys []string, prefix string) string {
 
 // SurrealQueryBuilder 构建 SurrealQL 关联查询
 type SurrealQueryBuilder struct {
-	request                    *QueryRequest
-	pathFinder                 *PathFinder
-	schemaProvider             SchemaProvider
-	namespace                  string
-	transitions                map[int]map[ResourceType]map[pathTransition]struct{}
-	projectLiveness            bool
-	queryMode                  graphQueryMode
-	activeEdgeServingRelations map[RelationType]struct{}
-	flatOneHopServingRelations map[RelationType]struct{}
-	servingHopCount            int
-	pathHopCount               int
+	request         *QueryRequest
+	pathFinder      *PathFinder
+	schemaProvider  SchemaProvider
+	namespace       string
+	transitions     map[int]map[ResourceType]map[pathTransition]struct{}
+	projectLiveness bool
+	pathHopCount    int
 }
 
 type pathTransition struct {
@@ -99,41 +81,14 @@ func NewSurrealQueryBuilderWithSchemaProvider(request *QueryRequest, provider Sc
 
 	pf := NewPathFinder(allOpts...)
 
-	servingRelations := make(map[RelationType]struct{})
-	for _, relation := range ActiveEdgeServingRelations {
-		servingRelations[RelationType(relation)] = struct{}{}
-	}
-	flatOneHopServingRelations := make(map[RelationType]struct{})
-	for _, relation := range FlatOneHopActiveEdgeServingRelations {
-		flatOneHopServingRelations[RelationType(relation)] = struct{}{}
-	}
-
 	return &SurrealQueryBuilder{
-		request:                    request,
-		pathFinder:                 pf,
-		schemaProvider:             provider,
-		namespace:                  namespace,
-		transitions:                buildPathTransitions(request, pf),
-		projectLiveness:            true,
-		activeEdgeServingRelations: servingRelations,
-		flatOneHopServingRelations: flatOneHopServingRelations,
+		request:         request,
+		pathFinder:      pf,
+		schemaProvider:  provider,
+		namespace:       namespace,
+		transitions:     buildPathTransitions(request, pf),
+		projectLiveness: true,
 	}
-}
-
-func (b *SurrealQueryBuilder) useActiveEdgeServing(relationType RelationType) bool {
-	if b == nil {
-		return false
-	}
-	_, ok := b.activeEdgeServingRelations[relationType]
-	return ok
-}
-
-func (b *SurrealQueryBuilder) useFlatOneHopActiveEdgeServing(relationType RelationType) bool {
-	if b == nil {
-		return false
-	}
-	_, ok := b.flatOneHopServingRelations[relationType]
-	return ok
 }
 
 func NewSurrealQueryBuilderForPath(request *QueryRequest, provider SchemaProvider, path resourcePath) *SurrealQueryBuilder {
@@ -147,48 +102,21 @@ func NewSurrealQueryBuilderForPath(request *QueryRequest, provider SchemaProvide
 	builder.transitions = buildTransitionsFromPaths([]resourcePath{path})
 	builder.pathHopCount = maxInt(0, len(path.Steps)-1)
 	builder.request.MaxHops = builder.pathHopCount
-	for _, step := range path.Steps[1:] {
-		if _, ok := builder.activeEdgeServingRelations[RelationType(step.RelationType)]; ok {
-			builder.servingHopCount++
-		}
-	}
 	return builder
 }
 
 func (b *SurrealQueryBuilder) routeName() string {
-	if b.usesFlatOneHopActiveEdgeServingQuery() {
-		return "active_edge_serving_flat_one_hop"
+	if b.usesFlatOneHopRelationQuery() {
+		return "single_table_flat_one_hop"
 	}
-	if b == nil || b.servingHopCount == 0 {
-		return "raw"
-	}
-	if b.servingHopCount == b.pathHopCount {
-		return "active_edge_serving"
-	}
-	return "mixed"
+	return "single_table"
 }
 
-func (b *SurrealQueryBuilder) usesRelationOnlyLiveness() bool {
-	// 图路径只以直接上报的 relation liveness 为事实来源。resource liveness 没有独立上报，
-	// 若参与原始查询会与仅由 relation liveness 刷新的 active edge view 产生语义差异。
-	// 零跳 resource-info 查询仍需 resource liveness。
-	return b != nil && b.pathHopCount > 0
-}
-
-// WithoutLivenessProjection 保留存活性过滤条件，但不在 SELECT 结果中投影存活时段。
-// 即时关系查询只需要目标标签，范围查询仍需保留时段以完成时间桶对齐。
 func (b *SurrealQueryBuilder) WithoutLivenessProjection() *SurrealQueryBuilder {
 	if b != nil {
 		b.projectLiveness = false
 	}
 	return b
-}
-
-func (b *SurrealQueryBuilder) livenessProjection(prefix, field, tpl string, args ...any) string {
-	if b == nil || !b.projectLiveness {
-		return ""
-	}
-	return prefix + field + ": " + fmt.Sprintf(tpl, args...)
 }
 
 func cloneQueryRequest(request *QueryRequest) *QueryRequest {
@@ -274,50 +202,27 @@ func (b *SurrealQueryBuilder) Build() string {
 	var sb strings.Builder
 	sb.WriteString(b.buildVariables())
 	sb.WriteString("\n\n")
-	if b.usesFlatOneHopActiveEdgeServingQuery() {
-		sb.WriteString(b.buildFlatOneHopServingQuery(b.getRelationsForType(1, b.request.SourceType)[0]))
+	if b.usesFlatOneHopRelationQuery() {
+		sb.WriteString(b.buildFlatOneHopRelationQuery(b.getRelationsForType(1, b.request.SourceType)[0]))
 		return sb.String()
 	}
 	sb.WriteString(b.buildMainQuery())
 	return sb.String()
 }
 
-// usesFlatOneHopActiveEdgeServingQuery 只覆盖已完成主键索引验证的单跳 Event relation。
-// active edge 行已投影 relation liveness，直接以业务主键过滤可避开 root 相关 ProjectValue。
-func (b *SurrealQueryBuilder) usesFlatOneHopActiveEdgeServingQuery() bool {
-	if b == nil || (b.queryMode != graphQueryModeInstant && b.queryMode != graphQueryModeRange) || len(b.request.SourceExpandInfo) > 0 {
-		return false
-	}
-	if b.pathHopCount != 1 || !b.usesRelationOnlyLiveness() {
-		return false
-	}
-	relations := b.getRelationsForType(1, b.request.SourceType)
-	if len(relations) != 1 {
-		return false
-	}
-	rel := relations[0]
-	if !b.useActiveEdgeServing(rel.Schema.RelationType) || !b.useFlatOneHopActiveEdgeServing(rel.Schema.RelationType) {
-		return false
-	}
-	sourceDataField := "source_data"
-	if rel.WhereField == fieldOut {
-		sourceDataField = "target_data"
-	}
-	_, ok := b.flatServingPrimaryKeyConditions(sourceDataField)
-	return ok
+// usesFlatOneHopRelationQuery reads a single path directly from its relation table.
+func (b *SurrealQueryBuilder) usesFlatOneHopRelationQuery() bool {
+	return b != nil && b.pathHopCount == 1 && len(b.getRelationsForType(1, b.request.SourceType)) == 1
 }
 
-// buildFlatOneHopServingQuery 直接从 active edge view 返回单边图行。view 已完成
-// relation liveness 的预关联，保留嵌套投影会让 SurrealDB 再次执行高成本的 ProjectValue。
-// range 查询必须保留 active period 作为 relation_liveness，供响应解析器生成时间桶。
-func (b *SurrealQueryBuilder) buildFlatOneHopServingQuery(rel *RelationQueryInfo) string {
+func (b *SurrealQueryBuilder) buildFlatOneHopRelationQuery(rel *RelationQueryInfo) string {
 	relationType := rel.Schema.RelationType
-	table := surrealTableName(string(relationType) + "_active_edge_view")
-	sourceIDField, sourceDataField := "source_id", "source_data"
-	targetIDField, targetDataField, targetTypeField := "target_id", "target_data", "target_type"
+	table := surrealTableName(string(relationType))
+	sourceIDField := "source_id"
+	targetIDField := "target_id"
 	if rel.WhereField == fieldOut {
-		sourceIDField, sourceDataField = "target_id", "target_data"
-		targetIDField, targetDataField, targetTypeField = "source_id", "source_data", "source_type"
+		sourceIDField = "target_id"
+		targetIDField = "source_id"
 	}
 
 	direction := ""
@@ -325,13 +230,19 @@ func (b *SurrealQueryBuilder) buildFlatOneHopServingQuery(rel *RelationQueryInfo
 		direction = fmt.Sprintf("\n            direction: '%s',", rel.Direction)
 	}
 
-	primaryKeyConditions, _ := b.flatServingPrimaryKeyConditions(sourceDataField)
+	sourceQuery := "SELECT VALUE id FROM " + surrealTableName(string(b.request.SourceType))
+	if conditions := b.sourceFilterConditions(true); len(conditions) > 0 {
+		sourceQuery += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	sourceData := "{ " + buildEntityDataFields(b.rootEntityDataFields(b.request.SourceType), sourceIDField) + " }"
+	targetData := "{ " + buildEntityDataFields(b.targetEntityDataFields(rel.TargetType), targetIDField) + " }"
 	relationLiveness := ""
 	if b.projectLiveness {
 		relationLiveness = "\n            relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }],"
 	}
 
-	return fmt.Sprintf(`SELECT {
+	return fmt.Sprintf(`LET $source_ids = (%s);
+SELECT {
     root: {
         entity_type: '%s',
         entity_id: <string>%s,
@@ -342,7 +253,7 @@ func (b *SurrealQueryBuilder) buildFlatOneHopServingQuery(rel *RelationQueryInfo
             hop: 1,
             relation_type: '%s',
             relation_category: '%s',%s
-            relation_id: <string>relation_id,%s
+            relation_id: <string>type::record('%s', relation_id),%s
             target: {
                 entity_type: %s,
                 entity_id: <string>%s,
@@ -357,26 +268,28 @@ WHERE %s
   AND active_period_start_ms <= $end_ms
   AND active_period_end_ms >= $start_ms
 LIMIT %d;`,
+		sourceQuery,
 		b.request.SourceType,
 		sourceIDField,
-		sourceDataField,
+		sourceData,
 		surrealObjectKey(string(relationType)+rel.KeySuffix),
 		relationType,
 		rel.Schema.Category,
 		direction,
+		escapeSurrealString(string(relationType)),
 		relationLiveness,
-		targetTypeField,
+		fmt.Sprintf("'%s'", rel.TargetType),
 		targetIDField,
-		targetDataField,
+		targetData,
 		table,
-		strings.Join(primaryKeyConditions, "\n  AND "),
+		sourceIDField+" IN $source_ids",
 		maxEdgesPerHopQueryLimit(),
 	)
 }
 
-// buildFlatServingQueryForPath 为 UQ 分层多跳执行构造单跳 Event 查询。每次调用都把当前 hop 的
-// source 主键写成字面量，因此不会在 SurrealDB 内以 $parent 相关子查询展开下一跳。
-func buildFlatServingQueryForPath(
+// buildFlatRelationQueryForPath resolves endpoint IDs using entity labels and
+// reads one relation table, without recursively expanding the next hop in SQL.
+func buildFlatRelationQueryForPath(
 	request *QueryRequest,
 	provider SchemaProvider,
 	path resourcePath,
@@ -393,34 +306,14 @@ func buildFlatServingQueryForPath(
 		return "", false
 	}
 
-	sourceDataField := "source_data"
-	if relations[0].WhereField == fieldOut {
-		sourceDataField = "target_data"
-	}
-	if _, ok := builder.flatServingPrimaryKeyConditions(sourceDataField); !ok {
-		return "", false
-	}
-
-	return builder.buildVariables() + "\n\n" + builder.buildFlatOneHopServingQuery(relations[0]), true
+	return builder.buildVariables() + "\n\n" + builder.buildFlatOneHopRelationQuery(relations[0]), true
 }
 
 // buildVariables 构建变量定义部分
 func (b *SurrealQueryBuilder) buildVariables() string {
 	startMs, endMs := b.request.GetQueryRange()
-	// 实体 liveness 表沿用旧 VM 秒级窗口，关系 liveness 表写入的是毫秒级窗口。
-	// 同一条 SurrealQL 同时保留两组变量，避免在查询层混用单位导致节点或边误判为不活跃。
-	startSec := startMs / 1000
-	endSec := endMs / 1000
-	return fmt.Sprintf(`LET $timestamp = %d;
-LET $look_back_delta = %d;
-LET $start = %d;
-LET $end = %d;
-LET $start_ms = %d;
+	return fmt.Sprintf(`LET $start_ms = %d;
 LET $end_ms = %d;`,
-		b.request.Timestamp,
-		b.request.LookBackDelta,
-		startSec,
-		endSec,
 		startMs,
 		endMs)
 }
@@ -453,61 +346,23 @@ func (b *SurrealQueryBuilder) buildMainQuery() string {
 	return sb.String()
 }
 
-// buildRootSource 优先使用完整主键构造 SurrealDB Record ID，以避免对根资源表做全表扫描；
-// 功能未开启或主键不完整时仍回退为原有的表名查询。
+// buildRootSource reads stored entities; their record IDs come from Databus
+// and must not be reconstructed from metadata label names.
 func (b *SurrealQueryBuilder) buildRootSource() string {
-	if recordID, ok := b.rootRecordID(); ok {
-		return recordID
-	}
-	return escapeSurrealIdentifier(string(b.request.SourceType))
+	return surrealTableName(string(b.request.SourceType))
 }
 
-// rootRecordID 按 Schema 中声明的主键顺序构造复合 Record ID，确保生成结果稳定且与入参 map 顺序无关。
-func (b *SurrealQueryBuilder) rootRecordID() (string, bool) {
-	if b == nil || b.request == nil || !RootRecordIDEnabled || len(b.request.SourceInfo) == 0 {
-		return "", false
-	}
-	primaryKeys := b.schemaProvider.GetResourcePrimaryKeys(b.namespace, b.request.SourceType)
-	if len(primaryKeys) == 0 {
-		return "", false
-	}
-	pairs := make([]string, 0, len(primaryKeys))
-	for _, key := range primaryKeys {
-		value, ok := b.request.SourceInfo[key]
-		if !ok {
-			return "", false
-		}
-		pairs = append(pairs, escapeSurrealRecordIDPart(key)+"="+escapeSurrealRecordIDPart(value))
-	}
-	return fmt.Sprintf("%s:⟨%s⟩", escapeSurrealIdentifier(string(b.request.SourceType)), strings.Join(pairs, ",")), true
-}
-
-// escapeSurrealRecordIDPart 转义 Record ID 尖括号内容中的反斜杠和结束符，避免破坏 SurrealQL 语法。
-func escapeSurrealRecordIDPart(value string) string {
-	value = strings.ReplaceAll(value, `\`, `\\`)
-	return strings.ReplaceAll(value, "⟩", `\⟩`)
-}
-
-// buildRootSelect 构建 Root 实体的 SELECT 结构
 func (b *SurrealQueryBuilder) buildRootSelect() string {
 	sourceType := b.request.SourceType
 	rootFields := b.rootEntityDataFields(sourceType)
-	rootLiveness := ""
-	if !b.usesRelationOnlyLiveness() {
-		livenessTable := surrealTableName(GetLivenessRecordTableName(sourceType))
-		livenessIDField := GetLivenessIDField(sourceType)
-		rootLiveness = b.livenessProjection(",\n        ", ResponseFieldLiveness, tplLivenessSelect, livenessTable, livenessIDField)
-	}
-
 	return fmt.Sprintf(`{
         entity_type: meta::tb(id),
         entity_id: <string>id,
         entity_data: { %s },
         created_at: created_at,
-        updated_at: updated_at%s
+        updated_at: updated_at
     }`,
-		buildEntityDataFields(rootFields, ""),
-		rootLiveness)
+		buildEntityDataFields(rootFields, ""))
 }
 
 func (b *SurrealQueryBuilder) rootEntityDataFields(sourceType ResourceType) []string {
@@ -601,398 +456,51 @@ func (b *SurrealQueryBuilder) getRelationsForType(hop int, resourceType Resource
 	return filtered
 }
 
-// buildRelationQuery 构建单个关系的查询
+// buildRelationQuery reads periods directly from the relation table. Endpoint records
+// supply labels because the five-argument writer does not populate snapshots.
 func (b *SurrealQueryBuilder) buildRelationQuery(hop int, _ ResourceType, rel *RelationQueryInfo) string {
-	relationType := rel.Schema.RelationType
-	if b.useActiveEdgeServing(relationType) {
-		return b.buildServingRelationQuery(hop, rel, "$parent.id", sqlIndent2)
-	}
-	relationTable := surrealTableName(string(relationType))
-	relationLivenessTable := surrealTableName(GetRelationLivenessRecordTableName(relationType))
-	targetLivenessTable := surrealTableName(GetLivenessRecordTableName(rel.TargetType))
-	targetLivenessIDField := GetLivenessIDField(rel.TargetType)
-	keyName := surrealObjectKey(string(relationType) + rel.KeySuffix)
-	targetFields := b.targetEntityDataFields(rel.TargetType)
-	targetLiveness := ""
-	if !b.usesRelationOnlyLiveness() {
-		targetLiveness = b.livenessProjection(",\n                ", ResponseFieldLiveness, tplLivenessSelectRef, targetLivenessTable, targetLivenessIDField, rel.SelectField)
-	}
-
-	var fieldsBuilder strings.Builder
-	fieldsBuilder.WriteString(fmt.Sprintf(`
-            hop: %d,
-            relation_type: '%s',
-            relation_category: '%s',`, hop, relationType, rel.Schema.Category))
-
-	if rel.Schema.Category == RelationCategoryDynamic {
-		fieldsBuilder.WriteString(fmt.Sprintf(`
-            direction: '%s',`, rel.Direction))
-	}
-
-	fieldsBuilder.WriteString(fmt.Sprintf(`
-            relation_id: <string>id%s,
-            target: {
-                entity_type: '%s',
-                entity_id: <string>%s,
-                entity_data: { %s }%s`,
-		b.livenessProjection(",\n            ", ResponseFieldRelationLiveness, tplRelLivenessSelect, relationLivenessTable),
-		rel.TargetType,
-		rel.SelectField,
-		buildEntityDataFields(targetFields, rel.SelectField),
-		targetLiveness))
-
-	if hop < b.request.MaxHops {
-		nextHopKey := fmt.Sprintf("hop%d", hop+1)
-		nextHopSelect := b.buildNestedHopSelect(hop+1, rel.TargetType, rel.SelectField)
-		fieldsBuilder.WriteString(fmt.Sprintf(`,
-                %s: %s`, nextHopKey, nextHopSelect))
-	}
-
-	fieldsBuilder.WriteString(`
-            }`)
-
-	if b.usesRelationOnlyLiveness() {
-		return fmt.Sprintf(sqlIndent2+`%s: (SELECT VALUE {%s
-        } FROM %s WHERE %s = $parent.id
-          AND `+tplRelLivenessFilter+`
-          LIMIT %d)`,
-			keyName,
-			fieldsBuilder.String(),
-			relationTable,
-			rel.WhereField,
-			relationLivenessTable,
-			maxEdgesPerHopQueryLimit())
-	}
-
-	return fmt.Sprintf(sqlIndent2+`%s: (SELECT VALUE {%s
-        } FROM %s WHERE %s = $parent.id
-          AND `+tplRelLivenessFilter+`
-          AND `+tplLivenessFilterRef+`
-          LIMIT %d)`,
-		keyName,
-		fieldsBuilder.String(),
-		relationTable,
-		rel.WhereField,
-		relationLivenessTable,
-		targetLivenessTable,
-		targetLivenessIDField,
-		rel.SelectField,
-		maxEdgesPerHopQueryLimit())
+	return b.buildRelationQueryFrom(hop, rel, "$parent.id")
 }
 
-// buildNestedHopSelect 构建嵌套在 target 内的下一跳查询
-func (b *SurrealQueryBuilder) buildNestedHopSelect(hop int, currentType ResourceType, parentField string) string {
-	if hop > b.request.MaxHops {
-		return "{}"
-	}
-
-	relations := b.getRelationsForType(hop, currentType)
-	if len(relations) == 0 {
-		return "{}"
-	}
-
-	var sb strings.Builder
-	sb.WriteString("{\n")
-
-	first := true
-	for _, rel := range relations {
-		if !first {
-			sb.WriteString(",\n")
-		}
-		first = false
-		sb.WriteString(b.buildNestedRelationQuery(hop, rel, parentField))
-	}
-
-	sb.WriteString("\n" + sqlIndent4 + "}")
-
-	return sb.String()
-}
-
-// buildNestedRelationQuery 构建嵌套的关系查询（用于 hop2+）
-func (b *SurrealQueryBuilder) buildNestedRelationQuery(hop int, rel *RelationQueryInfo, parentField string) string {
-	relationType := rel.Schema.RelationType
-	if b.useActiveEdgeServing(relationType) {
-		return b.buildServingRelationQuery(hop, rel, "$parent."+parentField, sqlIndent5)
-	}
-	relationTable := surrealTableName(string(relationType))
-	relationLivenessTable := surrealTableName(GetRelationLivenessRecordTableName(relationType))
-	targetLivenessTable := surrealTableName(GetLivenessRecordTableName(rel.TargetType))
-	targetLivenessIDField := GetLivenessIDField(rel.TargetType)
-	keyName := surrealObjectKey(string(relationType) + rel.KeySuffix)
-	targetFields := b.targetEntityDataFields(rel.TargetType)
-	targetLiveness := ""
-	if !b.usesRelationOnlyLiveness() {
-		targetLiveness = b.livenessProjection(",\n                            ", ResponseFieldLiveness, tplLivenessSelectRef, targetLivenessTable, targetLivenessIDField, rel.SelectField)
-	}
-
-	var fieldsBuilder strings.Builder
-	fieldsBuilder.WriteString(fmt.Sprintf(`
-                        hop: %d,
-                        relation_type: '%s',
-                        relation_category: '%s',`, hop, relationType, rel.Schema.Category))
-
-	if rel.Schema.Category == RelationCategoryDynamic {
-		fieldsBuilder.WriteString(fmt.Sprintf(`
-                        direction: '%s',`, rel.Direction))
-	}
-
-	fieldsBuilder.WriteString(fmt.Sprintf(`
-                        relation_id: <string>id%s,
-                        target: {
-                            entity_type: '%s',
-                            entity_id: <string>%s,
-                            entity_data: { %s }%s`,
-		b.livenessProjection(",\n                        ", ResponseFieldRelationLiveness, tplRelLivenessSelect, relationLivenessTable),
-		rel.TargetType,
-		rel.SelectField,
-		buildEntityDataFields(targetFields, rel.SelectField),
-		targetLiveness))
-
-	if hop < b.request.MaxHops {
-		nextHopKey := fmt.Sprintf("hop%d", hop+1)
-		nextHopSelect := b.buildDeeperNestedHopSelect(hop+1, rel.TargetType, rel.SelectField, 4)
-		fieldsBuilder.WriteString(fmt.Sprintf(`,
-                            %s: %s`, nextHopKey, nextHopSelect))
-	}
-
-	fieldsBuilder.WriteString(`
-                        }`)
-
-	if b.usesRelationOnlyLiveness() {
-		return fmt.Sprintf(sqlIndent5+`%s: (SELECT VALUE {%s
-                    } FROM %s WHERE %s = $parent.%s
-                      AND `+tplRelLivenessFilter+`
-                      LIMIT %d)`,
-			keyName,
-			fieldsBuilder.String(),
-			relationTable,
-			rel.WhereField,
-			parentField,
-			relationLivenessTable,
-			maxEdgesPerHopQueryLimit())
-	}
-
-	return fmt.Sprintf(sqlIndent5+`%s: (SELECT VALUE {%s
-                    } FROM %s WHERE %s = $parent.%s
-                      AND `+tplRelLivenessFilter+`
-                      AND `+tplLivenessFilterRef+`
-                      LIMIT %d)`,
-		keyName,
-		fieldsBuilder.String(),
-		relationTable,
-		rel.WhereField,
-		parentField,
-		relationLivenessTable,
-		targetLivenessTable,
-		targetLivenessIDField,
-		rel.SelectField,
-		maxEdgesPerHopQueryLimit())
-}
-
-// buildDeeperNestedHopSelect 构建更深层嵌套的 hop（hop3+）
-func (b *SurrealQueryBuilder) buildDeeperNestedHopSelect(hop int, currentType ResourceType, parentField string, indentLevel int) string {
-	if hop > b.request.MaxHops {
-		return "{}"
-	}
-
-	relations := b.getRelationsForType(hop, currentType)
-	if len(relations) == 0 {
-		return "{}"
-	}
-
-	indent := strings.Repeat(sqlIndent1, indentLevel)
-	var sb strings.Builder
-	sb.WriteString("{\n")
-
-	first := true
-	for _, rel := range relations {
-		if !first {
-			sb.WriteString(",\n")
-		}
-		first = false
-		sb.WriteString(b.buildDeeperNestedRelationQuery(hop, rel, parentField, indentLevel))
-	}
-
-	sb.WriteString(fmt.Sprintf("\n%s}", indent))
-
-	return sb.String()
-}
-
-// buildDeeperNestedRelationQuery 构建更深层嵌套的关系查询
-func (b *SurrealQueryBuilder) buildDeeperNestedRelationQuery(hop int, rel *RelationQueryInfo, parentField string, indentLevel int) string {
-	relationType := rel.Schema.RelationType
-	if b.useActiveEdgeServing(relationType) {
-		return b.buildServingRelationQuery(hop, rel, "$parent."+parentField, strings.Repeat(sqlIndent1, indentLevel))
-	}
-	relationTable := surrealTableName(string(relationType))
-	relationLivenessTable := surrealTableName(GetRelationLivenessRecordTableName(relationType))
-	targetLivenessTable := surrealTableName(GetLivenessRecordTableName(rel.TargetType))
-	targetLivenessIDField := GetLivenessIDField(rel.TargetType)
-
-	keyName := surrealObjectKey(string(relationType) + rel.KeySuffix)
-	indent := strings.Repeat(sqlIndent1, indentLevel)
-	innerIndent := strings.Repeat(sqlIndent1, indentLevel+1)
-	targetFields := b.targetEntityDataFields(rel.TargetType)
-	targetLiveness := ""
-	if !b.usesRelationOnlyLiveness() {
-		targetLiveness = b.livenessProjection(fmt.Sprintf(",\n%s    ", innerIndent), ResponseFieldLiveness, tplLivenessSelectRef, targetLivenessTable, targetLivenessIDField, rel.SelectField)
-	}
-
-	var fieldsBuilder strings.Builder
-	fieldsBuilder.WriteString(fmt.Sprintf(`
-%shop: %d,
-%srelation_type: '%s',
-%srelation_category: '%s',`, innerIndent, hop, innerIndent, relationType, innerIndent, rel.Schema.Category))
-
-	if rel.Schema.Category == RelationCategoryDynamic {
-		fieldsBuilder.WriteString(fmt.Sprintf(`
-%sdirection: '%s',`, innerIndent, rel.Direction))
-	}
-
-	fieldsBuilder.WriteString(fmt.Sprintf(`
-%srelation_id: <string>id%s,
-%starget: {
-%s    entity_type: '%s',
-%s    entity_id: <string>%s,
-%s    entity_data: { %s }%s`,
-		innerIndent,
-		b.livenessProjection(fmt.Sprintf(",\n%s", innerIndent), ResponseFieldRelationLiveness, tplRelLivenessSelect, relationLivenessTable),
-		innerIndent,
-		innerIndent, rel.TargetType,
-		innerIndent, rel.SelectField,
-		innerIndent, buildEntityDataFields(targetFields, rel.SelectField),
-		targetLiveness))
-
-	if hop < b.request.MaxHops {
-		nextHopKey := fmt.Sprintf("hop%d", hop+1)
-		nextHopSelect := b.buildDeeperNestedHopSelect(hop+1, rel.TargetType, rel.SelectField, indentLevel+2)
-		fieldsBuilder.WriteString(fmt.Sprintf(`,
-%s    %s: %s`, innerIndent, nextHopKey, nextHopSelect))
-	}
-
-	fieldsBuilder.WriteString(fmt.Sprintf(`
-%s}`, innerIndent))
-
-	if b.usesRelationOnlyLiveness() {
-		return fmt.Sprintf(`%s%s: (SELECT VALUE {%s
-%s} FROM %s WHERE %s = $parent.%s
-%s  AND `+tplRelLivenessFilter+`
-%s  LIMIT %d)`,
-			indent, keyName,
-			fieldsBuilder.String(),
-			indent, relationTable, rel.WhereField, parentField,
-			indent, relationLivenessTable,
-			indent, maxEdgesPerHopQueryLimit())
-	}
-
-	return fmt.Sprintf(`%s%s: (SELECT VALUE {%s
-%s} FROM %s WHERE %s = $parent.%s
-%s  AND `+tplRelLivenessFilter+`
-%s  AND `+tplLivenessFilterRef+`
-%s  LIMIT %d)`,
-		indent, keyName,
-		fieldsBuilder.String(),
-		indent, relationTable, rel.WhereField, parentField,
-		indent, relationLivenessTable,
-		indent, targetLivenessTable, targetLivenessIDField, rel.SelectField,
-		indent, maxEdgesPerHopQueryLimit())
-}
-
-// buildServingRelationQuery 读取预关联的活跃边数据，并保持 SurrealResponseParser 所需的响应结构。
-// active edge view 仅由 relation liveness 刷新，因此 active_period 只能投影为 relation liveness。
-func (b *SurrealQueryBuilder) buildServingRelationQuery(hop int, rel *RelationQueryInfo, parentRef, indent string) string {
-	relationType := rel.Schema.RelationType
-	table := surrealTableName(string(relationType) + "_active_edge_view")
-	matchField, targetIDField, targetDataField, targetTypeField := "source_id", "target_id", "target_data", "target_type"
+func (b *SurrealQueryBuilder) buildRelationQueryFrom(hop int, rel *RelationQueryInfo, parentRef string) string {
+	matchField, targetField := "source_id", "target_id"
 	if rel.WhereField == fieldOut {
-		matchField, targetIDField, targetDataField, targetTypeField = "target_id", "source_id", "source_data", "source_type"
+		matchField, targetField = "target_id", "source_id"
 	}
-
-	keyName := surrealObjectKey(string(relationType) + rel.KeySuffix)
-	direction := ""
+	fields := []string{
+		fmt.Sprintf("hop: %d", hop),
+		fmt.Sprintf("relation_type: '%s'", rel.Schema.RelationType),
+		fmt.Sprintf("relation_category: '%s'", rel.Schema.Category),
+		fmt.Sprintf("relation_id: <string>type::record('%s', relation_id)", escapeSurrealString(string(rel.Schema.RelationType))),
+	}
 	if rel.Schema.Category == RelationCategoryDynamic {
-		direction = fmt.Sprintf("\n%s        direction: '%s',", indent, rel.Direction)
+		fields = append(fields, fmt.Sprintf("direction: '%s'", rel.Direction))
 	}
-	relationLiveness := ""
 	if b.projectLiveness {
-		relationLiveness = fmt.Sprintf("\n%s        relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }],", indent)
+		fields = append(fields, "relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }]")
 	}
-
-	nested := ""
+	target := fmt.Sprintf("entity_type: '%s', entity_id: <string>%s, entity_data: { %s }", rel.TargetType, targetField, buildEntityDataFields(b.targetEntityDataFields(rel.TargetType), targetField))
 	if hop < b.request.MaxHops {
-		nextHop := b.buildNestedHopSelect(hop+1, rel.TargetType, targetIDField)
-		nested = fmt.Sprintf(",\n%s            hop%d: %s", indent, hop+1, nextHop)
+		children := []string{}
+		for _, next := range b.getRelationsForType(hop+1, rel.TargetType) {
+			children = append(children, b.buildRelationQueryFrom(hop+1, next, "$parent."+targetField))
+		}
+		target += fmt.Sprintf(", hop%d: { %s }", hop+1, strings.Join(children, ", "))
 	}
-
-	return fmt.Sprintf(`%s%s: (SELECT VALUE {
-%s        hop: %d,
-%s        relation_type: '%s',
-%s        relation_category: '%s',%s
-%s        relation_id: <string>relation_id,%s
-%s        target: {
-%s            entity_type: %s,
-%s            entity_id: <string>%s,
-%s            entity_data: %s%s
-%s        }
-%s    } FROM %s WHERE %s = %s
-%s      AND active_period_start_ms <= active_period_end_ms
-%s      AND active_period_start_ms <= $end_ms
-%s      AND active_period_end_ms >= $start_ms
-%s      LIMIT %d)`,
-		indent, keyName,
-		indent, hop,
-		indent, relationType,
-		indent, rel.Schema.Category,
-		direction,
-		indent, relationLiveness,
-		indent,
-		indent, targetTypeField,
-		indent, targetIDField,
-		indent, targetDataField, nested,
-		indent,
-		indent, table, matchField, parentRef,
-		indent,
-		indent,
-		indent,
-		indent, maxEdgesPerHopQueryLimit())
+	fields = append(fields, "target: { "+target+" }")
+	return fmt.Sprintf(`%s: (SELECT VALUE { %s } FROM %s WHERE %s = %s
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT %d)`,
+		surrealObjectKey(string(rel.Schema.RelationType)+rel.KeySuffix), strings.Join(fields, ", "), surrealTableName(string(rel.Schema.RelationType)), matchField, parentRef, maxEdgesPerHopQueryLimit())
 }
 
 // buildWhereClause 构建 WHERE 子句
 func (b *SurrealQueryBuilder) buildWhereClause() string {
-	_, usesRootRecordID := b.rootRecordID()
-	conditions := b.sourceFilterConditions(!usesRootRecordID)
-
-	if !b.usesRelationOnlyLiveness() {
-		livenessTable := surrealTableName(GetLivenessRecordTableName(b.request.SourceType))
-		livenessIDField := GetLivenessIDField(b.request.SourceType)
-		conditions = append(conditions, fmt.Sprintf(tplLivenessFilter, livenessTable, livenessIDField))
-	}
-
+	conditions := b.sourceFilterConditions(true)
 	if len(conditions) == 0 {
 		return ""
 	}
 	return "WHERE " + strings.Join(conditions, "\n  AND ")
-}
-
-// flatServingPrimaryKeyConditions 用 Event 行内的 source/target 业务主键过滤，避免 Record ID
-// 变量在当前 SurrealDB 版本退化为 TableScan。调用方必须先确认相关复合索引已由 metadata 下发。
-func (b *SurrealQueryBuilder) flatServingPrimaryKeyConditions(dataField string) ([]string, bool) {
-	if b == nil || b.request == nil || b.schemaProvider == nil || len(b.request.SourceInfo) == 0 {
-		return nil, false
-	}
-	primaryKeys := b.schemaProvider.GetResourcePrimaryKeys(b.namespace, b.request.SourceType)
-	if len(primaryKeys) == 0 {
-		return nil, false
-	}
-	conditions := make([]string, 0, len(primaryKeys))
-	for _, key := range primaryKeys {
-		value, ok := b.request.SourceInfo[key]
-		if !ok {
-			return nil, false
-		}
-		conditions = append(conditions, fmt.Sprintf("%s.%s = %s", dataField, escapeSurrealIdentifier(key), b.fieldLiteral(key, value)))
-	}
-	return conditions, true
 }
 
 func (b *SurrealQueryBuilder) sourceFilterConditions(includePrimaryKeys bool) []string {

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_bkbase.go
@@ -373,5 +373,64 @@ func (c *BKBaseSurrealDBClient) executeDirect(ctx context.Context, storageID, na
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("decode surrealdb response: %w", err)
 	}
-	return NewSurrealResponseParser(start, end).Parse(payload)
+	rows, err := normalizeDirectSurrealDBResponse(payload)
+	if err != nil {
+		return nil, err
+	}
+	return NewSurrealResponseParser(start, end).Parse([]map[string]any{{ResponseFieldResult: rows}})
+}
+
+// normalizeDirectSurrealDBResponse adapts the statement-oriented response from
+// SurrealDB's /sql endpoint to the graph row shape consumed by the parser.
+// USE NS/DB statements return a session object instead of a graph row and are
+// intentionally omitted from the normalized result.
+func normalizeDirectSurrealDBResponse(payload []map[string]any) ([]any, error) {
+	rows := make([]any, 0)
+	for statementIndex, statement := range payload {
+		if status, _ := statement["status"].(string); status == "ERR" {
+			return nil, fmt.Errorf("surrealdb statement %d failed: %v", statementIndex, statement[ResponseFieldResult])
+		}
+		result, exists := statement[ResponseFieldResult]
+		if !exists {
+			return nil, fmt.Errorf("parse surrealdb response: response[%d].%s: missing field", statementIndex, ResponseFieldResult)
+		}
+		// LET and other control statements can return null without producing graph rows.
+		if result == nil {
+			continue
+		}
+
+		if resultObject, ok := result.(map[string]any); ok {
+			if _, hasRoot := resultObject[ResponseFieldRoot]; !hasRoot {
+				if isSurrealDBSessionResult(resultObject) {
+					continue
+				}
+				return nil, fmt.Errorf("parse surrealdb response: response[%d].%s: missing field %s", statementIndex, ResponseFieldResult, ResponseFieldRoot)
+			}
+			rows = append(rows, map[string]any{ResponseFieldResult: resultObject})
+			continue
+		}
+
+		resultRows, ok := responseArray(result)
+		if !ok {
+			return nil, fmt.Errorf("parse surrealdb response: response[%d].%s: expected array, got %T", statementIndex, ResponseFieldResult, result)
+		}
+		for rowIndex, rowValue := range resultRows {
+			row, ok := rowValue.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("parse surrealdb response: response[%d].%s[%d]: expected object, got %T", statementIndex, ResponseFieldResult, rowIndex, rowValue)
+			}
+			normalizedRows, err := normalizeBKBaseGraphRows([]map[string]any{row})
+			if err != nil {
+				return nil, fmt.Errorf("parse surrealdb response: response[%d].%s[%d]: %w", statementIndex, ResponseFieldResult, rowIndex, err)
+			}
+			rows = append(rows, normalizedRows...)
+		}
+	}
+	return rows, nil
+}
+
+func isSurrealDBSessionResult(result map[string]any) bool {
+	_, hasNamespace := result["namespace"]
+	_, hasDatabase := result["database"]
+	return hasNamespace && hasDatabase
 }

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_direct_route_test.go
@@ -10,6 +10,7 @@
 package v1beta3
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -70,4 +71,111 @@ func TestSurrealDBRouteResolvesStorageAndExecutesDirectQuery(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, graphs)
+}
+
+func TestSurrealDBDirectQuerySkipsSessionAndEmptyStatements(t *testing.T) {
+	const storageID = "700008"
+
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "/sql", request.URL.Path)
+		response.Header().Set("Content-Type", "application/json")
+		_, err := response.Write([]byte(`[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":null},{"result":{"root":{"entity_type":"node","entity_id":"node:node-1","entity_data":{"node":"node-1"}}}}]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	tsdb.SetStorage(storageID, &tsdb.Storage{
+		Type:    metadata.SurrealDBStorageType,
+		Address: server.URL,
+	})
+
+	binding := BindingInfo{
+		StorageID: storageID,
+		Namespace: "mapleleaf_2",
+		Database:  "2_graph_rt",
+	}
+	graphs, err := (&BKBaseSurrealDBClient{}).ExecuteWithBinding(
+		contextWithTenantForBindingResolverTest("tenant-a"),
+		"bkcc__2",
+		binding,
+		"RETURN {root: {entity_type: 'node', entity_id: 'node:node-1'}};",
+		1000,
+		2000,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, graphs, 1)
+	assert.Equal(t, "node:node-1", graphs[0].RootID)
+}
+
+func TestNormalizeDirectSurrealDBResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		wantRows int
+		wantErr  string
+	}{
+		{
+			name:     "statement execution error is preserved",
+			response: `[{"status":"OK","result":null},{"status":"ERR","result":"table not found"}]`,
+			wantErr:  "surrealdb statement 1 failed: table not found",
+		},
+		{
+			name:     "session and null statements with graph object",
+			response: `[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":null},{"result":{"root":{"entity_type":"node","entity_id":"node:node-1"}}}]`,
+			wantRows: 1,
+		},
+		{
+			name:     "graph array with direct rows",
+			response: `[{"result":[{"root":{"entity_type":"node","entity_id":"node:node-1"}}]}]`,
+			wantRows: 1,
+		},
+		{
+			name:     "graph array with wrapped rows",
+			response: `[{"result":[{"result":{"root":{"entity_type":"node","entity_id":"node:node-1"}}}]}]`,
+			wantRows: 1,
+		},
+		{
+			name:     "only control statements produce no rows",
+			response: `[{"result":{"namespace":"mapleleaf_2","database":"2_graph_rt"}},{"result":null},{"result":[]}]`,
+			wantRows: 0,
+		},
+		{
+			name:     "missing result field",
+			response: `[{"status":"OK"}]`,
+			wantErr:  "response[0].result: missing field",
+		},
+		{
+			name:     "non session object without root",
+			response: `[{"result":{"status":"OK"}}]`,
+			wantErr:  "response[0].result: missing field root",
+		},
+		{
+			name:     "scalar result",
+			response: `[{"result":"Exceeded query recursion depth limit"}]`,
+			wantErr:  "response[0].result: expected array, got string",
+		},
+		{
+			name:     "array row must be object",
+			response: `[{"result":["broken-row"]}]`,
+			wantErr:  "response[0].result[0]: expected object, got string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var payload []map[string]any
+			require.NoError(t, json.Unmarshal([]byte(tt.response), &payload))
+
+			rows, err := normalizeDirectSurrealDBResponse(payload)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, rows, tt.wantRows)
+		})
+	}
 }

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_mock_server_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_mock_server_test.go
@@ -175,9 +175,13 @@ func tablePathSplitQuerySyncRequestSummaries(t *testing.T, requests []tableQuery
 			summary.ContainsRelations = []string{string(RelationNodeWithPod)}
 			summary.NotContainsRelations = []string{string(RelationNodeWithSystem), string(RelationSystemToPod)}
 		case strings.Contains(dsl, string(RelationNodeWithSystem)):
-			summary.Path = []string{"node", "system", "pod"}
-			summary.ContainsRelations = []string{string(RelationNodeWithSystem), string(RelationSystemToPod)}
-			summary.NotContainsRelations = []string{string(RelationNodeWithPod)}
+			summary.Path = []string{"node", "system"}
+			summary.ContainsRelations = []string{string(RelationNodeWithSystem)}
+			summary.NotContainsRelations = []string{string(RelationNodeWithPod), string(RelationSystemToPod)}
+		case strings.Contains(dsl, string(RelationSystemToPod)):
+			summary.Path = []string{"system", "pod"}
+			summary.ContainsRelations = []string{string(RelationSystemToPod)}
+			summary.NotContainsRelations = []string{string(RelationNodeWithPod), string(RelationNodeWithSystem)}
 		default:
 			t.Fatalf("unexpected split DSL without known path relation: %s", dsl)
 		}
@@ -227,6 +231,33 @@ func tablePathSplitBKBaseResponsesBySurrealQL(
 		pathKey := strings.Join(resourceTypesToPath(resourcePathTypes(path)), "/")
 		responseJSON, ok := responsesByPath[pathKey]
 		require.True(t, ok, "missing mock response for path %s", pathKey)
+		if len(path.Steps) == 3 {
+			var response BKBaseResponse
+			require.NoError(t, json.Unmarshal([]byte(responseJSON), &response))
+			row := response.Data.List[0]["result"].(map[string]any)
+			firstEdge := row["hop1"].(map[string]any)[string(RelationNodeWithSystem)].([]any)[0].(map[string]any)
+			middle := firstEdge["target"].(map[string]any)
+			secondHop := middle["hop2"]
+			delete(middle, "hop2")
+			firstResponse, err := json.Marshal(response)
+			require.NoError(t, err)
+			firstPath := resourcePath{Steps: path.Steps[:2]}
+			firstSQL, ok := buildFlatRelationQueryForPath(&req, provider, firstPath, mode)
+			require.True(t, ok)
+			result[surrealQL(tableMockUseNSDBStatement+firstSQL)] = string(firstResponse)
+			secondRequest := cloneQueryRequest(&req)
+			secondRequest.SourceType = ResourceTypeSystem
+			secondRequest.SourceInfo = map[string]string{"system": "system-1"}
+			secondRequest.TargetType = ResourceTypePod
+			secondPath := resourcePath{Steps: path.Steps[1:]}
+			secondSQL, ok := buildFlatRelationQueryForPath(secondRequest, provider, secondPath, mode)
+			require.True(t, ok)
+			response.Data.List = []map[string]any{{"result": map[string]any{"root": middle, "hop1": secondHop}}}
+			secondResponse, err := json.Marshal(response)
+			require.NoError(t, err)
+			result[surrealQL(tableMockUseNSDBStatement+secondSQL)] = string(secondResponse)
+			continue
+		}
 
 		builder := NewSurrealQueryBuilderForPath(&req, provider, path)
 		configureBuilderForGraphQueryMode(builder, mode)

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_mock_server_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_mock_server_test.go
@@ -215,7 +215,6 @@ func tablePathSplitBKBaseResponsesBySurrealQL(
 	}
 
 	req.Normalize()
-	adjustMaxHopsForUnconstrainedPath(&req, provider)
 	pf := NewPathFinder(
 		WithAllowedCategories(req.AllowedRelationTypes...),
 		WithDynamicDirection(req.DynamicRelationDirection),

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_table_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_table_test.go
@@ -755,7 +755,6 @@ func tableSingleTableResponsesBySurrealQL(
 	t.Helper()
 
 	req.Normalize()
-	adjustMaxHopsForUnconstrainedPath(&req, provider)
 	pFinder := NewPathFinder(
 		WithAllowedCategories(req.AllowedRelationTypes...),
 		WithDynamicDirection(req.DynamicRelationDirection),

--- a/pkg/unify-query/cmdb/v1beta3/surrealdb_table_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/surrealdb_table_test.go
@@ -25,13 +25,12 @@ import (
 
 func TestSurrealDBQuerySync(t *testing.T) {
 	tests := []struct {
-		name                       string
-		request                    QueryRequest
-		provider                   SchemaProvider
-		binding                    BindingInfo
-		activeEdgeServingRelations []string
-		queryMode                  graphQueryMode
-		expectedSQL                string
+		name        string
+		request     QueryRequest
+		provider    SchemaProvider
+		binding     BindingInfo
+		queryMode   graphQueryMode
+		expectedSQL string
 	}{
 		{
 			name: "host to module query uses runtime binding schema and bkbase query_sync payload",
@@ -61,14 +60,9 @@ func TestSurrealDBQuerySync(t *testing.T) {
 					},
 				},
 			),
-			binding:                    *tableMockBindingInfo(),
-			activeEdgeServingRelations: []string{string(RelationNodeWithPod)},
-			queryMode:                  graphQueryModeInstant,
-			expectedSQL: `LET $timestamp = 1776910000000;
-LET $look_back_delta = 7000000000;
-LET $start = 1769910000;
-LET $end = 1776910000;
-LET $start_ms = 1769910000000;
+			binding:   *tableMockBindingInfo(),
+			queryMode: graphQueryModeInstant,
+			expectedSQL: `LET $start_ms = 1769910000000;
 LET $end_ms = 1776910000000;
 
 SELECT {
@@ -81,29 +75,17 @@ SELECT {
     },
 
     hop1: {
-        host_module_link: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'host_module_link',
-            relation_category: 'static',
-            relation_id: <string>id,
-            target: {
-                entity_type: 'module',
-                entity_id: <string>out,
-                entity_data: { bk_module_id: out.bk_module_id }
-            }
-        } FROM host_module_link WHERE in = $parent.id
-          AND (SELECT * FROM host_module_link_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-          AND (SELECT * FROM module_liveness_record WHERE reference_id = $parent.out AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-          LIMIT 1001)
+host_module_link: (SELECT VALUE { hop: 1, relation_type: 'host_module_link', relation_category: 'static', relation_id: <string>type::record('host_module_link', relation_id), target: { entity_type: 'module', entity_id: <string>target_id, entity_data: { bk_module_id: target_id.bk_module_id } } } FROM host_module_link WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001)
     }
 } AS result
 FROM host
 WHERE bk_host_id = '38268'
-  AND (SELECT * FROM host_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
 LIMIT 10;`,
 		},
 		{
-			name: "node to pod query uses active edge serving table",
+			name: "node to pod query uses single relation table",
 			request: QueryRequest{
 				SpaceUID:           tableMockSpaceUID,
 				Timestamp:          300000,
@@ -126,14 +108,9 @@ LIMIT 10;`,
 					},
 				},
 			),
-			binding:                    *tableMockBindingInfo(),
-			activeEdgeServingRelations: []string{string(RelationNodeWithPod)},
-			queryMode:                  graphQueryModeInstant,
-			expectedSQL: `LET $timestamp = 300000;
-LET $look_back_delta = 86400000;
-LET $start = 0;
-LET $end = 300;
-LET $start_ms = 0;
+			binding:   *tableMockBindingInfo(),
+			queryMode: graphQueryModeInstant,
+			expectedSQL: `LET $start_ms = 0;
 LET $end_ms = 300000;
 
 SELECT {
@@ -146,29 +123,17 @@ SELECT {
     },
 
     hop1: {
-        node_with_pod: (SELECT VALUE {
-                hop: 1,
-                relation_type: 'node_with_pod',
-                relation_category: 'static',
-                relation_id: <string>relation_id,
-                target: {
-                    entity_type: target_type,
-                    entity_id: <string>target_id,
-                    entity_data: target_data
-                }
-            } FROM node_with_pod_active_edge_view WHERE source_id = $parent.id
-              AND active_period_start_ms <= active_period_end_ms
-              AND active_period_start_ms <= $end_ms
-              AND active_period_end_ms >= $start_ms
-              LIMIT 1001)
+node_with_pod: (SELECT VALUE { hop: 1, relation_type: 'node_with_pod', relation_category: 'static', relation_id: <string>type::record('node_with_pod', relation_id), target: { entity_type: 'pod', entity_id: <string>target_id, entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod } } } FROM node_with_pod WHERE source_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001)
     }
 } AS result
 FROM node
-WHERE (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
+
 LIMIT 100;`,
 		},
 		{
-			name: "pod to node query uses active edge serving table in reverse",
+			name: "pod to node query uses single relation table in reverse",
 			request: QueryRequest{
 				SpaceUID:           tableMockSpaceUID,
 				Timestamp:          300000,
@@ -189,14 +154,9 @@ LIMIT 100;`,
 					ToType:       ResourceTypePod,
 				}},
 			),
-			binding:                    *tableMockBindingInfo(),
-			activeEdgeServingRelations: []string{string(RelationNodeWithPod)},
-			queryMode:                  graphQueryModeInstant,
-			expectedSQL: `LET $timestamp = 300000;
-LET $look_back_delta = 86400000;
-LET $start = 0;
-LET $end = 300;
-LET $start_ms = 0;
+			binding:   *tableMockBindingInfo(),
+			queryMode: graphQueryModeInstant,
+			expectedSQL: `LET $start_ms = 0;
 LET $end_ms = 300000;
 
 SELECT {
@@ -209,37 +169,19 @@ SELECT {
     },
 
     hop1: {
-        node_with_pod: (SELECT VALUE {
-                hop: 1,
-                relation_type: 'node_with_pod',
-                relation_category: 'static',
-                relation_id: <string>relation_id,
-                target: {
-                    entity_type: source_type,
-                    entity_id: <string>source_id,
-                    entity_data: source_data
-                }
-            } FROM node_with_pod_active_edge_view WHERE target_id = $parent.id
-              AND active_period_start_ms <= active_period_end_ms
-              AND active_period_start_ms <= $end_ms
-              AND active_period_end_ms >= $start_ms
-              LIMIT 1001)
+node_with_pod: (SELECT VALUE { hop: 1, relation_type: 'node_with_pod', relation_category: 'static', relation_id: <string>type::record('node_with_pod', relation_id), target: { entity_type: 'node', entity_id: <string>source_id, entity_data: { bcs_cluster_id: source_id.bcs_cluster_id, node: source_id.node } } } FROM node_with_pod WHERE target_id = $parent.id
+ AND active_period_start_ms <= active_period_end_ms
+ AND active_period_start_ms <= $end_ms AND active_period_end_ms >= $start_ms LIMIT 1001)
     }
 } AS result
 FROM pod
-WHERE (SELECT * FROM pod_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
+
 LIMIT 100;`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldRelations := ActiveEdgeServingRelations
-			ActiveEdgeServingRelations = append([]string(nil), tt.activeEdgeServingRelations...)
-			t.Cleanup(func() {
-				ActiveEdgeServingRelations = oldRelations
-			})
-
 			req := tt.request
 			builder := NewSurrealQueryBuilderWithSchemaProvider(&req, tt.provider)
 			configureBuilderForGraphQueryMode(builder, tt.queryMode)
@@ -274,222 +216,6 @@ LIMIT 100;`,
 			assert.Equal(t, tt.binding.Database, payload.ResultTableID)
 		})
 	}
-}
-
-func TestActiveEdgeServingSurrealQLFallbackContract(t *testing.T) {
-	provider := newTableSchemaProvider(
-		map[ResourceType]tableResourceDefinition{
-			ResourceTypeNode: {primaryKeys: []string{"bcs_cluster_id", "node"}},
-			ResourceTypePod:  {primaryKeys: []string{"bcs_cluster_id", "namespace", "pod"}},
-		},
-		[]RelationSchema{{
-			RelationType: RelationNodeWithPod,
-			Category:     RelationCategoryStatic,
-			FromType:     ResourceTypeNode,
-			ToType:       ResourceTypePod,
-		}},
-	)
-	req := QueryRequest{
-		Timestamp:          300000,
-		SourceType:         ResourceTypeNode,
-		TargetType:         ResourceTypePod,
-		TargetTypeExplicit: true,
-		MaxHops:            1,
-	}
-	tests := []struct {
-		name             string
-		mode             graphQueryMode
-		servingRelations []string
-		expectedSQL      string
-	}{
-		{
-			name: "instant falls back when relation is not enabled",
-			mode: graphQueryModeInstant,
-			expectedSQL: `LET $timestamp = 300000;
-LET $look_back_delta = 86400000;
-LET $start = 0;
-LET $end = 300;
-LET $start_ms = 0;
-LET $end_ms = 300000;
-
-SELECT {
-    root: {
-        entity_type: meta::tb(id),
-        entity_id: <string>id,
-        entity_data: { bcs_cluster_id: bcs_cluster_id, node: node },
-        created_at: created_at,
-        updated_at: updated_at
-    },
-
-    hop1: {
-        node_with_pod: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'node_with_pod',
-            relation_category: 'static',
-            relation_id: <string>id,
-            target: {
-                entity_type: 'pod',
-                entity_id: <string>out,
-                entity_data: { bcs_cluster_id: out.bcs_cluster_id, namespace: out.namespace, pod: out.pod }
-            }
-        } FROM node_with_pod WHERE in = $parent.id
-          AND (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-          AND (SELECT * FROM pod_liveness_record WHERE reference_id = $parent.out AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-          LIMIT 1001)
-    }
-} AS result
-FROM node
-WHERE (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-LIMIT 100;`,
-		},
-		{
-			name:             "range ignores enabled serving relation",
-			mode:             graphQueryModeRange,
-			servingRelations: []string{string(RelationNodeWithPod)},
-			expectedSQL: `LET $timestamp = 300000;
-LET $look_back_delta = 86400000;
-LET $start = 0;
-LET $end = 300;
-LET $start_ms = 0;
-LET $end_ms = 300000;
-
-SELECT {
-    root: {
-        entity_type: meta::tb(id),
-        entity_id: <string>id,
-        entity_data: { bcs_cluster_id: bcs_cluster_id, node: node },
-        created_at: created_at,
-        updated_at: updated_at,
-        liveness: (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-    },
-
-    hop1: {
-        node_with_pod: (SELECT VALUE {
-            hop: 1,
-            relation_type: 'node_with_pod',
-            relation_category: 'static',
-            relation_id: <string>id,
-            relation_liveness: (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND period_end >= $start_ms AND period_start <= $end_ms AND period_start <= period_end),
-            target: {
-                entity_type: 'pod',
-                entity_id: <string>out,
-                entity_data: { bcs_cluster_id: out.bcs_cluster_id, namespace: out.namespace, pod: out.pod },
-                liveness: (SELECT * FROM pod_liveness_record WHERE reference_id = $parent.out AND period_end >= $start AND period_start <= $end AND period_start <= period_end)
-            }
-        } FROM node_with_pod WHERE in = $parent.id
-          AND (SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-          AND (SELECT * FROM pod_liveness_record WHERE reference_id = $parent.out AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-          LIMIT 1001)
-    }
-} AS result
-FROM node
-WHERE (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE
-LIMIT 100;`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			oldRelations := ActiveEdgeServingRelations
-			ActiveEdgeServingRelations = append([]string(nil), tt.servingRelations...)
-			t.Cleanup(func() { ActiveEdgeServingRelations = oldRelations })
-
-			query := req
-			builder := NewSurrealQueryBuilderWithSchemaProvider(&query, provider)
-			configureBuilderForGraphQueryMode(builder, tt.mode)
-
-			actualSQL := builder.Build()
-			if tt.mode == graphQueryModeRange && len(tt.servingRelations) > 0 {
-				assert.Contains(t, actualSQL, "FROM node_with_pod_active_edge_view")
-				assert.NotContains(t, actualSQL, "FROM node_with_pod WHERE")
-				return
-			}
-			assert.Equal(t, tt.expectedSQL, actualSQL)
-		})
-	}
-
-	t.Run("multi hop follows serving relation configuration", func(t *testing.T) {
-		multiHopProvider := newTableSchemaProvider(
-			map[ResourceType]tableResourceDefinition{
-				ResourceTypeNode:       {primaryKeys: []string{"bcs_cluster_id", "node"}},
-				ResourceTypePod:        {primaryKeys: []string{"bcs_cluster_id", "namespace", "pod"}},
-				ResourceTypeReplicaSet: {primaryKeys: []string{"bcs_cluster_id", "namespace", "replicaset"}},
-			},
-			[]RelationSchema{
-				{RelationType: RelationNodeWithPod, Category: RelationCategoryStatic, FromType: ResourceTypeNode, ToType: ResourceTypePod},
-				{RelationType: RelationPodWithReplicaSet, Category: RelationCategoryStatic, FromType: ResourceTypePod, ToType: ResourceTypeReplicaSet},
-			},
-		)
-		multiHopReq := QueryRequest{
-			Timestamp:          300000,
-			SourceType:         ResourceTypeNode,
-			TargetType:         ResourceTypeReplicaSet,
-			TargetTypeExplicit: true,
-			MaxHops:            2,
-		}
-		path := resourcePath{Steps: []resourcePathStep{
-			{ResourceType: string(ResourceTypeNode)},
-			{ResourceType: string(ResourceTypePod), RelationType: string(RelationNodeWithPod), Category: string(RelationCategoryStatic), Direction: string(DirectionOutbound)},
-			{ResourceType: string(ResourceTypeReplicaSet), RelationType: string(RelationPodWithReplicaSet), Category: string(RelationCategoryStatic), Direction: string(DirectionOutbound)},
-		}}
-
-		cases := []struct {
-			name                  string
-			servingRelations      []string
-			expectedRoute         string
-			expectedSQLContains   []string
-			expectedSQLNotContain []string
-		}{
-			{
-				name:             "all hops use serving",
-				servingRelations: []string{string(RelationNodeWithPod), string(RelationPodWithReplicaSet)},
-				expectedRoute:    "active_edge_serving",
-				expectedSQLContains: []string{
-					"FROM node_with_pod_active_edge_view",
-					"entity_id: <string>target_id",
-					"FROM pod_with_replicaset_active_edge_view WHERE source_id = $parent.target_id",
-				},
-			},
-			{
-				name:             "configured hop uses serving and remaining hop uses raw",
-				servingRelations: []string{string(RelationNodeWithPod)},
-				expectedRoute:    "mixed",
-				expectedSQLContains: []string{
-					"FROM node_with_pod_active_edge_view",
-					"FROM pod_with_replicaset WHERE in = $parent.target_id",
-				},
-				expectedSQLNotContain: []string{"FROM pod_with_replicaset_active_edge_view"},
-			},
-			{
-				name:             "raw hop followed by serving",
-				servingRelations: []string{string(RelationPodWithReplicaSet)},
-				expectedRoute:    "mixed",
-				expectedSQLContains: []string{
-					"FROM node_with_pod WHERE in = $parent.id",
-					"FROM pod_with_replicaset_active_edge_view WHERE source_id = $parent.out",
-				},
-				expectedSQLNotContain: []string{"FROM node_with_pod_active_edge_view"},
-			},
-		}
-
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				oldRelations := ActiveEdgeServingRelations
-				ActiveEdgeServingRelations = append([]string(nil), tc.servingRelations...)
-				t.Cleanup(func() { ActiveEdgeServingRelations = oldRelations })
-
-				builder := NewSurrealQueryBuilderForPath(&multiHopReq, multiHopProvider, path)
-				sql := builder.Build()
-				assert.Equal(t, tc.expectedRoute, builder.routeName())
-				for _, expected := range tc.expectedSQLContains {
-					assert.Contains(t, sql, expected)
-				}
-				for _, unexpected := range tc.expectedSQLNotContain {
-					assert.NotContains(t, sql, unexpected)
-				}
-			})
-		}
-	})
 }
 
 func TestSurrealDBResponseParsing(t *testing.T) {
@@ -745,8 +471,8 @@ func TestSurrealDBPathSplitQuerySyncRequestsTableDriven(t *testing.T) {
 			bkbaseResponseOverrides: map[string]string{
 				"node/pod": tableEmptyBKBaseResponseJSON,
 			},
-			expectedResponseJSON: `{"path":["node","system","pod"],"matchers":[{"pod":"pod-via-system"}],"query_sync_requests":[{"path":["node","pod"],"prefer_storage":"surrealdb","properties":{"cluster_name":"mock_surrealdb_cluster"},"result_table_id":"mock_graph_result_table","contains_relations":["node_with_pod"],"not_contains_relations":["node_with_system","system_to_pod"]},{"path":["node","system","pod"],"prefer_storage":"surrealdb","properties":{"cluster_name":"mock_surrealdb_cluster"},"result_table_id":"mock_graph_result_table","contains_relations":["node_with_system","system_to_pod"],"not_contains_relations":["node_with_pod"]}]}`,
-			expectedRequestCount: 2,
+			expectedResponseJSON: `{"path":["node","system","pod"],"matchers":[{"pod":"pod-via-system"}],"query_sync_requests":[{"path":["node","pod"],"prefer_storage":"surrealdb","properties":{"cluster_name":"mock_surrealdb_cluster"},"result_table_id":"mock_graph_result_table","contains_relations":["node_with_pod"],"not_contains_relations":["node_with_system","system_to_pod"]},{"path":["node","system"],"prefer_storage":"surrealdb","properties":{"cluster_name":"mock_surrealdb_cluster"},"result_table_id":"mock_graph_result_table","contains_relations":["node_with_system"],"not_contains_relations":["node_with_pod","system_to_pod"]},{"path":["system","pod"],"prefer_storage":"surrealdb","properties":{"cluster_name":"mock_surrealdb_cluster"},"result_table_id":"mock_graph_result_table","contains_relations":["system_to_pod"],"not_contains_relations":["node_with_pod","node_with_system"]}]}`,
+			expectedRequestCount: 3,
 		},
 	}
 
@@ -809,7 +535,7 @@ func TestSurrealDBPathSplitQuerySyncRequestsTableDriven(t *testing.T) {
 	}
 }
 
-func TestActiveEdgeServingQuerySyncTableDriven(t *testing.T) {
+func TestSingleTableQuerySyncTableDriven(t *testing.T) {
 	provider := newTableSchemaProvider(
 		map[ResourceType]tableResourceDefinition{
 			ResourceTypeHost: {
@@ -829,7 +555,7 @@ func TestActiveEdgeServingQuerySyncTableDriven(t *testing.T) {
 		}},
 	)
 
-	forwardResponse := tableActiveEdgeServingResponseJSON(
+	forwardResponse := tableSingleTableResponseJSON(
 		t,
 		ResourceTypeHost,
 		"host:⟨bk_host_id=38268⟩",
@@ -839,7 +565,7 @@ func TestActiveEdgeServingQuerySyncTableDriven(t *testing.T) {
 		"module:⟨bk_module_id=10259⟩",
 		map[string]string{"bk_module_id": "10259"},
 	)
-	reverseResponse := tableActiveEdgeServingResponseJSON(
+	reverseResponse := tableSingleTableResponseJSON(
 		t,
 		ResourceTypeModule,
 		"module:⟨bk_module_id=10259⟩",
@@ -865,27 +591,27 @@ func TestActiveEdgeServingQuerySyncTableDriven(t *testing.T) {
 		expectedDataProjection string
 	}{
 		{
-			name:                   "forward serving response returns module primary key matcher",
+			name:                   "forward single-table response returns module primary key matcher",
 			requestJSON:            `{"space_uid":"` + tableMockSpaceUID + `","timestamp":600000,"source_type":"host","source_info":{"bk_host_id":"38268"},"target_type":"module","look_back_delta":600000}`,
 			responseJSON:           forwardResponse,
 			mode:                   graphQueryModeInstant,
 			expectedPath:           []string{"host", "module"},
 			expectedMatchers:       cmdb.Matchers{{"bk_module_id": "10259"}},
-			expectedMatchClause:    "source_id = $parent.id",
-			expectedDataProjection: "entity_data: target_data",
+			expectedMatchClause:    "source_id IN $source_ids",
+			expectedDataProjection: "entity_data: { bk_module_id: target_id.bk_module_id }",
 		},
 		{
-			name:                   "reverse serving response returns host primary key matcher",
+			name:                   "reverse single-table response returns host primary key matcher",
 			requestJSON:            `{"space_uid":"` + tableMockSpaceUID + `","timestamp":600000,"source_type":"module","source_info":{"bk_module_id":"10259"},"target_type":"host","look_back_delta":600000}`,
 			responseJSON:           reverseResponse,
 			mode:                   graphQueryModeInstant,
 			expectedPath:           []string{"module", "host"},
 			expectedMatchers:       cmdb.Matchers{{"bk_host_id": "38268"}},
-			expectedMatchClause:    "target_id = $parent.id",
-			expectedDataProjection: "entity_data: source_data",
+			expectedMatchClause:    "target_id IN $source_ids",
+			expectedDataProjection: "entity_data: { bk_host_id: source_id.bk_host_id }",
 		},
 		{
-			name:         "range serving response produces target buckets from active period",
+			name:         "range single-table response produces target buckets from active period",
 			requestJSON:  `{"space_uid":"` + tableMockSpaceUID + `","timestamp":600000,"source_type":"host","source_info":{"bk_host_id":"38268"},"target_type":"module","look_back_delta":600000}`,
 			responseJSON: forwardResponse,
 			mode:         graphQueryModeRange,
@@ -898,29 +624,15 @@ func TestActiveEdgeServingQuerySyncTableDriven(t *testing.T) {
 				{Timestamp: 300000, Matchers: cmdb.Matchers{{"bk_module_id": "10259"}}},
 				{Timestamp: 600000, Matchers: cmdb.Matchers{{"bk_module_id": "10259"}}},
 			},
-			expectedMatchClause:    "source_data.bk_host_id = '38268'",
-			expectedDataProjection: "entity_data: target_data",
+			expectedMatchClause:    "SELECT VALUE id FROM host WHERE bk_host_id = '38268'",
+			expectedDataProjection: "entity_data: { bk_module_id: target_id.bk_module_id }",
 		},
 	}
 
-	oldRelations := ActiveEdgeServingRelations
-	oldFlatRelations := FlatOneHopActiveEdgeServingRelations
-	ActiveEdgeServingRelations = []string{string(RelationHostWithModule)}
-	t.Cleanup(func() {
-		ActiveEdgeServingRelations = oldRelations
-		FlatOneHopActiveEdgeServingRelations = oldFlatRelations
-	})
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.mode == graphQueryModeRange {
-				FlatOneHopActiveEdgeServingRelations = []string{string(RelationHostWithModule)}
-			} else {
-				FlatOneHopActiveEdgeServingRelations = nil
-			}
-
 			req := decodeTableQueryRequestJSON(t, tt.requestJSON)
-			responses := tableActiveEdgeServingResponsesBySurrealQL(t, req, provider, tt.mode, tt.responseJSON)
+			responses := tableSingleTableResponsesBySurrealQL(t, req, provider, tt.mode, tt.responseJSON)
 			server := newSurrealDBMockServer(t, responses)
 			t.Cleanup(server.Close)
 
@@ -971,7 +683,8 @@ func TestActiveEdgeServingQuerySyncTableDriven(t *testing.T) {
 			assert.Equal(t, tableMockDatabase, requests[0].SQLPayload.ResultTableID)
 
 			dsl := requests[0].SQLPayload.DSL
-			assert.Contains(t, dsl, "FROM host_with_module_active_edge_view")
+			assert.Contains(t, dsl, "FROM host_with_module\n")
+			assert.NotContains(t, dsl, "_active_edge_view")
 			assert.Contains(t, dsl, tt.expectedMatchClause)
 			assert.Contains(t, dsl, tt.expectedDataProjection)
 			assert.Contains(t, dsl, "active_period_start_ms <= $end_ms")
@@ -1011,31 +724,28 @@ func TestSurrealQueryBuilderForPathUsesRelationOnlyLiveness(t *testing.T) {
 		},
 	}}
 
-	oldRelations := ActiveEdgeServingRelations
-	t.Cleanup(func() { ActiveEdgeServingRelations = oldRelations })
-
-	ActiveEdgeServingRelations = nil
 	rawSQL := NewSurrealQueryBuilderForPath(req, provider, path).Build()
-	assert.Contains(t, rawSQL, "node_with_pod_liveness_record")
+	assert.Contains(t, rawSQL, "FROM node_with_pod\n")
+	assert.NotContains(t, rawSQL, "_liveness_record")
 	assert.NotContains(t, rawSQL, "FROM node_liveness_record")
 	assert.NotContains(t, rawSQL, "FROM pod_liveness_record")
 	assert.Contains(t, rawSQL, ResponseFieldRelationLiveness+":")
 
-	ActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
 	servingBuilder := NewSurrealQueryBuilderForPath(req, provider, path)
 	servingSQL := servingBuilder.Build()
-	assert.Equal(t, "active_edge_serving", servingBuilder.routeName())
-	assert.Contains(t, servingSQL, "FROM node_with_pod_active_edge_view")
+	assert.Equal(t, "single_table_flat_one_hop", servingBuilder.routeName())
+	assert.Contains(t, servingSQL, "FROM node_with_pod\n")
 	assert.NotContains(t, servingSQL, "FROM node_liveness_record")
 	assert.NotContains(t, servingSQL, "FROM pod_liveness_record")
 	assert.Contains(t, servingSQL, ResponseFieldRelationLiveness+":")
 
 	rootOnlyPath := resourcePath{Steps: []resourcePathStep{{ResourceType: string(ResourceTypeNode)}}}
 	rootOnlySQL := NewSurrealQueryBuilderForPath(req, provider, rootOnlyPath).Build()
-	assert.Contains(t, rootOnlySQL, "node_liveness_record")
+	assert.Contains(t, rootOnlySQL, "FROM node\nWHERE node = 'node-1'")
+	assert.NotContains(t, rootOnlySQL, "_liveness_record")
 }
 
-func tableActiveEdgeServingResponsesBySurrealQL(
+func tableSingleTableResponsesBySurrealQL(
 	t *testing.T,
 	req QueryRequest,
 	provider SchemaProvider,
@@ -1064,7 +774,7 @@ func tableActiveEdgeServingResponsesBySurrealQL(
 	}
 }
 
-func tableActiveEdgeServingResponseJSON(
+func tableSingleTableResponseJSON(
 	t *testing.T,
 	rootType ResourceType,
 	rootID string,

--- a/pkg/unify-query/cmdb/v1beta3/trace_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/trace_test.go
@@ -145,9 +145,6 @@ func TestRangeValidationTraceIncludesPointLimit(t *testing.T) {
 
 func TestPathQueryTraceIncludesFullPathIdentityAndSelection(t *testing.T) {
 	recorder := setupV1Beta3TraceRecorder(t)
-	previousServingRelations := ActiveEdgeServingRelations
-	ActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
-	t.Cleanup(func() { ActiveEdgeServingRelations = previousServingRelations })
 	model := &Model{}
 	path := resourcePath{Steps: []resourcePathStep{
 		{ResourceType: string(ResourceTypeNode)},
@@ -200,9 +197,9 @@ func TestPathQueryTraceIncludesFullPathIdentityAndSelection(t *testing.T) {
 	assert.Equal(t, aggregateSpan.SpanContext().SpanID(), pathSpan.Parent().SpanID())
 	assert.Equal(t, identity, traceStringAttribute(t, pathSpan, "path-identity"))
 	assert.Equal(t, "success", traceStringAttribute(t, pathSpan, "path-result"))
-	assert.Equal(t, "active_edge_serving", traceStringAttribute(t, pathSpan, "query-route"))
+	assert.Equal(t, "single_table_flat_one_hop", traceStringAttribute(t, pathSpan, "query-route"))
 	assert.Equal(t, int64(1), traceIntAttribute(t, pathSpan, "path-hop-count"))
-	assert.Equal(t, int64(1), traceIntAttribute(t, pathSpan, "active-edge-serving-hop-count"))
+	assert.Equal(t, int64(1), traceIntAttribute(t, pathSpan, "relation-table-hop-count"))
 	assert.Equal(t, int64(1), traceIntAttribute(t, pathSpan, "edge-count"))
 }
 

--- a/pkg/unify-query/cmdb/v1beta3/types.go
+++ b/pkg/unify-query/cmdb/v1beta3/types.go
@@ -113,7 +113,6 @@ const (
 const (
 	FieldPeriodStart = "period_start"
 	FieldPeriodEnd   = "period_end"
-	FieldReferenceID = "reference_id"
 )
 
 const (
@@ -186,16 +185,4 @@ func GenerateResourceID(resourceType ResourceType, labels map[string]string) str
 	}
 
 	return fmt.Sprintf("%s:⟨%s⟩", resourceType, strings.Join(pairs, ","))
-}
-
-func GetLivenessRecordTableName(resourceType ResourceType) string {
-	return string(resourceType) + "_liveness_record"
-}
-
-func GetRelationLivenessRecordTableName(relationType RelationType) string {
-	return string(relationType) + "_liveness_record"
-}
-
-func GetLivenessIDField(resourceType ResourceType) string {
-	return FieldReferenceID
 }

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3.go
@@ -40,7 +40,7 @@ const defaultPathQueryMaxRouting = 4
 // 因此必须跨请求共享额度，避免 BKBase 压力随 query_list 数量成倍放大。
 var pathQuerySemaphore = make(chan struct{}, defaultPathQueryMaxRouting)
 
-func GetModel(ctx context.Context) (cmdb.CMDB, error) {
+func GetModel(ctx context.Context) (*Model, error) {
 	modelMutex.Lock()
 	defer modelMutex.Unlock()
 	if defaultModel == nil {
@@ -143,6 +143,20 @@ func (m *Model) QueryResourceMatcher(
 	expandShow bool,
 	pathResource []cmdb.Resource,
 ) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []string, resTarget cmdb.Resource, resMatchers cmdb.Matchers, err error) {
+	return m.QueryResourceMatcherWithMaxHops(ctx, lookBackDelta, spaceUid, ts, target, source, indexMatcher, expandMatcher, expandShow, pathResource, nil)
+}
+
+// QueryResourceMatcherWithMaxHops accepts an explicit v1beta3 hop budget; nil uses the configured default.
+func (m *Model) QueryResourceMatcherWithMaxHops(
+	ctx context.Context,
+	lookBackDelta, spaceUid string,
+	ts string,
+	target, source cmdb.Resource,
+	indexMatcher, expandMatcher cmdb.Matcher,
+	expandShow bool,
+	pathResource []cmdb.Resource,
+	maxHops *int,
+) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []string, resTarget cmdb.Resource, resMatchers cmdb.Matchers, err error) {
 	ctx, span := trace.NewSpan(ctx, "cmdb-query-resource-matcher")
 	defer endV1Beta3TraceSpan(span, &err)
 
@@ -176,15 +190,22 @@ func (m *Model) QueryResourceMatcher(
 		TargetTypeExplicit:  target != "",
 		TargetInfoShow:      expandShow,
 		PathResource:        toResourceTypes(pathResource),
-		MaxHops:             computeMaxHops(source, target, pathResource),
+		MaxHops:             DefaultMaxHops,
 		LookBackDelta:       lbd,
 		LookBackDeltaSet:    lookBackDelta != "",
 		LegacyCompatibility: true,
 		DisableRootLimit:    true,
 	}
+	if maxHops != nil {
+		req.MaxHops = *maxHops
+	}
+	if err = validateMaxHops(req.MaxHops); err != nil {
+		return "", nil, nil, "", nil, err
+	}
 	req.Normalize()
 
-	if relationType, ok := m.vmPreferredRelation(req); ok {
+	// The VM adapter cannot enforce an explicit hop budget.
+	if relationType, ok := m.vmPreferredRelation(req); ok && maxHops == nil {
 		span.Set("preferred-route", "vm")
 		span.Set("preferred-relation", relationType)
 		metric.CMDBRelationRouteInc(ctx, "vm", string(graphQueryModeInstant), "started")
@@ -222,6 +243,21 @@ func (m *Model) QueryResourceMatcherRange(
 	indexMatcher, expandMatcher cmdb.Matcher,
 	expandShow bool,
 	pathResource []cmdb.Resource,
+) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []string, resTarget cmdb.Resource, result []cmdb.MatchersWithTimestamp, err error) {
+	return m.QueryResourceMatcherRangeWithMaxHops(ctx, lookBackDelta, spaceUid, step, startTs, endTs, target, source, indexMatcher, expandMatcher, expandShow, pathResource, nil)
+}
+
+// QueryResourceMatcherRangeWithMaxHops applies the same hop budget to every range bucket.
+func (m *Model) QueryResourceMatcherRangeWithMaxHops(
+	ctx context.Context,
+	lookBackDelta, spaceUid string,
+	step string,
+	startTs, endTs string,
+	target, source cmdb.Resource,
+	indexMatcher, expandMatcher cmdb.Matcher,
+	expandShow bool,
+	pathResource []cmdb.Resource,
+	maxHops *int,
 ) (resSource cmdb.Resource, resIndexMatcher cmdb.Matcher, resPaths []string, resTarget cmdb.Resource, result []cmdb.MatchersWithTimestamp, err error) {
 	ctx, span := trace.NewSpan(ctx, "cmdb-query-resource-matcher-range")
 	defer endV1Beta3TraceSpan(span, &err)
@@ -283,15 +319,22 @@ func (m *Model) QueryResourceMatcherRange(
 		TargetTypeExplicit:  target != "",
 		TargetInfoShow:      expandShow,
 		PathResource:        toResourceTypes(pathResource),
-		MaxHops:             computeMaxHops(source, target, pathResource),
+		MaxHops:             DefaultMaxHops,
 		LookBackDelta:       rangeQueryLookBackDelta(lbd, start, end, stepMs, lookBackDelta != ""),
 		LookBackDeltaSet:    lookBackDelta != "",
 		LegacyCompatibility: true,
 		DisableRootLimit:    true,
 	}
+	if maxHops != nil {
+		req.MaxHops = *maxHops
+	}
+	if err = validateMaxHops(req.MaxHops); err != nil {
+		return "", nil, nil, "", nil, err
+	}
 	req.Normalize()
 
-	if relationType, ok := m.vmPreferredRelation(req); ok {
+	// The VM adapter cannot enforce an explicit hop budget.
+	if relationType, ok := m.vmPreferredRelation(req); ok && maxHops == nil {
 		span.Set("preferred-route", "vm")
 		span.Set("preferred-relation", relationType)
 		metric.CMDBRelationRouteInc(ctx, "vm", string(graphQueryModeRange), "started")
@@ -496,6 +539,9 @@ func (m *Model) queryLivenessGraph(
 		sourceTypeInferred = true
 	}
 	req.Normalize()
+	if err := validateMaxHops(req.MaxHops); err != nil {
+		return nil, nil, nil, err
+	}
 	span.Set("source-type-inferred", sourceTypeInferred)
 	span.Set("source-type", string(req.SourceType))
 	span.Set("target-type", string(req.TargetType))
@@ -508,22 +554,12 @@ func (m *Model) queryLivenessGraph(
 		span.Set("source-info-fields-before-compat-filter", originalSourceFieldCount)
 		span.Set("source-info-fields-after-compat-filter", len(req.SourceInfo))
 	}
-	// 同类型查询有两种不同语义，必须在路径发现前归一化：
-	// 1. target_type 未显式传入时，这是旧接口的信息展示路径，只查 source 自身；
-	// 2. target_type 显式等于 source_type 时，这是自关联查询，只允许一跳直连自关联。
+	// 只有未指定目标的信息查询不展开关系；显式目标按 max_hops 搜索，类型相同也不例外。
 	implicitSelfTarget := !req.TargetTypeExplicit && req.SourceType == req.TargetType
 	if implicitSelfTarget {
-		// 信息展示路径不应展开任何 relation hop；否则会把同类型自关联结果混入
-		// “source 自身信息”的响应。
 		req.MaxHops = 0
 		req.PathResource = nil
-	} else if isExplicitDirectSelfTarget(req) {
-		// 显式同类型 target 要求查询真实自关联边。空资源占位符是 PathFinder
-		// 的“只走直连”约束，避免在 source -> ... -> source 的多跳环路里取数。
-		req.MaxHops = 1
-		req.PathResource = []ResourceType{""}
 	}
-	adjustMaxHopsForUnconstrainedPath(req, provider)
 
 	if err := validateQueryResources(req, provider); err != nil {
 		span.Set("failure-stage", "resource-validation")
@@ -850,6 +886,18 @@ func (m *Model) executeOneGraphQueryPath(
 		spanErr = traversalErr
 		return pathQueryResult{idx: idx, path: path, err: traversalErr}
 	}
+	// Bound extraction too: merged relation rows can otherwise form a longer walk
+	// than the SQL path that produced them. Copy wrappers to avoid mutating executor data.
+	boundedGraphs := make([]*LivenessGraph, len(graphs))
+	hops := len(path.Steps) - 1
+	for i, graph := range graphs {
+		if graph != nil {
+			bounded := *graph
+			bounded.maxTargetHops = &hops
+			boundedGraphs[i] = &bounded
+		}
+	}
+	graphs = boundedGraphs
 	graphCount, nodeCount, edgeCount := livenessGraphStats(graphs)
 	span.Set("path-result", "success")
 	span.Set("graph-count", graphCount)
@@ -1453,48 +1501,8 @@ func shouldIncludeRootTarget(req *QueryRequest) bool {
 	return !req.TargetTypeExplicit || req.SourceType != req.TargetType
 }
 
-func isExplicitDirectSelfTarget(req *QueryRequest) bool {
-	return req != nil && req.TargetTypeExplicit && req.SourceType == req.TargetType && len(req.PathResource) == 0
-}
-
 func targetExtractionPathResource(req *QueryRequest) []ResourceType {
-	if isExplicitDirectSelfTarget(req) {
-		return []ResourceType{""}
-	}
 	return req.PathResource
-}
-
-func adjustMaxHopsForUnconstrainedPath(req *QueryRequest, provider SchemaProvider) {
-	if req == nil ||
-		provider == nil ||
-		len(req.PathResource) > 0 ||
-		req.SourceType == "" ||
-		req.TargetType == "" ||
-		req.SourceType == req.TargetType ||
-		req.MaxHops >= MaxAllowedHops {
-		return
-	}
-
-	maxFinder := NewPathFinder(
-		WithAllowedCategories(req.AllowedRelationTypes...),
-		WithDynamicDirection(req.DynamicRelationDirection),
-		WithMaxHops(MaxAllowedHops),
-		WithSchemaProvider(provider),
-		WithNamespace(req.SchemaNamespace()),
-	)
-	paths, err := maxFinder.FindAllPaths(req.SourceType, req.TargetType, nil)
-	if err != nil {
-		return
-	}
-
-	for _, path := range paths {
-		if hops := len(path.Steps) - 1; hops > req.MaxHops {
-			req.MaxHops = hops
-		}
-	}
-	if req.MaxHops > MaxAllowedHops {
-		req.MaxHops = MaxAllowedHops
-	}
 }
 
 type sourceTypeCandidate struct {
@@ -1733,26 +1741,6 @@ func matcherToMap(m cmdb.Matcher) map[string]string {
 		result[k] = v
 	}
 	return result
-}
-
-func computeMaxHops(source, target cmdb.Resource, pathResource []cmdb.Resource) int {
-	if len(pathResource) == 0 {
-		return DefaultMaxHops
-	}
-	pathConstraint, directOnly := normalizePathResource(FromCMDBResource(source), FromCMDBResource(target), toResourceTypes(pathResource))
-	if directOnly {
-		return 1
-	}
-	if len(pathConstraint) == 0 {
-		return DefaultMaxHops
-	}
-	// path_resource 可能只给出部分中间资源。除了约束本身，还要给 source/target 两侧各留出默认 schema
-	// 的连接空间；否则 host->system->pod->replicaset->deployment 这类合法路径会因为预算太浅被剪掉。
-	maxHops := DefaultMaxHops + len(pathConstraint) + 1
-	if maxHops > MaxAllowedHops {
-		return MaxAllowedHops
-	}
-	return maxHops
 }
 
 func extractMatchersFromGraphsWithOptions(

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3.go
@@ -474,7 +474,6 @@ func (m *Model) queryLivenessGraph(
 	span.Set("max-edges-per-hop", effectiveMaxEdgesPerHop())
 	span.Set("max-targets", effectiveMaxTargets())
 	span.Set("max-response-bytes", effectiveMaxResponseBytes())
-	span.Set("root-record-id-enabled", RootRecordIDEnabled)
 	if mode == graphQueryModeRange {
 		span.Set("range-start", rangeStart)
 		span.Set("range-end", rangeEnd)
@@ -792,13 +791,13 @@ func (m *Model) executeOneGraphQueryPath(
 	builder := NewSurrealQueryBuilderForPath(req, provider, path)
 	configureBuilderForGraphQueryMode(builder, mode)
 	route := builder.routeName()
-	usesFlatMultiHop := usesFlatMultiHopActiveEdgeServingPath(req, provider, path, mode)
+	usesFlatMultiHop := usesFlatMultiHopRelationPath(req, provider, path, mode)
 	if usesFlatMultiHop {
-		route = "active_edge_serving_flat_multi_hop"
+		route = "single_table_flat_multi_hop"
 	}
 	span.Set("query-route", route)
 	span.Set("path-hop-count", builder.pathHopCount)
-	span.Set("active-edge-serving-hop-count", builder.servingHopCount)
+	span.Set("relation-table-hop-count", builder.pathHopCount)
 	metric.CMDBRelationRouteInc(ctx, route, string(mode), "started")
 	queryStarted := time.Now()
 	defer func() {
@@ -836,7 +835,7 @@ func (m *Model) executeOneGraphQueryPath(
 		spanErr = runErr
 		return pathQueryResult{idx: idx, path: path, err: runErr}
 	}
-	if builder.usesFlatOneHopActiveEdgeServingQuery() && len(graphs) > effectiveMaxEdgesPerHop() {
+	if builder.usesFlatOneHopRelationQuery() && len(graphs) > effectiveMaxEdgesPerHop() {
 		spanErr = &ResultLimitError{
 			Reason: "max_edges_per_hop",
 			Count:  len(graphs),
@@ -870,38 +869,25 @@ type flatServingHopResult struct {
 	graphs []*LivenessGraph
 }
 
-// usesFlatMultiHopActiveEdgeServingPath 要求整条路径的每一跳都完成 Event 主键投影与索引验证。
-// 任意一跳不满足时，完整回退到原有嵌套查询，避免将未建索引的 relation 误路由到分层模式。
-func usesFlatMultiHopActiveEdgeServingPath(
+// usesFlatMultiHopRelationPath splits a path when each frontier can be identified
+// by its metadata keys. Partial-key legacy requests use the single-table nested query.
+func usesFlatMultiHopRelationPath(
 	req *QueryRequest,
 	provider SchemaProvider,
 	path resourcePath,
 	mode graphQueryMode,
 ) bool {
-	if req == nil || provider == nil || len(path.Steps) <= 2 || len(req.SourceExpandInfo) > 0 {
+	if req == nil || provider == nil || len(path.Steps) <= 2 {
 		return false
 	}
 	if mode != graphQueryModeInstant && mode != graphQueryModeRange {
 		return false
 	}
-
-	servingRelations := make(map[RelationType]struct{}, len(ActiveEdgeServingRelations))
-	for _, relationType := range ActiveEdgeServingRelations {
-		servingRelations[RelationType(relationType)] = struct{}{}
-	}
-	flatRelations := make(map[RelationType]struct{}, len(FlatMultiHopActiveEdgeServingRelations))
-	for _, relationType := range FlatMultiHopActiveEdgeServingRelations {
-		flatRelations[RelationType(relationType)] = struct{}{}
+	if _, ok := flatServingPrimaryKeyMap(provider, req.SchemaNamespace(), req.SourceType, req.SourceInfo); !ok {
+		return false
 	}
 
 	for hop := 1; hop < len(path.Steps); hop++ {
-		relationType := RelationType(path.Steps[hop].RelationType)
-		if _, ok := servingRelations[relationType]; !ok {
-			return false
-		}
-		if _, ok := flatRelations[relationType]; !ok {
-			return false
-		}
 		currentType := ResourceType(path.Steps[hop-1].ResourceType)
 		nextType := ResourceType(path.Steps[hop].ResourceType)
 		if len(provider.GetResourcePrimaryKeys(req.SchemaNamespace(), currentType)) == 0 ||
@@ -912,8 +898,8 @@ func usesFlatMultiHopActiveEdgeServingPath(
 	return true
 }
 
-// executeFlatMultiHopServingPath 将多跳图路径拆成按 hop 推进的单跳 Event 查询。同一 hop 的父节点
-// 可以并发执行，但每个查询使用业务主键字面量，因此 SDB 不需要通过 $parent 相关子查询连接关系表。
+// executeFlatMultiHopServingPath queries one relation table per hop. Parent
+// nodes in the same frontier can be queried concurrently without recursive SQL.
 func (m *Model) executeFlatMultiHopServingPath(
 	ctx context.Context,
 	req *QueryRequest,
@@ -1063,7 +1049,7 @@ func (m *Model) executeFlatServingHopQuery(
 ) (graphs []*LivenessGraph, err error) {
 	ctx, span := trace.NewSpan(ctx, "cmdb-v2-query-graph-flat-hop")
 	defer endV1Beta3TraceSpan(span, &err)
-	span.Set("query-route", "active_edge_serving_flat_multi_hop")
+	span.Set("query-route", "single_table_flat_multi_hop")
 	span.Set("flat-hop", hop)
 	span.Set("source-resource-type", string(source.resourceType))
 	span.Set("source-resource-id", source.resourceID)
@@ -1072,17 +1058,19 @@ func (m *Model) executeFlatServingHopQuery(
 	hopRequest := cloneQueryRequest(req)
 	hopRequest.SourceType = source.resourceType
 	hopRequest.SourceInfo = source.sourceInfo
-	hopRequest.SourceExpandInfo = nil
+	if hop > 1 {
+		hopRequest.SourceExpandInfo = nil
+	}
 	hopRequest.TargetType = ResourceType(path.Steps[1].ResourceType)
 	hopRequest.TargetTypeExplicit = true
 	hopRequest.PathResource = nil
 	hopRequest.MaxHops = 1
 
 	buildStarted := time.Now()
-	sql, ok := buildFlatServingQueryForPath(hopRequest, provider, path, mode)
+	sql, ok := buildFlatRelationQueryForPath(hopRequest, provider, path, mode)
 	span.Set("surrealql-build-duration", time.Since(buildStarted))
 	if !ok {
-		return nil, fmt.Errorf("cannot build flat serving query for hop %d from %q", hop, source.resourceType)
+		return nil, fmt.Errorf("cannot build single-table query for hop %d from %q", hop, source.resourceType)
 	}
 	span.Set("surrealql-bytes", len(sql))
 
@@ -1219,7 +1207,6 @@ func configureBuilderForGraphQueryMode(builder *SurrealQueryBuilder, mode graphQ
 	if builder == nil {
 		return
 	}
-	builder.queryMode = mode
 	if mode == graphQueryModeInstant {
 		builder.WithoutLivenessProjection()
 	}
@@ -1979,8 +1966,8 @@ func isAnyTargetPathActiveInWindow(paths []*targetPathInfo, windowStart, windowE
 }
 
 func isTargetPathActiveInWindow(path *targetPathInfo, windowStart, windowEnd int64) bool {
-	// 图路径的时间桶与 SurrealQL/active edge view 一样只看 relation liveness；
-	// 只有零跳 resource-info 结果没有边时才回退到 resource liveness。
+	// Graph paths use the intervals stored on relation rows. Resource-only
+	// responses have no edges and use their resource periods when provided.
 	periodGroups := path.EdgePeriods
 	if len(periodGroups) == 0 {
 		periodGroups = path.NodePeriods

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
@@ -1062,23 +1062,13 @@ func TestInferSourceTypeUsesDefinedResourcesWithoutRelations(t *testing.T) {
 	assert.Equal(t, ResourceTypeCluster, sourceType)
 }
 
-func TestComputeMaxHopsKeepsRoomForPartialPathResource(t *testing.T) {
-	assert.Equal(t, DefaultMaxHops, computeMaxHops("", "", nil))
-	assert.Equal(t, DefaultMaxHops, computeMaxHops("node", "deployment", nil))
-	assert.Equal(t, DefaultMaxHops, computeMaxHops("node", "", nil))
-	assert.Equal(t, 1, computeMaxHops("node", "pod", []cmdb.Resource{""}))
-	assert.Equal(t, DefaultMaxHops, computeMaxHops("node", "pod", []cmdb.Resource{"pod"}))
-	assert.Equal(t, DefaultMaxHops+2, computeMaxHops("node", "deployment", []cmdb.Resource{"pod"}))
-	assert.Equal(t, MaxAllowedHops, computeMaxHops("node", "host", []cmdb.Resource{"a", "b", "c", "d", "e"}))
-}
-
 func TestRangeQueryLookBackDeltaUsesRequiredWindowWhenOmitted(t *testing.T) {
 	assert.Equal(t, int64(660000), rangeQueryLookBackDelta(DefaultLookBackDelta, 0, 600000, 60000, false))
 	assert.Equal(t, DefaultLookBackDelta, rangeQueryLookBackDelta(DefaultLookBackDelta, 0, 600000, 60000, true))
 	assert.Equal(t, int64(660000), rangeQueryLookBackDelta(60000, 0, 600000, 60000, true))
 }
 
-func TestQueryLivenessGraphRaisesMaxHopsWhenDefaultCannotReachTarget(t *testing.T) {
+func TestQueryLivenessGraphDoesNotRaiseRequestedMaxHops(t *testing.T) {
 	ctx := context.Background()
 	provider := relation.NewStaticSchemaProvider(relation.StaticProviderConfig{
 		ResourcePrimaryKeys: map[string][]string{
@@ -1106,41 +1096,9 @@ func TestQueryLivenessGraphRaisesMaxHopsWhenDefaultCannotReachTarget(t *testing.
 		MaxHops:    DefaultMaxHops,
 	})
 
-	require.NoError(t, err)
-	assert.Contains(t, executor.sql, "FROM node_with_pod\n")
-	assert.NotContains(t, executor.sql, "$parent")
-	assert.Equal(t, []resourcePath{{Steps: []resourcePathStep{
-		{ResourceType: "node"},
-		{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
-		{ResourceType: "replicaset", RelationType: "pod_with_replicaset", Category: "static", Direction: "outbound"},
-		{ResourceType: "deployment", RelationType: "deployment_with_replicaset", Category: "static", Direction: "inbound"},
-	}}}, paths)
-}
-
-func TestAdjustMaxHopsForUnconstrainedPathKeepsLongerAlternatives(t *testing.T) {
-	provider := relation.NewStaticSchemaProvider(relation.StaticProviderConfig{
-		ResourcePrimaryKeys: map[string][]string{
-			"node":    {"node"},
-			"system":  {"system"},
-			"pod":     {"pod"},
-			"service": {"service"},
-		},
-		RelationSchemas: []relation.RelationSchema{
-			{RelationName: "node_with_pod", Category: relation.RelationCategoryStatic, FromType: "node", ToType: "pod"},
-			{RelationName: "pod_with_service", Category: relation.RelationCategoryStatic, FromType: "pod", ToType: "service"},
-			{RelationName: "node_with_system", Category: relation.RelationCategoryStatic, FromType: "node", ToType: "system"},
-			{RelationName: "system_with_pod", Category: relation.RelationCategoryStatic, FromType: "system", ToType: "pod"},
-		},
-	})
-	req := &QueryRequest{
-		SourceType: ResourceTypeNode,
-		TargetType: ResourceTypeService,
-		MaxHops:    DefaultMaxHops,
-	}
-
-	adjustMaxHopsForUnconstrainedPath(req, NewSchemaProviderFromRelation(provider))
-
-	assert.Equal(t, 3, req.MaxHops)
+	require.ErrorContains(t, err, "empty paths")
+	assert.Empty(t, paths)
+	assert.Empty(t, executor.sqls)
 }
 
 func TestSurrealQueryBuilderUsesScalarLivenessFilters(t *testing.T) {
@@ -2659,7 +2617,7 @@ func TestExtractMatchersAllowsSelfLoopForExplicitSelfTarget(t *testing.T) {
 	assert.Equal(t, cmdb.Matchers{{"pod": "pod-a"}}, matchers)
 }
 
-func TestQueryLivenessGraphConstrainsExplicitSameTypeTargetsToSelfRelation(t *testing.T) {
+func TestQueryLivenessGraphHonorsExplicitDirectPathForSameTypeTargets(t *testing.T) {
 	ctx := context.Background()
 	provider := relation.NewStaticSchemaProvider(relation.StaticProviderConfig{
 		ResourcePrimaryKeys: map[string][]string{
@@ -2736,6 +2694,7 @@ func TestQueryLivenessGraphConstrainsExplicitSameTypeTargetsToSelfRelation(t *te
 		SourceInfo:         map[string]string{"bk_target_ip": "source"},
 		TargetType:         ResourceTypeSystem,
 		TargetTypeExplicit: true,
+		PathResource:       []ResourceType{""},
 	})
 
 	require.NoError(t, err)
@@ -2807,6 +2766,7 @@ func TestQueryLivenessGraphRejectsExplicitSameTypeWithoutSelfRelation(t *testing
 		SourceInfo:         map[string]string{"bk_target_ip": "127.0.0.1"},
 		TargetType:         ResourceTypeSystem,
 		TargetTypeExplicit: true,
+		MaxHops:            1,
 		LookBackDelta:      600000,
 		LookBackDeltaSet:   true,
 	})

--- a/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/v1beta3_test.go
@@ -695,8 +695,8 @@ func TestQueryLivenessGraphUsesInjectedSchemaProvider(t *testing.T) {
 			Direction:    "outbound",
 		},
 	}}}, paths)
-	assert.Contains(t, executor.sql, "entity_data: { custom_id: custom_id }")
-	assert.Contains(t, executor.sql, "entity_data: { target_id: out.target_id }")
+	assert.Contains(t, executor.sql, "entity_data: { custom_id: source_id.custom_id }")
+	assert.Contains(t, executor.sql, "entity_data: { target_id: target_id.target_id }")
 }
 
 func TestQueryLivenessGraphPropagatesSchemaProviderFailures(t *testing.T) {
@@ -782,7 +782,7 @@ func TestQueryLivenessGraphProjectsTargetInfoFields(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Contains(t, executor.sql, "entity_data: { target_id: out.target_id, version: out.version }")
+	assert.Contains(t, executor.sql, "entity_data: { target_id: target_id.target_id, version: target_id.version }")
 }
 
 func TestSurrealQueryBuilderProjectsRootInfoFieldsForImplicitTarget(t *testing.T) {
@@ -1005,8 +1005,8 @@ func TestQueryLivenessGraphUsesSpaceUIDSchemaNamespace(t *testing.T) {
 		},
 	}}}, paths)
 	assert.Contains(t, executor.sql, "FROM biz_pod_node")
-	assert.Contains(t, executor.sql, "entity_data: { biz_pod: biz_pod }")
-	assert.Contains(t, executor.sql, "entity_data: { global_node: out.global_node }")
+	assert.Contains(t, executor.sql, "entity_data: { biz_pod: source_id.biz_pod }")
+	assert.Contains(t, executor.sql, "entity_data: { global_node: target_id.global_node }")
 	assert.NotContains(t, executor.sql, "global_pod_node")
 }
 
@@ -1107,7 +1107,8 @@ func TestQueryLivenessGraphRaisesMaxHopsWhenDefaultCannotReachTarget(t *testing.
 	})
 
 	require.NoError(t, err)
-	assert.Contains(t, executor.sql, "hop3")
+	assert.Contains(t, executor.sql, "FROM node_with_pod\n")
+	assert.NotContains(t, executor.sql, "$parent")
 	assert.Equal(t, []resourcePath{{Steps: []resourcePathStep{
 		{ResourceType: "node"},
 		{ResourceType: "pod", RelationType: "node_with_pod", Category: "static", Direction: "outbound"},
@@ -1153,55 +1154,12 @@ func TestSurrealQueryBuilderUsesScalarLivenessFilters(t *testing.T) {
 		Limit:         10,
 	}).Build()
 
-	assert.Contains(t, sql, "SELECT * FROM node_liveness_record WHERE reference_id = $parent.id")
-	assert.Contains(t, sql, "SELECT * FROM node_with_pod_liveness_record WHERE relation_id = $parent.id")
-	assert.Contains(t, sql, "LET $end = 600;")
+	assert.NotContains(t, sql, "_liveness_record")
+	assert.Contains(t, sql, "FROM node_with_pod WHERE source_id = $parent.id")
+	assert.NotContains(t, sql, "LET $end =")
 	assert.Contains(t, sql, "LET $end_ms = 600000;")
-	assert.Contains(t, sql, "[0] != NONE")
+	assert.Contains(t, sql, "active_period_end_ms >= $start_ms")
 	assert.NotContains(t, sql, "(SELECT count() FROM only")
-}
-
-func TestSurrealQueryBuilderRootRecordIDContract(t *testing.T) {
-	previous := RootRecordIDEnabled
-	RootRecordIDEnabled = true
-	t.Cleanup(func() { RootRecordIDEnabled = previous })
-	provider := newTableSchemaProvider(
-		map[ResourceType]tableResourceDefinition{
-			ResourceTypeNode: {primaryKeys: []string{"bcs_cluster_id", "node"}},
-		},
-		nil,
-	)
-
-	t.Run("uses schema primary-key order and keeps non-primary filters", func(t *testing.T) {
-		req := &QueryRequest{
-			Timestamp:        600000,
-			LookBackDelta:    600000,
-			SourceType:       ResourceTypeNode,
-			SourceInfo:       map[string]string{"node": `node⟩\1`, "bcs_cluster_id": "BCS-K8S-00001"},
-			SourceExpandInfo: map[string]string{"region": "east"},
-			Limit:            10,
-		}
-		builder := NewSurrealQueryBuilderWithSchemaProvider(req, provider)
-
-		assert.Equal(t, `node:⟨bcs_cluster_id=BCS-K8S-00001,node=node\⟩\\1⟩`, builder.buildRootSource())
-		assert.Equal(t,
-			"WHERE region = 'east'\n  AND (SELECT * FROM node_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end AND period_start <= period_end LIMIT 1)[0] != NONE",
-			builder.buildWhereClause(),
-		)
-		assert.Contains(t, builder.Build(), "FROM node:⟨bcs_cluster_id=BCS-K8S-00001,node=node\\⟩\\\\1⟩\n")
-	})
-
-	t.Run("falls back to table scan when a primary key is missing", func(t *testing.T) {
-		req := &QueryRequest{
-			Timestamp:  600000,
-			SourceType: ResourceTypeNode,
-			SourceInfo: map[string]string{"node": "node-1"},
-		}
-		builder := NewSurrealQueryBuilderWithSchemaProvider(req, provider)
-
-		assert.Equal(t, "node", builder.buildRootSource())
-		assert.Contains(t, builder.buildWhereClause(), "node = 'node-1'")
-	})
 }
 
 func TestSurrealQueryBuilderCanOmitLivenessProjection(t *testing.T) {
@@ -1218,24 +1176,19 @@ func TestSurrealQueryBuilderCanOmitLivenessProjection(t *testing.T) {
 	rangeSQL := NewSurrealQueryBuilder(cloneQueryRequest(req)).Build()
 	assert.Contains(t, rangeSQL, ResponseFieldLiveness+":")
 	assert.Contains(t, rangeSQL, ResponseFieldRelationLiveness+":")
-	assert.Contains(t, rangeSQL, "node_liveness_record WHERE reference_id = $parent.id")
-	assert.Contains(t, rangeSQL, "node_with_pod_liveness_record WHERE relation_id = $parent.id")
+	assert.NotContains(t, rangeSQL, "_liveness_record")
+	assert.Contains(t, rangeSQL, "relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }]")
 
 	instantSQL := NewSurrealQueryBuilder(cloneQueryRequest(req)).WithoutLivenessProjection().Build()
 	assert.NotContains(t, instantSQL, ResponseFieldLiveness+":")
 	assert.NotContains(t, instantSQL, ResponseFieldRelationLiveness+":")
-	assert.Contains(t, instantSQL, "node_liveness_record WHERE reference_id = $parent.id")
-	assert.Contains(t, instantSQL, "node_with_pod_liveness_record WHERE relation_id = $parent.id")
+	assert.NotContains(t, instantSQL, "_liveness_record")
+	assert.Contains(t, instantSQL, "active_period_start_ms <= $end_ms")
+	assert.Contains(t, instantSQL, "active_period_end_ms >= $start_ms")
 }
 
-func TestSurrealQueryBuilderFlatOneHopActiveEdgeServingContract(t *testing.T) {
-	previousFlat := FlatOneHopActiveEdgeServingRelations
-	previousServing := ActiveEdgeServingRelations
-	FlatOneHopActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
-	ActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
+func TestSurrealQueryBuilderFlatOneHopSingleTableContract(t *testing.T) {
 	t.Cleanup(func() {
-		FlatOneHopActiveEdgeServingRelations = previousFlat
-		ActiveEdgeServingRelations = previousServing
 	})
 
 	request := &QueryRequest{
@@ -1261,84 +1214,31 @@ func TestSurrealQueryBuilderFlatOneHopActiveEdgeServingContract(t *testing.T) {
 	instantBuilder := NewSurrealQueryBuilderForPath(request, GetSchemaProvider(), path)
 	configureBuilderForGraphQueryMode(instantBuilder, graphQueryModeInstant)
 	instantSQL := instantBuilder.Build()
-	assert.Equal(t, "active_edge_serving_flat_one_hop", instantBuilder.routeName())
-	assert.Contains(t, instantSQL, "FROM node_with_pod_active_edge_view\nWHERE source_data.bcs_cluster_id = 'BCS-K8S-00001'\n  AND source_data.node = 'node-1'")
+	assert.Equal(t, "single_table_flat_one_hop", instantBuilder.routeName())
+	assert.Contains(t, instantSQL, "SELECT VALUE id FROM node WHERE bcs_cluster_id = 'BCS-K8S-00001' AND node = 'node-1'")
+	assert.Contains(t, instantSQL, "FROM node_with_pod\nWHERE source_id IN $source_ids")
+	assert.NotContains(t, instantSQL, "_active_edge_view")
 	assert.NotContains(t, instantSQL, "LET $flat_root_id")
 	assert.NotContains(t, instantSQL, "FROM node\nWHERE")
 	assert.NotContains(t, instantSQL, "source_id = $")
-	assert.Contains(t, instantSQL, "entity_data: source_data")
-	assert.Contains(t, instantSQL, "entity_data: target_data")
+	assert.Contains(t, instantSQL, "entity_data: { bcs_cluster_id: source_id.bcs_cluster_id, node: source_id.node }")
+	assert.Contains(t, instantSQL, "entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod }")
 	assert.NotContains(t, instantSQL, "relation_liveness:")
 	assert.NotContains(t, instantSQL, "hop2")
 
 	rangeBuilder := NewSurrealQueryBuilderForPath(request, GetSchemaProvider(), path)
 	configureBuilderForGraphQueryMode(rangeBuilder, graphQueryModeRange)
 	rangeSQL := rangeBuilder.Build()
-	assert.Equal(t, "active_edge_serving_flat_one_hop", rangeBuilder.routeName())
-	assert.Contains(t, rangeSQL, "FROM node_with_pod_active_edge_view\nWHERE source_data.bcs_cluster_id = 'BCS-K8S-00001'\n  AND source_data.node = 'node-1'")
+	assert.Equal(t, "single_table_flat_one_hop", rangeBuilder.routeName())
+	assert.Contains(t, rangeSQL, "SELECT VALUE id FROM node WHERE bcs_cluster_id = 'BCS-K8S-00001' AND node = 'node-1'")
+	assert.Contains(t, rangeSQL, "FROM node_with_pod\nWHERE source_id IN $source_ids")
 	assert.Contains(t, rangeSQL, "relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }]")
 	assert.Contains(t, rangeSQL, "active_period_start_ms <= active_period_end_ms")
 	assert.NotContains(t, rangeSQL, "FROM node\nWHERE")
 }
 
-func TestSurrealQueryBuilderFlatOneHopActiveEdgeServingFallsBack(t *testing.T) {
-	previousFlat := FlatOneHopActiveEdgeServingRelations
-	previousServing := ActiveEdgeServingRelations
-	FlatOneHopActiveEdgeServingRelations = nil
-	ActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
+func TestSurrealQueryBuilderFlatOneHopSingleTableReverseContract(t *testing.T) {
 	t.Cleanup(func() {
-		FlatOneHopActiveEdgeServingRelations = previousFlat
-		ActiveEdgeServingRelations = previousServing
-	})
-
-	request := &QueryRequest{
-		Timestamp:          600000,
-		LookBackDelta:      600000,
-		SourceType:         ResourceTypeNode,
-		SourceInfo:         map[string]string{"bcs_cluster_id": "BCS-K8S-00001", "node": "node-1"},
-		TargetType:         ResourceTypePod,
-		TargetTypeExplicit: true,
-		PathResource:       []ResourceType{ResourceTypeNode, ResourceTypePod},
-		MaxHops:            1,
-	}
-	path := resourcePath{Steps: []resourcePathStep{
-		{ResourceType: string(ResourceTypeNode)},
-		{
-			ResourceType: string(ResourceTypePod),
-			RelationType: string(RelationNodeWithPod),
-			Category:     string(RelationCategoryStatic),
-			Direction:    string(DirectionOutbound),
-		},
-	}}
-
-	instantBuilder := NewSurrealQueryBuilderForPath(request, GetSchemaProvider(), path)
-	configureBuilderForGraphQueryMode(instantBuilder, graphQueryModeInstant)
-	instantSQL := instantBuilder.Build()
-	assert.Equal(t, "active_edge_serving", instantBuilder.routeName())
-	assert.Contains(t, instantSQL, "FROM node\nWHERE")
-	assert.Contains(t, instantSQL, "source_id = $parent.id")
-
-	FlatOneHopActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
-	request.SourceExpandInfo = map[string]string{"region": "sh"}
-	expandedBuilder := NewSurrealQueryBuilderForPath(request, GetSchemaProvider(), path)
-	configureBuilderForGraphQueryMode(expandedBuilder, graphQueryModeInstant)
-	assert.Equal(t, "active_edge_serving", expandedBuilder.routeName())
-	assert.Contains(t, expandedBuilder.Build(), "region = 'sh'")
-
-	rangeBuilder := NewSurrealQueryBuilderForPath(request, GetSchemaProvider(), path)
-	configureBuilderForGraphQueryMode(rangeBuilder, graphQueryModeRange)
-	assert.Equal(t, "active_edge_serving", rangeBuilder.routeName())
-	assert.Contains(t, rangeBuilder.Build(), "FROM node_with_pod_active_edge_view")
-}
-
-func TestSurrealQueryBuilderFlatOneHopActiveEdgeServingReverseContract(t *testing.T) {
-	previousFlat := FlatOneHopActiveEdgeServingRelations
-	previousServing := ActiveEdgeServingRelations
-	FlatOneHopActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
-	ActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
-	t.Cleanup(func() {
-		FlatOneHopActiveEdgeServingRelations = previousFlat
-		ActiveEdgeServingRelations = previousServing
 	})
 
 	request := &QueryRequest{
@@ -1364,32 +1264,28 @@ func TestSurrealQueryBuilderFlatOneHopActiveEdgeServingReverseContract(t *testin
 	builder := NewSurrealQueryBuilderForPath(request, GetSchemaProvider(), path)
 	configureBuilderForGraphQueryMode(builder, graphQueryModeInstant)
 	sql := builder.Build()
-	assert.Equal(t, "active_edge_serving_flat_one_hop", builder.routeName())
-	assert.Contains(t, sql, "FROM node_with_pod_active_edge_view\nWHERE target_data.bcs_cluster_id = 'BCS-K8S-00001'\n  AND target_data.namespace = 'default'\n  AND target_data.pod = 'nginx-1'")
+	assert.Equal(t, "single_table_flat_one_hop", builder.routeName())
+	assert.Contains(t, sql, "SELECT VALUE id FROM pod WHERE bcs_cluster_id = 'BCS-K8S-00001' AND namespace = 'default' AND pod = 'nginx-1'")
+	assert.Contains(t, sql, "FROM node_with_pod\nWHERE target_id IN $source_ids")
 	assert.Contains(t, sql, "entity_id: <string>target_id")
-	assert.Contains(t, sql, "entity_data: target_data")
+	assert.Contains(t, sql, "entity_data: { bcs_cluster_id: target_id.bcs_cluster_id, namespace: target_id.namespace, pod: target_id.pod }")
 	assert.Contains(t, sql, "entity_id: <string>source_id")
-	assert.Contains(t, sql, "entity_data: source_data")
+	assert.Contains(t, sql, "entity_data: { bcs_cluster_id: source_id.bcs_cluster_id, node: source_id.node }")
 
 	rangeBuilder := NewSurrealQueryBuilderForPath(request, GetSchemaProvider(), path)
 	configureBuilderForGraphQueryMode(rangeBuilder, graphQueryModeRange)
 	rangeSQL := rangeBuilder.Build()
-	assert.Equal(t, "active_edge_serving_flat_one_hop", rangeBuilder.routeName())
-	assert.Contains(t, rangeSQL, "FROM node_with_pod_active_edge_view\nWHERE target_data.bcs_cluster_id = 'BCS-K8S-00001'\n  AND target_data.namespace = 'default'\n  AND target_data.pod = 'nginx-1'")
+	assert.Equal(t, "single_table_flat_one_hop", rangeBuilder.routeName())
+	assert.Contains(t, rangeSQL, "SELECT VALUE id FROM pod WHERE bcs_cluster_id = 'BCS-K8S-00001' AND namespace = 'default' AND pod = 'nginx-1'")
+	assert.Contains(t, rangeSQL, "FROM node_with_pod\nWHERE target_id IN $source_ids")
 	assert.Contains(t, rangeSQL, "relation_liveness: [{ period_start: active_period_start_ms, period_end: active_period_end_ms }]")
 	assert.NotContains(t, rangeSQL, "FROM pod\nWHERE")
 }
 
-func TestFlatOneHopActiveEdgeServingRejectsFanoutAboveLimit(t *testing.T) {
-	previousFlat := FlatOneHopActiveEdgeServingRelations
-	previousServing := ActiveEdgeServingRelations
+func TestFlatOneHopSingleTableRejectsFanoutAboveLimit(t *testing.T) {
 	previousMaxEdges := MaxEdgesPerHop
-	FlatOneHopActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
-	ActiveEdgeServingRelations = []string{string(RelationNodeWithPod)}
 	MaxEdgesPerHop = 1
 	t.Cleanup(func() {
-		FlatOneHopActiveEdgeServingRelations = previousFlat
-		ActiveEdgeServingRelations = previousServing
 		MaxEdgesPerHop = previousMaxEdges
 	})
 
@@ -1431,7 +1327,7 @@ func TestFlatOneHopActiveEdgeServingRejectsFanoutAboveLimit(t *testing.T) {
 	assert.Equal(t, "max_edges_per_hop", limitErr.TruncationReason())
 }
 
-func TestSurrealQueryBuilderUsesSecondEntityAndMillisecondRelationWindows(t *testing.T) {
+func TestSurrealQueryBuilderUsesMillisecondRelationWindows(t *testing.T) {
 	sql := NewSurrealQueryBuilder(&QueryRequest{
 		Timestamp:     1782984106000,
 		LookBackDelta: 604800000,
@@ -1443,12 +1339,13 @@ func TestSurrealQueryBuilderUsesSecondEntityAndMillisecondRelationWindows(t *tes
 		Limit:         100,
 	}).Build()
 
-	assert.Contains(t, sql, "LET $start = 1782379306;")
-	assert.Contains(t, sql, "LET $end = 1782984106;")
+	assert.NotContains(t, sql, "LET $start =")
+	assert.NotContains(t, sql, "LET $end =")
 	assert.Contains(t, sql, "LET $start_ms = 1782379306000;")
 	assert.Contains(t, sql, "LET $end_ms = 1782984106000;")
-	assert.Contains(t, sql, "SELECT * FROM module_liveness_record WHERE reference_id = $parent.id AND $end >= period_start AND $start <= period_end")
-	assert.Contains(t, sql, "SELECT * FROM module_with_set_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end")
+	assert.NotContains(t, sql, "_liveness_record")
+	assert.Contains(t, sql, "active_period_start_ms <= $end_ms")
+	assert.Contains(t, sql, "active_period_end_ms >= $start_ms")
 }
 
 func TestSurrealQueryBuilderFiltersInvertedRelationLivenessPeriods(t *testing.T) {
@@ -1463,7 +1360,8 @@ func TestSurrealQueryBuilderFiltersInvertedRelationLivenessPeriods(t *testing.T)
 		Limit:         100,
 	}).Build()
 
-	assert.Contains(t, sql, "SELECT * FROM module_with_set_liveness_record WHERE relation_id = $parent.id AND $end_ms >= period_start AND $start_ms <= period_end AND period_start <= period_end LIMIT 1")
+	assert.Contains(t, sql, "active_period_start_ms <= active_period_end_ms")
+	assert.Contains(t, sql, "FROM module_with_set WHERE source_id = $parent.id")
 }
 
 func TestSurrealParserNormalizesSecondEntityPeriodsForRangeTargetList(t *testing.T) {
@@ -2176,7 +2074,7 @@ func TestQueryResourceMatcherAppliesSourceExpandInfo(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Contains(t, executor.sql, "env_name = 'production'")
-	assert.Contains(t, executor.sql, "relation_id = $parent.id")
+	assert.Contains(t, executor.sql, "active_period_end_ms >= $start_ms")
 	assert.NotContains(t, executor.sql, "system_liveness_record WHERE reference_id = $parent.")
 	assert.NotContains(t, executor.sql, "host_liveness_record WHERE reference_id = $parent.")
 	assert.NotContains(t, executor.sql, ResponseFieldLiveness+":")
@@ -2372,10 +2270,10 @@ func TestSurrealQueryBuilderEscapesSchemaDerivedTableNames(t *testing.T) {
 	}, provider).Build()
 
 	assert.Contains(t, sql, "FROM ⟨custom-resource⟩")
-	assert.Contains(t, sql, "⟨custom-resource_liveness_record⟩")
+	assert.NotContains(t, sql, "_liveness_record")
 	assert.Contains(t, sql, "⟨custom-relation⟩:")
 	assert.Contains(t, sql, "FROM ⟨custom-relation⟩")
-	assert.Contains(t, sql, "⟨custom-relation_liveness_record⟩")
+	assert.Contains(t, sql, "active_period_start_ms <= active_period_end_ms")
 }
 
 func TestQueryLivenessGraphRejectsInvalidTypedPrimaryKey(t *testing.T) {
@@ -3220,16 +3118,7 @@ func TestQueryLivenessGraphFlattensBusinessSevenTwoHopEventPath(t *testing.T) {
 		setID     = "15"
 	)
 
-	previousServingRelations := ActiveEdgeServingRelations
-	previousFlatOneHopRelations := FlatOneHopActiveEdgeServingRelations
-	previousFlatMultiHopRelations := FlatMultiHopActiveEdgeServingRelations
-	ActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
-	FlatOneHopActiveEdgeServingRelations = nil
-	FlatMultiHopActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
 	t.Cleanup(func() {
-		ActiveEdgeServingRelations = previousServingRelations
-		FlatOneHopActiveEdgeServingRelations = previousFlatOneHopRelations
-		FlatMultiHopActiveEdgeServingRelations = previousFlatMultiHopRelations
 	})
 
 	provider := businessSevenTwoHopSchemaProvider()
@@ -3265,12 +3154,12 @@ func TestQueryLivenessGraphFlattensBusinessSevenTwoHopEventPath(t *testing.T) {
 		t.Run(string(mode), func(t *testing.T) {
 			executor := &recordingGraphQueryExecutor{responseForSQL: func(sql string) graphQueryResponse {
 				switch {
-				case strings.Contains(sql, "FROM host_with_module_active_edge_view"):
+				case strings.Contains(sql, "FROM host_with_module\n"):
 					return graphQueryResponse{graphs: []*LivenessGraph{
 						cloneLivenessGraphForTest(firstHop, 0, 0),
 						cloneLivenessGraphForTest(firstHop, 0, 0),
 					}}
-				case strings.Contains(sql, "FROM module_with_set_active_edge_view"):
+				case strings.Contains(sql, "FROM module_with_set\n"):
 					return graphQueryResponse{graphs: []*LivenessGraph{
 						cloneLivenessGraphForTest(secondHop, 0, 0),
 						cloneLivenessGraphForTest(secondHopEarlierPeriod, 0, 0),
@@ -3300,8 +3189,8 @@ func TestQueryLivenessGraphFlattensBusinessSevenTwoHopEventPath(t *testing.T) {
 			}
 
 			require.Len(t, executor.sqls, 2)
-			assert.Contains(t, executor.sqls[0], "source_data.bk_host_id = '"+hostID+"'")
-			assert.Contains(t, executor.sqls[1], "source_data.bk_module_id = '"+moduleID+"'")
+			assert.Contains(t, executor.sqls[0], "SELECT VALUE id FROM host WHERE bk_host_id = '"+hostID+"'")
+			assert.Contains(t, executor.sqls[1], "SELECT VALUE id FROM module WHERE bk_module_id = '"+moduleID+"'")
 			for _, sql := range executor.sqls {
 				assert.NotContains(t, sql, "$parent")
 				assert.Contains(t, sql, "active_period_start_ms <= active_period_end_ms")
@@ -3344,13 +3233,7 @@ func TestLivenessGraphMergesDuplicateEdgePeriods(t *testing.T) {
 func TestQueryLivenessGraphFlatMultiHopUsesCompositeMetadataPrimaryKeys(t *testing.T) {
 	const timestamp = int64(1786731939847)
 
-	previousServingRelations := ActiveEdgeServingRelations
-	previousFlatMultiHopRelations := FlatMultiHopActiveEdgeServingRelations
-	ActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
-	FlatMultiHopActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
 	t.Cleanup(func() {
-		ActiveEdgeServingRelations = previousServingRelations
-		FlatMultiHopActiveEdgeServingRelations = previousFlatMultiHopRelations
 	})
 
 	provider := newTableSchemaProvider(
@@ -3388,9 +3271,9 @@ func TestQueryLivenessGraphFlatMultiHopUsesCompositeMetadataPrimaryKeys(t *testi
 	)
 	executor := &recordingGraphQueryExecutor{responseForSQL: func(sql string) graphQueryResponse {
 		switch {
-		case strings.Contains(sql, "FROM host_with_module_active_edge_view"):
+		case strings.Contains(sql, "FROM host_with_module\n"):
 			return graphQueryResponse{graphs: []*LivenessGraph{cloneLivenessGraphForTest(firstHop, 0, 0)}}
-		case strings.Contains(sql, "FROM module_with_set_active_edge_view"):
+		case strings.Contains(sql, "FROM module_with_set\n"):
 			return graphQueryResponse{graphs: []*LivenessGraph{cloneLivenessGraphForTest(secondHop, 0, 0)}}
 		default:
 			return graphQueryResponse{err: errors.New("unexpected SurrealQL")}
@@ -3406,22 +3289,16 @@ func TestQueryLivenessGraphFlatMultiHopUsesCompositeMetadataPrimaryKeys(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, cmdb.Matchers{{"bk_biz_id": "7", "bk_set_id": "15"}}, matchers)
 	require.Len(t, executor.sqls, 2)
-	assert.Contains(t, executor.sqls[0], "source_data.bk_biz_id = '7'")
-	assert.Contains(t, executor.sqls[0], "source_data.bk_host_id = '185667'")
-	assert.Contains(t, executor.sqls[1], "source_data.bk_biz_id = '7'")
-	assert.Contains(t, executor.sqls[1], "source_data.bk_module_id = '73'")
+	assert.Contains(t, executor.sqls[0], "bk_biz_id = '7'")
+	assert.Contains(t, executor.sqls[0], "bk_host_id = '185667'")
+	assert.Contains(t, executor.sqls[1], "bk_biz_id = '7'")
+	assert.Contains(t, executor.sqls[1], "bk_module_id = '73'")
 }
 
 func TestQueryLivenessGraphRunsFlatMultiHopParentsInParallel(t *testing.T) {
 	const timestamp = int64(1786731939847)
 
-	previousServingRelations := ActiveEdgeServingRelations
-	previousFlatMultiHopRelations := FlatMultiHopActiveEdgeServingRelations
-	ActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
-	FlatMultiHopActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
 	t.Cleanup(func() {
-		ActiveEdgeServingRelations = previousServingRelations
-		FlatMultiHopActiveEdgeServingRelations = previousFlatMultiHopRelations
 	})
 
 	firstHop := businessSevenSingleHopGraph(
@@ -3458,12 +3335,12 @@ func TestQueryLivenessGraphRunsFlatMultiHopParentsInParallel(t *testing.T) {
 
 	executor := &recordingGraphQueryExecutor{responseForSQL: func(sql string) graphQueryResponse {
 		switch {
-		case strings.Contains(sql, "FROM host_with_module_active_edge_view"):
+		case strings.Contains(sql, "FROM host_with_module\n"):
 			return graphQueryResponse{graphs: []*LivenessGraph{cloneLivenessGraphForTest(firstHop, 0, 0)}}
-		case strings.Contains(sql, "FROM module_with_set_active_edge_view"):
+		case strings.Contains(sql, "FROM module_with_set\n"):
 			started <- sql
 			<-release
-			if strings.Contains(sql, "source_data.bk_module_id = '13293'") {
+			if strings.Contains(sql, "bk_module_id = '13293'") {
 				return graphQueryResponse{graphs: []*LivenessGraph{businessSevenSingleHopGraph(
 					ResourceTypeModule, "module:`13293`", map[string]string{"bk_module_id": "13293"},
 					RelationModuleWithSet, "module_with_set:`13293_3469`", ResourceTypeSet, "set:`3469`",
@@ -3509,14 +3386,8 @@ func TestQueryLivenessGraphRunsFlatMultiHopParentsInParallel(t *testing.T) {
 	assert.ElementsMatch(t, cmdb.Matchers{{"bk_set_id": "15"}, {"bk_set_id": "3469"}}, result.matchers)
 }
 
-func TestQueryLivenessGraphFallsBackWhenMultiHopRelationIsNotFlatReady(t *testing.T) {
-	previousServingRelations := ActiveEdgeServingRelations
-	previousFlatMultiHopRelations := FlatMultiHopActiveEdgeServingRelations
-	ActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
-	FlatMultiHopActiveEdgeServingRelations = []string{string(RelationHostWithModule)}
+func TestQueryLivenessGraphUsesSingleTableWithoutServingConfiguration(t *testing.T) {
 	t.Cleanup(func() {
-		ActiveEdgeServingRelations = previousServingRelations
-		FlatMultiHopActiveEdgeServingRelations = previousFlatMultiHopRelations
 	})
 
 	executor := &recordingGraphQueryExecutor{}
@@ -3527,21 +3398,16 @@ func TestQueryLivenessGraphFallsBackWhenMultiHopRelationIsNotFlatReady(t *testin
 	_, _, _, err = model.QueryLivenessGraph(context.Background(), businessSevenTwoHopRequest(1786731939847, "185667"))
 	require.NoError(t, err)
 	require.Len(t, executor.sqls, 1)
-	assert.Contains(t, executor.sqls[0], "FROM host_with_module_active_edge_view")
-	assert.Contains(t, executor.sqls[0], "FROM module_with_set_active_edge_view")
-	assert.Contains(t, executor.sqls[0], "$parent.target_id")
+	assert.Contains(t, executor.sqls[0], "FROM host_with_module\n")
+	assert.NotContains(t, executor.sqls[0], "FROM module_with_set")
+	assert.NotContains(t, executor.sqls[0], "$parent")
+	assert.NotContains(t, executor.sqls[0], "_active_edge_view")
 }
 
 func TestQueryLivenessGraphRejectsFlatMultiHopFanoutAboveLimit(t *testing.T) {
-	previousServingRelations := ActiveEdgeServingRelations
-	previousFlatMultiHopRelations := FlatMultiHopActiveEdgeServingRelations
 	previousMaxEdgesPerHop := MaxEdgesPerHop
-	ActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
-	FlatMultiHopActiveEdgeServingRelations = []string{string(RelationHostWithModule), string(RelationModuleWithSet)}
 	MaxEdgesPerHop = 1
 	t.Cleanup(func() {
-		ActiveEdgeServingRelations = previousServingRelations
-		FlatMultiHopActiveEdgeServingRelations = previousFlatMultiHopRelations
 		MaxEdgesPerHop = previousMaxEdgesPerHop
 	})
 
@@ -3745,11 +3611,13 @@ func assertTrimmedPathSQLs(t *testing.T, sqls []string) {
 			assert.NotContains(t, sql, "system_to_container")
 			assert.NotContains(t, sql, "system_to_statefulset")
 		case strings.Contains(sql, "system_to_container"):
-			assert.Contains(t, sql, "container_to_pod")
+			assert.NotContains(t, sql, "container_to_pod")
+			assert.NotContains(t, sql, "$parent")
 			assert.NotContains(t, sql, "system_to_pod")
 			assert.NotContains(t, sql, "system_to_statefulset")
 		case strings.Contains(sql, "system_to_statefulset"):
-			assert.Contains(t, sql, "statefulset_to_pod")
+			assert.NotContains(t, sql, "statefulset_to_pod")
+			assert.NotContains(t, sql, "$parent")
 			assert.NotContains(t, sql, "system_to_pod")
 			assert.NotContains(t, sql, "system_to_container")
 		default:

--- a/pkg/unify-query/service/http/api/api.go
+++ b/pkg/unify-query/service/http/api/api.go
@@ -283,12 +283,12 @@ func HandlerAPIRelationV1Beta3MultiResource(c *gin.Context) {
 
 			timestamp := cast.ToString(qry.Timestamp)
 			// v1beta3 默认 HTTP 协议对齐旧 VM relation：底层走 SurrealDB，但响应仍返回 legacy path 字段。
-			d.SourceType, d.SourceInfo, d.Path, d.TargetType, d.TargetList, queryErr = model.QueryResourceMatcher(
+			d.SourceType, d.SourceInfo, d.Path, d.TargetType, d.TargetList, queryErr = model.QueryResourceMatcherWithMaxHops(
 				queryCtx,
 				qry.LookBackDelta, user.SpaceUID, timestamp,
 				qry.TargetType, qry.SourceType,
 				qry.SourceInfo, qry.SourceExpandInfo, qry.TargetInfoShow,
-				qry.PathResource,
+				qry.PathResource, qry.MaxHops,
 			)
 			if queryErr != nil {
 				d.Message = queryErr.Error()
@@ -411,12 +411,12 @@ func HandlerAPIRelationV1Beta3MultiResourceRange(c *gin.Context) {
 			startTs := cast.ToString(qry.StartTs)
 			endTs := cast.ToString(qry.EndTs)
 			// range 保持 VM 兼容响应，target_list 的窗口语义在 v1beta3 model 内部对齐。
-			d.SourceType, d.SourceInfo, d.Path, d.TargetType, d.TargetList, queryErr = model.QueryResourceMatcherRange(
+			d.SourceType, d.SourceInfo, d.Path, d.TargetType, d.TargetList, queryErr = model.QueryResourceMatcherRangeWithMaxHops(
 				queryCtx,
 				qry.LookBackDelta, user.SpaceUID, qry.Step, startTs, endTs,
 				qry.TargetType, qry.SourceType,
 				qry.SourceInfo, qry.SourceExpandInfo, qry.TargetInfoShow,
-				qry.PathResource,
+				qry.PathResource, qry.MaxHops,
 			)
 			if queryErr != nil {
 				d.Message = queryErr.Error()


### PR DESCRIPTION
SurrealDB graph queries fail when a binding uses relation tables that store endpoint record IDs and active periods directly: the previous query builder still reads auxiliary liveness/active-edge tables, and the direct response parser rejects session/control statement results.

This change queries the relation tables directly for single-hop and multi-hop paths, resolves actual resource record IDs from schema keys, dereferences endpoint labels, and retains relation-period filtering and range buckets. It removes the active-edge serving configuration and synthetic root-record-ID switch rather than retaining an old-schema fallback. Direct SQL responses now normalize session/control statements and preserve execution errors. Redis lookup failures are also preserved instead of being reported as missing bindings.

Validation:
- Full unify-query module tests with ordinary build tags passed.
- `go test -race -count=1 ./cmdb/v1beta3` passed.
- 154 read-only acceptance cases passed across three configured databases; relations without a usable positive sample were skipped and are not counted as passing.
- Four HTTP cases passed in a temporary process using an explicit test binding: single-hop and multi-hop, each instant and range. That binding override and temporary launcher are not included in this PR.


Traversal depth is controlled by the request, including same-type queries such as pod -> pod. Both v1beta3 instant and range HTTP query_list items accept `max_hops`: 1 allows direct relations, and 3 allows paths of up to three hops. An omitted value uses `cmdb.v1beta3.max_hops` (code default 2). Explicit zero/negative values and values above `cmdb.v1beta3.max_allowed_hops` (code default 5) are rejected rather than clamped. Requests with an explicit budget stay on the SurrealDB implementation because the VM adapter cannot enforce that budget.

The change removes same-type direct-only rewriting and automatic depth increases based on schema/path_resource. Callers requiring deeper paths must now supply a sufficient max_hops value. Missing target_type continues to mean source information only. Full paths preserve repeated resource types, and graph-result extraction is bounded after row merging. Existing first-successful-path selection and relation-category defaults remain; a larger hop budget does not mean all candidate paths are merged or that dynamic metric values are returned.

Additional validation for hop control:
- `go test ./... -count=1` passed for the full unify-query module.
- `go test -race ./cmdb/v1beta3 ./service/http/api -count=1` passed.
- Regression cases cover dynamic pod self-relations at depths 1/2/3, instant/range adapter propagation and invalid budgets, no automatic budget increase, and repeated-type path extraction with a depth bound.
- These hop-control changes have not yet been deployed or validated against a live SurrealDB instance; the earlier live acceptance results above predate this addition.

Deployment requires the new relation-table schema and valid tenant-scoped result-table/storage routes. Missing routes still fail explicitly. Deployment/configuration changes, traffic enablement, and full post-deployment HTTP acceptance remain separate from this code change. The opt-in live test reads connection settings from stdin; no environment credentials or captured payloads are included.

Related: #1472 is closed in favor of this PR. Its missing-self-path-to-empty-success compatibility branch is intentionally not carried over; a path that cannot be found within the requested constraints still fails explicitly.

Lint status: full lint remains incomplete. For the hop-control addition, gofumpt and git diff --check passed. A scoped incremental run with golangci-lint v1.64.8 remained active for over two minutes despite a 90-second timeout and was terminated without a result. The module-wide pre-commit lint hook also rewrites unrelated files; this commit uses the explicit checks above without rerunning that hook. This is not a lint pass.
