### PR TITLE
fix(unify-query): ignore target_info_show when target has no info --story=138124380

### DIFF
--- a/pkg/unify-query/cmdb/v1beta1/query_maker.go
+++ b/pkg/unify-query/cmdb/v1beta1/query_maker.go
@@ -85,29 +85,29 @@ func (q *QueryFactory) MakeQueryTs() (*structured.QueryTs, error) {
 		}
 	}
 
+	// target_info_show is a projection switch. Targets with no Info fields
+	// have nothing to expand; ignore the flag instead of failing the relation query.
 	if q.ExpandShow {
 		infoIndex := ResourcesInfo(q.Target)
-		targetIndex := ResourcesIndex(q.Target)
+		if len(infoIndex) > 0 {
+			targetIndex := ResourcesIndex(q.Target)
 
-		if len(infoIndex) == 0 {
-			return nil, fmt.Errorf("该资源未配置 info 扩展数据")
-		}
+			ref := string(rune(ascii + q.index))
+			queries, err := q.buildInfoQuery(q.Target, q.IndexMatcher, q.ExpandMatcher)
+			if err != nil {
+				return nil, err
+			}
 
-		ref := string(rune(ascii + q.index))
-		queries, err := q.buildInfoQuery(q.Target, q.IndexMatcher, q.ExpandMatcher)
-		if err != nil {
-			return nil, err
-		}
+			queryList = append(queryList, queries)
 
-		queryList = append(queryList, queries)
+			allIndex := append([]string{}, targetIndex...)
+			allIndex = append(allIndex, infoIndex...)
 
-		allIndex := append([]string{}, targetIndex...)
-		allIndex = append(allIndex, infoIndex...)
-
-		if q.metricMerge == "" {
-			q.metricMerge = fmt.Sprintf("count(%s) by (%s)", ref, strings.Join(allIndex, ","))
-		} else {
-			q.metricMerge = fmt.Sprintf("(%s) * on(%s) group_left(%s) %s", q.metricMerge, strings.Join(targetIndex, ","), strings.Join(infoIndex, ","), ref)
+			if q.metricMerge == "" {
+				q.metricMerge = fmt.Sprintf("count(%s) by (%s)", ref, strings.Join(allIndex, ","))
+			} else {
+				q.metricMerge = fmt.Sprintf("(%s) * on(%s) group_left(%s) %s", q.metricMerge, strings.Join(targetIndex, ","), strings.Join(infoIndex, ","), ref)
+			}
 		}
 	}
 

--- a/pkg/unify-query/cmdb/v1beta1/query_maker_test.go
+++ b/pkg/unify-query/cmdb/v1beta1/query_maker_test.go
@@ -11,7 +11,6 @@ package v1beta1
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,8 +33,6 @@ func TestMakeQuery(t *testing.T) {
 		expandMatch  map[string]string
 		promQL       string
 		step         string
-
-		err error
 	}
 
 	cases := []Case{
@@ -94,17 +91,6 @@ func TestMakeQuery(t *testing.T) {
 			},
 			step:   "1m",
 			promQL: `count by (bcs_cluster_id, node) (count_over_time(bkmonitor:node_with_pod_relation{bcs_cluster_id!="",namespace!="",node!="",pod!=""}[1m]) * on (bcs_cluster_id, namespace, pod) group_left () (count by (bcs_cluster_id, namespace, pod) (count_over_time(bkmonitor:container_with_pod_relation{bcs_cluster_id!="",container="unify-query",namespace!="",pod!=""}[1m]) * on (bcs_cluster_id, namespace, pod, container) group_left () (count_over_time(bkmonitor:container_info_relation{bcs_cluster_id!="",container="unify-query",namespace!="",pod!="",version="3.9.3269"}[1m])))))`,
-		},
-		{
-			name:       "level 2 with expand show",
-			path:       []string{"pod", "node", "system"},
-			expandShow: true,
-			indexMatcher: map[string]string{
-				"pod":            "pod1",
-				"namespace":      "ns1",
-				"bcs_cluster_id": "cluster1",
-			},
-			err: fmt.Errorf("该资源未配置 info 扩展数据"),
 		},
 		{
 			name:       "level 3 with expand show",
@@ -183,20 +169,50 @@ func TestMakeQuery(t *testing.T) {
 			}
 
 			queryTs, err := queryMaker.MakeQueryTs()
-			if c.err != nil {
-				assert.Equal(t, err, c.err)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, queryTs)
+			assert.NoError(t, err)
+			assert.NotNil(t, queryTs)
 
-				if queryTs != nil {
-					promQLString, promQLErr := queryTs.ToPromQL(ctx)
-					assert.Nil(t, promQLErr)
-					if promQLErr == nil {
-						assert.Equal(t, c.promQL, promQLString)
-					}
+			if queryTs != nil {
+				promQLString, promQLErr := queryTs.ToPromQL(ctx)
+				assert.Nil(t, promQLErr)
+				if promQLErr == nil {
+					assert.Equal(t, c.promQL, promQLString)
 				}
 			}
 		})
 	}
+}
+
+func TestMakeQueryIgnoresExpandShowWhenTargetHasNoInfo(t *testing.T) {
+	mock.Init()
+	ctx := metadata.InitHashID(context.Background())
+	path := []string{"pod", "node", "system"}
+	indexMatcher := map[string]string{
+		"pod":            "pod1",
+		"namespace":      "ns1",
+		"bcs_cluster_id": "cluster1",
+	}
+
+	promQL := func(expandShow bool) string {
+		t.Helper()
+		queryMaker := &QueryFactory{
+			Path:         path,
+			Source:       cmdb.Resource(path[0]),
+			Target:       cmdb.Resource(path[len(path)-1]),
+			IndexMatcher: indexMatcher,
+			ExpandShow:   expandShow,
+		}
+		queryTs, err := queryMaker.MakeQueryTs()
+		assert.NoError(t, err)
+		if queryTs == nil {
+			return ""
+		}
+		promQLString, promQLErr := queryTs.ToPromQL(ctx)
+		assert.NoError(t, promQLErr)
+		return promQLString
+	}
+
+	without := promQL(false)
+	assert.Equal(t, without, promQL(true))
+	assert.NotEmpty(t, without)
 }


### PR DESCRIPTION
## Summary
- `target_info_show` is a projection switch for target Info fields. When the target resource has no Info fields, v1beta1 used to fail closed while assembling the relation query.
- That failure was swallowed into an empty 200 response, so enabling the flag dropped relation results that the same query returned without the flag.
- Ignore `target_info_show` when the target has no Info fields, matching `false` / omitted.
- See TAPD #1010158081138124380

## Test plan
- [x] `go test ./cmdb/v1beta1/` (Go 1.24)
- [x] no-Info target: ExpandShow true PromQL equals false
- [x] container/host expand-show golden PromQL unchanged
