### PR TITLE
fix(unify-query): 折叠查询仅选择存在字段映射的物理索引 --bug=163830824

### DIFF
--- a/pkg/unify-query/tsdb/elasticsearch/collapse_indexes.go
+++ b/pkg/unify-query/tsdb/elasticsearch/collapse_indexes.go
@@ -1,0 +1,138 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package elasticsearch
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	elastic "github.com/olivere/elastic/v7"
+)
+
+// mappingFieldNames retains per-index existence, including ES field aliases and
+// multi-fields which the merged display field map need not expose.
+func mappingFieldNames(mapping map[string]any) map[string]bool {
+	fields := make(map[string]bool)
+	var visit func(map[string]any, string)
+	visit = func(node map[string]any, prefix string) {
+		for _, key := range []string{"properties", "fields", "runtime"} {
+			children, ok := node[key].(map[string]any)
+			if !ok {
+				continue
+			}
+			for name, value := range children {
+				child, ok := value.(map[string]any)
+				if !ok {
+					continue
+				}
+				full := name
+				if prefix != "" {
+					full = prefix + "." + name
+				}
+				fields[full] = true
+				visit(child, full)
+			}
+		}
+	}
+	var unwrap func(map[string]any)
+	unwrap = func(node map[string]any) {
+		if _, ok := node["properties"]; ok {
+			visit(node, "")
+			return
+		}
+		if _, ok := node["runtime"]; ok {
+			visit(node, "")
+			return
+		}
+		for _, value := range node {
+			if child, ok := value.(map[string]any); ok {
+				unwrap(child)
+			}
+		}
+	}
+	unwrap(mapping)
+	return fields
+}
+
+func cloneIndexFields(source map[string]map[string]bool) map[string]map[string]bool {
+	if source == nil {
+		return nil
+	}
+	result := make(map[string]map[string]bool, len(source))
+	for index, fields := range source {
+		result[index] = make(map[string]bool, len(fields))
+		for field, exists := range fields {
+			result[index][field] = exists
+		}
+	}
+	return result
+}
+
+func filterCollapseIndexes(qo *queryOption, indexFields map[string]map[string]bool, field string, source *elastic.SearchSource) error {
+	if field == "" {
+		return nil
+	}
+	// Scroll does not support collapse; preserve ES validation of that request.
+	if qo.query != nil && (qo.query.Scroll != "" || (qo.query.ResultTableOption != nil && qo.query.ResultTableOption.ScrollID != "")) {
+		return nil
+	}
+	if indexFields == nil {
+		return fmt.Errorf("collapse requires per-index field metadata")
+	}
+	missing := make([]string, 0)
+	for _, index := range qo.physicalIndexes {
+		if !indexFields[index][field] {
+			missing = append(missing, index)
+		}
+	}
+	if len(qo.physicalIndexes) == 0 || len(missing) == len(qo.physicalIndexes) {
+		// Keep the original target scope and explicit match_none. Empty targets
+		// mean all ES indices; collapse and sort must not run on unmapped shards.
+		*source = *elastic.NewSearchSource().Query(elastic.NewMatchNoneQuery()).Size(0)
+		return nil
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	missingSet := make(map[string]bool, len(missing))
+	known := make(map[string]bool, len(qo.physicalIndexes))
+	for _, index := range missing {
+		missingSet[index] = true
+	}
+	for _, index := range qo.physicalIndexes {
+		known[index] = true
+	}
+	targets := make([]string, 0, len(qo.indexes)+len(missing))
+	wildcard := false
+	for _, target := range qo.indexes {
+		switch {
+		case strings.ContainsAny(target, "*?"):
+			targets = append(targets, target)
+			wildcard = true
+		case known[target]:
+			if !missingSet[target] {
+				targets = append(targets, target)
+			}
+		default:
+			// Exact aliases expand after index exclusions and reintroduce missing
+			// indices. Replacing them with physical indices bypasses filter/routing.
+			return fmt.Errorf("cannot safely exclude unmapped collapse indices from exact alias %q", target)
+		}
+	}
+	if wildcard {
+		sort.Strings(missing)
+		for _, index := range missing {
+			targets = append(targets, "-"+index)
+		}
+	}
+	qo.indexes = targets
+	return nil
+}

--- a/pkg/unify-query/tsdb/elasticsearch/collapse_indexes.go
+++ b/pkg/unify-query/tsdb/elasticsearch/collapse_indexes.go
@@ -11,11 +11,75 @@ package elasticsearch
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
 	elastic "github.com/olivere/elastic/v7"
 )
+
+type collapseIndexMetadata struct {
+	fields          map[string]map[string]bool
+	directQuerySafe map[string]bool
+}
+
+func cloneCollapseIndexMetadata(source *collapseIndexMetadata) *collapseIndexMetadata {
+	if source == nil {
+		return nil
+	}
+	cloned := &collapseIndexMetadata{fields: cloneIndexFields(source.fields), directQuerySafe: make(map[string]bool, len(source.directQuerySafe))}
+	for index, safe := range source.directQuerySafe {
+		cloned.directQuerySafe[index] = safe
+	}
+	return cloned
+}
+
+// Only convert aliases after proving that direct access cannot bypass an alias
+// filter or search routing. Mapping-only responses cannot establish that proof.
+func collapseDirectQuerySafe(index string, aliases map[string]any, targets []string) bool {
+	matchedAlias := false
+	for _, target := range targets {
+		if strings.HasPrefix(target, "-") || strings.HasPrefix(target, "<") {
+			return false
+		}
+	}
+	for _, target := range targets {
+		if collapseTargetMatches(target, index) {
+			return true
+		}
+	}
+	for alias, value := range aliases {
+		matched := false
+		for _, target := range targets {
+			if collapseTargetMatches(target, alias) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		options, ok := value.(map[string]any)
+		if !ok {
+			return false
+		}
+		for _, key := range []string{"filter", "routing", "search_routing"} {
+			if value, exists := options[key]; exists && value != nil && value != "" {
+				return false
+			}
+		}
+		matchedAlias = true
+	}
+	return matchedAlias
+}
+
+func collapseTargetMatches(pattern, name string) bool {
+	expression := regexp.QuoteMeta(pattern)
+	expression = strings.ReplaceAll(expression, `\*`, ".*")
+	expression = strings.ReplaceAll(expression, `\?`, ".")
+	matched, _ := regexp.MatchString("^"+expression+"$", name)
+	return matched
+}
 
 // mappingFieldNames retains per-index existence, including ES field aliases and
 // multi-fields which the merged display field map need not expose.
@@ -76,7 +140,7 @@ func cloneIndexFields(source map[string]map[string]bool) map[string]map[string]b
 	return result
 }
 
-func filterCollapseIndexes(qo *queryOption, indexFields map[string]map[string]bool, field string, source *elastic.SearchSource) error {
+func filterCollapseIndexes(qo *queryOption, indexFields *collapseIndexMetadata, field string, source *elastic.SearchSource) error {
 	if field == "" {
 		return nil
 	}
@@ -89,7 +153,7 @@ func filterCollapseIndexes(qo *queryOption, indexFields map[string]map[string]bo
 	}
 	missing := make([]string, 0)
 	for _, index := range qo.physicalIndexes {
-		if !indexFields[index][field] {
+		if !indexFields.fields[index][field] {
 			missing = append(missing, index)
 		}
 	}
@@ -102,37 +166,27 @@ func filterCollapseIndexes(qo *queryOption, indexFields map[string]map[string]bo
 	if len(missing) == 0 {
 		return nil
 	}
-	missingSet := make(map[string]bool, len(missing))
-	known := make(map[string]bool, len(qo.physicalIndexes))
-	for _, index := range missing {
-		missingSet[index] = true
-	}
+	// Use only the mapped concrete snapshot. Alias exclusion expressions are
+	// not sufficient: the deployed backend can still resolve excluded shards.
+	targets := make([]string, 0, len(qo.physicalIndexes)-len(missing))
 	for _, index := range qo.physicalIndexes {
-		known[index] = true
-	}
-	targets := make([]string, 0, len(qo.indexes)+len(missing))
-	wildcard := false
-	for _, target := range qo.indexes {
-		switch {
-		case strings.ContainsAny(target, "*?"):
-			targets = append(targets, target)
-			wildcard = true
-		case known[target]:
-			if !missingSet[target] {
-				targets = append(targets, target)
+		if !indexFields.fields[index][field] {
+			continue
+		}
+		safe := indexFields.directQuerySafe[index]
+		// Explicit index targets are also safe when only GetMapping is available.
+		for _, target := range qo.indexes {
+			if target == index {
+				safe = true
 			}
-		default:
-			// Exact aliases expand after index exclusions and reintroduce missing
-			// indices. Replacing them with physical indices bypasses filter/routing.
-			return fmt.Errorf("cannot safely exclude unmapped collapse indices from exact alias %q", target)
 		}
-	}
-	if wildcard {
-		sort.Strings(missing)
-		for _, index := range missing {
-			targets = append(targets, "-"+index)
+		if !safe {
+			return fmt.Errorf("cannot safely select concrete collapse indices: alias scope is restricted or unknown for %q", index)
 		}
+		targets = append(targets, index)
 	}
+	sort.Strings(targets)
 	qo.indexes = targets
+	qo.physicalIndexes = append([]string(nil), targets...)
 	return nil
 }

--- a/pkg/unify-query/tsdb/elasticsearch/collapse_indexes_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/collapse_indexes_test.go
@@ -32,10 +32,11 @@ func TestFilterCollapseIndexes(t *testing.T) {
 		field                   string
 		empty, fail             bool
 	}{
-		{name: "wildcard aliases preserve scope", targets: []string{"logs*"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"logs*", "-bad"}},
+		{name: "wildcard aliases preserve scope", targets: []string{"logs*"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"good"}},
+		{name: "unrestricted exact alias", targets: []string{"logs"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"good"}},
 		{name: "physical indices", targets: []string{"bad", "good"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"good"}},
 		{name: "all mapped exact alias unchanged", targets: []string{"logs"}, physical: []string{"good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"logs"}},
-		{name: "mixed exact alias fails closed", targets: []string{"logs"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", fail: true},
+		{name: "mixed exact alias with unknown scope fails closed", targets: []string{"logs"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", fail: true},
 		{name: "all missing retains scope with match none", targets: []string{"logs*"}, physical: []string{"bad"}, fields: map[string]map[string]bool{"bad": {}}, field: "session", want: []string{"logs*"}, empty: true},
 		{name: "no physical indices", targets: []string{"logs*"}, fields: map[string]map[string]bool{}, field: "session", want: []string{"logs*"}, empty: true},
 		{name: "unknown metadata fails closed", targets: []string{"logs*"}, physical: []string{"good"}, field: "session", fail: true},
@@ -44,7 +45,11 @@ func TestFilterCollapseIndexes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qo := &queryOption{indexes: tt.targets, physicalIndexes: tt.physical}
 			source := elastic.NewSearchSource().Query(elastic.NewMatchAllQuery()).Sort("timestamp", false).Collapse(elastic.NewCollapseBuilder("session"))
-			err := filterCollapseIndexes(qo, tt.fields, tt.field, source)
+			var snapshot *collapseIndexMetadata
+			if tt.fields != nil {
+				snapshot = &collapseIndexMetadata{fields: tt.fields, directQuerySafe: map[string]bool{"good": !tt.fail}}
+			}
+			err := filterCollapseIndexes(qo, snapshot, tt.field, source)
 			if tt.fail {
 				require.Error(t, err)
 				return
@@ -80,7 +85,7 @@ func TestPrepareRawQueryFiltersCollapseIndexes(t *testing.T) {
 	calls := 0
 	httpmock.RegisterResponder(http.MethodGet, mock.EsUrl+"/collapse_%2A", func(*http.Request) (*http.Response, error) {
 		calls++
-		return httpmock.NewStringResponse(200, `{"bad":{"mappings":{"properties":{"end_time":{"type":"long"}}}},"good":{"mappings":{"properties":{"end_time":{"type":"long"},"attributes":{"properties":{"gen_ai.session.id":{"type":"keyword"}}}}}}}`), nil
+		return httpmock.NewStringResponse(200, `{"bad":{"mappings":{"properties":{"end_time":{"type":"long"}}}},"good":{"aliases":{"collapse_good":{}},"mappings":{"properties":{"end_time":{"type":"long"},"attributes":{"properties":{"gen_ai.session.id":{"type":"keyword"}}}}}}}`), nil
 	})
 	inst, err := NewInstance(ctx, &InstanceOption{Connect: Connect{Address: mock.EsUrl}, Timeout: time.Second})
 	require.NoError(t, err)
@@ -91,15 +96,50 @@ func TestPrepareRawQueryFiltersCollapseIndexes(t *testing.T) {
 	prepared, err := inst.PrepareRawQuery(ctx, q, start, end, fields)
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
-	require.Equal(t, []string{"collapse_*", "-bad"}, prepared.queryOption.indexes)
+	require.Equal(t, []string{"good"}, prepared.queryOption.indexes)
 	require.Contains(t, prepared.body, `"collapse":{"field":"attributes.gen_ai.session.id"}`)
 	require.Equal(t, []string{"collapse_*"}, fields.indexes)
 	require.Equal(t, "session", q.Collapse.Field)
 	encoded, err := encodeRawBatchMember(RawBatchMember{Prepared: prepared})
 	require.NoError(t, err)
-	require.Contains(t, encoded, `"index":["collapse_*","-bad"]`)
-	httpmock.RegisterResponder(http.MethodPost, mock.EsUrl+"/collapse_%2A%2C-bad/_search", httpmock.NewStringResponder(200, `{"took":1,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}`))
+	require.Contains(t, encoded, `"index":["good"]`)
+	httpmock.RegisterResponder(http.MethodPost, mock.EsUrl+"/good/_search", httpmock.NewStringResponder(200, `{"took":1,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}`))
 	_, _, _, err = inst.QueryPreparedRawData(ctx, prepared, make(chan map[string]any, 1))
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
+}
+
+func TestCollapseDirectQuerySafe(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		targets []string
+		aliases map[string]any
+		want    bool
+	}{
+		{name: "unfiltered wildcard alias", targets: []string{"logs*"}, aliases: map[string]any{"logs_today": map[string]any{}}, want: true},
+		{name: "unfiltered exact alias", targets: []string{"logs_today"}, aliases: map[string]any{"logs_today": map[string]any{}}, want: true},
+		{name: "filtered wildcard alias", targets: []string{"logs*"}, aliases: map[string]any{"logs_today": map[string]any{"filter": map[string]any{"term": map[string]any{"tenant": "a"}}}}},
+		{name: "search routing", targets: []string{"logs*"}, aliases: map[string]any{"logs_today": map[string]any{"search_routing": "1"}}},
+		{name: "routing shorthand", targets: []string{"logs*"}, aliases: map[string]any{"logs_today": map[string]any{"routing": "1"}}},
+		{name: "index routing only", targets: []string{"logs*"}, aliases: map[string]any{"logs_today": map[string]any{"index_routing": "1"}}, want: true},
+		{name: "unrelated filtered alias", targets: []string{"logs*"}, aliases: map[string]any{"logs_today": map[string]any{}, "other": map[string]any{"filter": map[string]any{}}}, want: true},
+		{name: "metadata missing", targets: []string{"logs*"}},
+		{name: "explicit physical index", targets: []string{"v2_good"}, want: true},
+		{name: "physical pattern", targets: []string{"v2_*"}, want: true},
+		{name: "negative expression fails closed", targets: []string{"v2_*", "-other"}},
+		{name: "no regex expansion", targets: []string{"logs[ab]"}, aliases: map[string]any{"logsa": map[string]any{}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, collapseDirectQuerySafe("v2_good", tt.aliases, tt.targets))
+		})
+	}
+}
+
+func TestCloneCollapseIndexMetadata(t *testing.T) {
+	original := &collapseIndexMetadata{fields: map[string]map[string]bool{"good": {"session": true}}, directQuerySafe: map[string]bool{"good": true}}
+	cloned := cloneCollapseIndexMetadata(original)
+	cloned.fields["good"]["session"] = false
+	cloned.directQuerySafe["good"] = false
+	require.True(t, original.fields["good"]["session"])
+	require.True(t, original.directQuerySafe["good"])
 }

--- a/pkg/unify-query/tsdb/elasticsearch/collapse_indexes_test.go
+++ b/pkg/unify-query/tsdb/elasticsearch/collapse_indexes_test.go
@@ -1,0 +1,105 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package elasticsearch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	elastic "github.com/olivere/elastic/v7"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/mock"
+)
+
+func TestFilterCollapseIndexes(t *testing.T) {
+	for _, tt := range []struct {
+		name                    string
+		targets, physical, want []string
+		fields                  map[string]map[string]bool
+		field                   string
+		empty, fail             bool
+	}{
+		{name: "wildcard aliases preserve scope", targets: []string{"logs*"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"logs*", "-bad"}},
+		{name: "physical indices", targets: []string{"bad", "good"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"good"}},
+		{name: "all mapped exact alias unchanged", targets: []string{"logs"}, physical: []string{"good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", want: []string{"logs"}},
+		{name: "mixed exact alias fails closed", targets: []string{"logs"}, physical: []string{"bad", "good"}, fields: map[string]map[string]bool{"good": {"session": true}}, field: "session", fail: true},
+		{name: "all missing retains scope with match none", targets: []string{"logs*"}, physical: []string{"bad"}, fields: map[string]map[string]bool{"bad": {}}, field: "session", want: []string{"logs*"}, empty: true},
+		{name: "no physical indices", targets: []string{"logs*"}, fields: map[string]map[string]bool{}, field: "session", want: []string{"logs*"}, empty: true},
+		{name: "unknown metadata fails closed", targets: []string{"logs*"}, physical: []string{"good"}, field: "session", fail: true},
+		{name: "non collapse unchanged", targets: []string{"logs*"}, physical: []string{"bad"}, want: []string{"logs*"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			qo := &queryOption{indexes: tt.targets, physicalIndexes: tt.physical}
+			source := elastic.NewSearchSource().Query(elastic.NewMatchAllQuery()).Sort("timestamp", false).Collapse(elastic.NewCollapseBuilder("session"))
+			err := filterCollapseIndexes(qo, tt.fields, tt.field, source)
+			if tt.fail {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, qo.indexes)
+			if tt.empty {
+				body, err := marshalSearchSource(source)
+				require.NoError(t, err)
+				require.JSONEq(t, `{"query":{"match_none":{}},"size":0}`, body)
+			}
+		})
+	}
+}
+
+func TestMappingFieldNames(t *testing.T) {
+	var mapping map[string]any
+	require.NoError(t, json.Unmarshal([]byte(`{"mappings":{"_doc":{"properties":{"attributes":{"properties":{"gen_ai.session.id":{"type":"keyword"}}},"message":{"type":"text","fields":{"keyword":{"type":"keyword"}}},"session_alias":{"type":"alias","path":"attributes.gen_ai.session.id"}},"runtime":{"computed":{"type":"keyword"}}}}}`), &mapping))
+	fields := mappingFieldNames(mapping)
+	for _, field := range []string{"attributes.gen_ai.session.id", "message.keyword", "session_alias", "computed"} {
+		require.True(t, fields[field], field)
+	}
+	require.False(t, fields["absent"])
+	clone := cloneIndexFields(map[string]map[string]bool{"index": fields})
+	delete(clone["index"], "session_alias")
+	require.True(t, fields["session_alias"])
+}
+
+func TestPrepareRawQueryFiltersCollapseIndexes(t *testing.T) {
+	mock.Init()
+	metadata.InitMetadata()
+	ctx := metadata.InitHashID(context.Background())
+	calls := 0
+	httpmock.RegisterResponder(http.MethodGet, mock.EsUrl+"/collapse_%2A", func(*http.Request) (*http.Response, error) {
+		calls++
+		return httpmock.NewStringResponse(200, `{"bad":{"mappings":{"properties":{"end_time":{"type":"long"}}}},"good":{"mappings":{"properties":{"end_time":{"type":"long"},"attributes":{"properties":{"gen_ai.session.id":{"type":"keyword"}}}}}}}`), nil
+	})
+	inst, err := NewInstance(ctx, &InstanceOption{Connect: Connect{Address: mock.EsUrl}, Timeout: time.Second})
+	require.NoError(t, err)
+	q := &metadata.Query{DB: "collapse_*", StorageType: metadata.ElasticsearchStorageType, Size: 20, TimeField: metadata.TimeField{Name: "end_time", Type: "long", Unit: "microsecond"}, FieldAlias: metadata.FieldAlias{"session": "attributes.gen_ai.session.id"}, Collapse: &metadata.Collapse{Field: "session"}}
+	start, end := time.Unix(1, 0), time.Unix(2, 0)
+	fields, err := inst.PrepareRawFieldMetadata(ctx, q, start, end)
+	require.NoError(t, err)
+	prepared, err := inst.PrepareRawQuery(ctx, q, start, end, fields)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	require.Equal(t, []string{"collapse_*", "-bad"}, prepared.queryOption.indexes)
+	require.Contains(t, prepared.body, `"collapse":{"field":"attributes.gen_ai.session.id"}`)
+	require.Equal(t, []string{"collapse_*"}, fields.indexes)
+	require.Equal(t, "session", q.Collapse.Field)
+	encoded, err := encodeRawBatchMember(RawBatchMember{Prepared: prepared})
+	require.NoError(t, err)
+	require.Contains(t, encoded, `"index":["collapse_*","-bad"]`)
+	httpmock.RegisterResponder(http.MethodPost, mock.EsUrl+"/collapse_%2A%2C-bad/_search", httpmock.NewStringResponder(200, `{"took":1,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}`))
+	_, _, _, err = inst.QueryPreparedRawData(ctx, prepared, make(chan map[string]any, 1))
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -188,8 +188,24 @@ func (i *Instance) checkQuery(query *metadata.Query) error {
 	return nil
 }
 
+type esIndexMetadata struct {
+	settings        map[string]map[string]any
+	mappings        map[string]map[string]any
+	physicalIndexes []string
+	directQuerySafe map[string]bool
+}
+
 func resolveIndexMetadata(ctx context.Context, span *trace.Span, cli *elastic.Client, aliases ...string) (map[string]map[string]any, map[string]map[string]any, []string, error) {
+	snapshot, err := resolveIndexMetadataSnapshot(ctx, span, cli, aliases...)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return snapshot.settings, snapshot.mappings, snapshot.physicalIndexes, nil
+}
+
+func resolveIndexMetadataSnapshot(ctx context.Context, span *trace.Span, cli *elastic.Client, aliases ...string) (*esIndexMetadata, error) {
 	settings := make(map[string]map[string]any)
+	directQuerySafe := make(map[string]bool)
 	mappings := make(map[string]map[string]any)
 
 	span.Set("get-indexes", aliases)
@@ -210,7 +226,7 @@ func resolveIndexMetadata(ctx context.Context, span *trace.Span, cli *elastic.Cl
 		res, err := cli.GetMapping().Index(aliases...).Type("").Do(ctx)
 		if err != nil {
 			span.Set("get-mapping-error", truncateString(err.Error(), esIndexMetadataErrorMaxLength))
-			return nil, nil, nil, metadata.NewMessage(
+			return nil, metadata.NewMessage(
 				metadata.MsgQueryES,
 				"索引查询异常: %+v",
 				aliases,
@@ -226,6 +242,7 @@ func resolveIndexMetadata(ctx context.Context, span *trace.Span, cli *elastic.Cl
 		for index, indice := range indices {
 			settings[index] = indice.Settings
 			mappings[index] = indice.Mappings
+			directQuerySafe[index] = collapseDirectQuerySafe(index, indice.Aliases, aliases)
 		}
 	}
 
@@ -235,7 +252,7 @@ func resolveIndexMetadata(ctx context.Context, span *trace.Span, cli *elastic.Cl
 	}
 	sort.Strings(physicalIndexes)
 
-	return settings, mappings, physicalIndexes, nil
+	return &esIndexMetadata{settings: settings, mappings: mappings, physicalIndexes: physicalIndexes, directQuerySafe: directQuerySafe}, nil
 }
 
 // fieldMap 获取es索引的字段映射
@@ -249,7 +266,7 @@ func (i *Instance) fieldMapWithPhysicalIndexes(ctx context.Context, fieldAlias m
 	return fields, indexes, err
 }
 
-func (i *Instance) fieldMapWithIndexFields(ctx context.Context, fieldAlias metadata.FieldAlias, aliases ...string) (metadata.FieldsMap, []string, map[string]map[string]bool, error) {
+func (i *Instance) fieldMapWithIndexFields(ctx context.Context, fieldAlias metadata.FieldAlias, aliases ...string) (metadata.FieldsMap, []string, *collapseIndexMetadata, error) {
 	if len(aliases) == 0 {
 		return nil, nil, nil, fmt.Errorf("query indexes is empty")
 	}
@@ -269,15 +286,16 @@ func (i *Instance) fieldMapWithIndexFields(ctx context.Context, fieldAlias metad
 	}
 	defer cli.Stop()
 
-	settings, mappings, physicalIndexes, err := resolveIndexMetadata(ctx, span, cli, aliases...)
+	snapshot, err := resolveIndexMetadataSnapshot(ctx, span, cli, aliases...)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	settings, mappings, physicalIndexes := snapshot.settings, snapshot.mappings, snapshot.physicalIndexes
 	span.Set("mapping-length", len(mappings))
 	span.Set("physical-index-length", len(physicalIndexes))
 
 	iof := NewIndexOptionFormat(fieldAlias)
-	indexFields := make(map[string]map[string]bool, len(mappings))
+	indexFields := &collapseIndexMetadata{fields: make(map[string]map[string]bool, len(mappings)), directQuerySafe: snapshot.directQuerySafe}
 
 	// 忽略 mapping 为空的情况的报错
 	if len(mappings) == 0 {
@@ -297,7 +315,7 @@ func (i *Instance) fieldMapWithIndexFields(ctx context.Context, fieldAlias metad
 		index := indexes[idx]
 		if in, ok := mappings[index]; ok && in != nil {
 			iof.Parse(settings[index], in)
-			indexFields[index] = mappingFieldNames(in)
+			indexFields.fields[index] = mappingFieldNames(in)
 		}
 	}
 

--- a/pkg/unify-query/tsdb/elasticsearch/instance.go
+++ b/pkg/unify-query/tsdb/elasticsearch/instance.go
@@ -245,8 +245,13 @@ func (i *Instance) fieldMap(ctx context.Context, fieldAlias metadata.FieldAlias,
 }
 
 func (i *Instance) fieldMapWithPhysicalIndexes(ctx context.Context, fieldAlias metadata.FieldAlias, aliases ...string) (metadata.FieldsMap, []string, error) {
+	fields, indexes, _, err := i.fieldMapWithIndexFields(ctx, fieldAlias, aliases...)
+	return fields, indexes, err
+}
+
+func (i *Instance) fieldMapWithIndexFields(ctx context.Context, fieldAlias metadata.FieldAlias, aliases ...string) (metadata.FieldsMap, []string, map[string]map[string]bool, error) {
 	if len(aliases) == 0 {
-		return nil, nil, fmt.Errorf("query indexes is empty")
+		return nil, nil, nil, fmt.Errorf("query indexes is empty")
 	}
 
 	var err error
@@ -260,23 +265,24 @@ func (i *Instance) fieldMapWithPhysicalIndexes(ctx context.Context, fieldAlias m
 	span.Set("aliases", aliases)
 	cli, err := i.getClient(ctx, i.connect)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get client error: %w", err)
+		return nil, nil, nil, fmt.Errorf("get client error: %w", err)
 	}
 	defer cli.Stop()
 
 	settings, mappings, physicalIndexes, err := resolveIndexMetadata(ctx, span, cli, aliases...)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	span.Set("mapping-length", len(mappings))
 	span.Set("physical-index-length", len(physicalIndexes))
 
 	iof := NewIndexOptionFormat(fieldAlias)
+	indexFields := make(map[string]map[string]bool, len(mappings))
 
 	// 忽略 mapping 为空的情况的报错
 	if len(mappings) == 0 {
 		span.Set("field-map-length", 0)
-		return iof.FieldsMap(), physicalIndexes, nil
+		return iof.FieldsMap(), physicalIndexes, indexFields, nil
 	}
 
 	indexes := make([]string, 0)
@@ -291,11 +297,12 @@ func (i *Instance) fieldMapWithPhysicalIndexes(ctx context.Context, fieldAlias m
 		index := indexes[idx]
 		if in, ok := mappings[index]; ok && in != nil {
 			iof.Parse(settings[index], in)
+			indexFields[index] = mappingFieldNames(in)
 		}
 	}
 
 	span.Set("field-map-length", len(iof.FieldsMap()))
-	return iof.FieldsMap(), physicalIndexes, nil
+	return iof.FieldsMap(), physicalIndexes, indexFields, nil
 }
 
 func buildESQuerySource(ctx context.Context, qb *metadata.Query, fact *FormatFactory, forceUnmappedTypes map[string]string) (*elastic.SearchSource, elastic.Query, string, error) {

--- a/pkg/unify-query/tsdb/elasticsearch/raw_query.go
+++ b/pkg/unify-query/tsdb/elasticsearch/raw_query.go
@@ -31,7 +31,7 @@ type PreparedFieldMetadata struct {
 	indexes         []string
 	physicalIndexes []string
 	fieldMap        metadata.FieldsMap
-	indexFields     map[string]map[string]bool
+	indexFields     *collapseIndexMetadata
 	connectionKey   RawBatchConnectionKey
 	reuseIdentity   [sha256.Size]byte
 	complete        bool
@@ -277,7 +277,7 @@ func clonePreparedFieldMetadata(source *PreparedFieldMetadata) *PreparedFieldMet
 		indexes:         append([]string(nil), source.indexes...),
 		physicalIndexes: append([]string(nil), source.physicalIndexes...),
 		fieldMap:        cloneFieldsMap(source.fieldMap),
-		indexFields:     cloneIndexFields(source.indexFields),
+		indexFields:     cloneCollapseIndexMetadata(source.indexFields),
 		connectionKey:   source.connectionKey,
 		reuseIdentity:   source.reuseIdentity,
 		complete:        source.complete,

--- a/pkg/unify-query/tsdb/elasticsearch/raw_query.go
+++ b/pkg/unify-query/tsdb/elasticsearch/raw_query.go
@@ -31,6 +31,7 @@ type PreparedFieldMetadata struct {
 	indexes         []string
 	physicalIndexes []string
 	fieldMap        metadata.FieldsMap
+	indexFields     map[string]map[string]bool
 	connectionKey   RawBatchConnectionKey
 	reuseIdentity   [sha256.Size]byte
 	complete        bool
@@ -93,7 +94,7 @@ func (i *Instance) PrepareRawFieldMetadata(
 	if err != nil {
 		return nil, err
 	}
-	fieldMap, physicalIndexes, err := i.fieldMapWithPhysicalIndexes(ctx, query.FieldAlias, indexes...)
+	fieldMap, physicalIndexes, indexFields, err := i.fieldMapWithIndexFields(ctx, query.FieldAlias, indexes...)
 	if err != nil {
 		return nil, metadata.NewMessage(
 			metadata.MsgQueryES,
@@ -106,6 +107,7 @@ func (i *Instance) PrepareRawFieldMetadata(
 		indexes:         append([]string(nil), indexes...),
 		physicalIndexes: append([]string(nil), physicalIndexes...),
 		fieldMap:        cloneFieldsMap(fieldMap),
+		indexFields:     indexFields,
 		connectionKey:   i.RawBatchConnectionKey(ctx),
 		reuseIdentity:   reuseIdentity,
 		complete:        true,
@@ -168,6 +170,9 @@ func (i *Instance) PrepareRawQuery(
 	fact := newRawFormatFactory(ctx, rawQuery, qo, fieldMetadata.fieldMap)
 	source, countQuery, _, err := buildESQuerySource(ctx, rawQuery, fact, nil)
 	if err != nil {
+		return nil, err
+	}
+	if err := filterCollapseIndexes(qo, fieldMetadata.indexFields, fact.Collapse(rawQuery.Collapse), source); err != nil {
 		return nil, err
 	}
 	body, err := marshalSearchSource(source)
@@ -272,6 +277,7 @@ func clonePreparedFieldMetadata(source *PreparedFieldMetadata) *PreparedFieldMet
 		indexes:         append([]string(nil), source.indexes...),
 		physicalIndexes: append([]string(nil), source.physicalIndexes...),
 		fieldMap:        cloneFieldsMap(source.fieldMap),
+		indexFields:     cloneIndexFields(source.indexFields),
 		connectionKey:   source.connectionKey,
 		reuseIdentity:   source.reuseIdentity,
 		complete:        source.complete,


### PR DESCRIPTION
原始数据折叠查询命中缺少折叠字段映射的索引时会返回分片错误。此前使用“通配别名 + 负号索引排除项”的版本在部署环境验收中仍命中被排除索引，因此本次改为：复用已有 IndexGet/mapping 信息，只将包含折叠字段的明确物理索引列表下发给单次搜索和 `_msearch`。

转换前检查别名约束：只有直接匹配物理索引，或匹配到的别名均不带 filter/routing/search_routing 时才能直查。受限或元数据未知的范围明确报错，避免绕过别名过滤或搜索路由。无约束的精确别名也支持筛选；全部有字段时保持原查询，全部缺字段时返回 match_none 空结果。字段类型和 doc_values 错误继续由 ES 返回。

验证：
- Go 1.24.4 下 `make test` 全模块通过，ES 包覆盖率 85.3%。
- golangci-lint v1.64.8 相对基线的增量检查通过；全模块存量 lint 及本机 hook 版本问题沿用此前记录，仅对提交进程禁用失效 hook，检查显式执行。
- 本地 ES 7.17.29 验证单次与 `_msearch` 均使用筛选后的物理索引；无约束别名正常返回、全部缺字段返回空集，受限混合别名拒绝转换，全部有字段的受限别名保持原行为。
- 已补充实际搜索 URL、批量 header、字段解码、快照复用/拷贝和别名约束的回归断言。

本次新版本尚待重新发布并进行部署环境验收；上一版本验收失败的事实保留，不将本地验证表述为部署验收通过。
